### PR TITLE
Fix #75

### DIFF
--- a/sed-builder/src/main/java/cfa/vo/sed/science/stacker/SedStackerFrame.java
+++ b/sed-builder/src/main/java/cfa/vo/sed/science/stacker/SedStackerFrame.java
@@ -38,6 +38,7 @@ import cfa.vo.iris.sed.quantities.IUnit;
 import cfa.vo.iris.sed.quantities.SPVYUnit;
 import cfa.vo.iris.sed.quantities.XUnit;
 import cfa.vo.sedlib.common.SedException;
+import cfa.vo.sedlib.common.SedNoDataException;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.beans.PropertyChangeListener;
@@ -1121,6 +1122,15 @@ public class SedStackerFrame extends javax.swing.JInternalFrame {
 
     private void createSedButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_createSedButtonActionPerformed
 	try {
+	    
+	    if(selectedStack.getSeds().isEmpty()) {
+	    NarrowOptionPane.showMessageDialog(null,
+                    "Stack is empty. Please add SEDs to the stack first.",
+                    "Empty Stack",
+                    NarrowOptionPane.ERROR_MESSAGE);
+            throw new SedNoDataException();
+	}
+	    
 	    ExtSed sed = SedStack.createSedFromStack(selectedStack);
 	    
 	    manager.add(sed);

--- a/sed-builder/src/main/java/cfa/vo/sed/science/stacker/SedStackerRedshifter.java
+++ b/sed-builder/src/main/java/cfa/vo/sed/science/stacker/SedStackerRedshifter.java
@@ -66,8 +66,13 @@ public class SedStackerRedshifter {
         
 	this.redshiftConfigChanged = false;
 	
-        if(stack.getSeds().isEmpty())
+	if(stack.getSeds().isEmpty()) {
+	    NarrowOptionPane.showMessageDialog(null,
+                    "Stack is empty. Please add SEDs to the stack to redshift.",
+                    "Empty Stack",
+                    NarrowOptionPane.ERROR_MESSAGE);
             throw new SedNoDataException();
+	}
 	
 	try {
 	    client.findSherpa();

--- a/sed-builder/src/main/java/cfa/vo/sed/science/stacker/SedStackerStacker.java
+++ b/sed-builder/src/main/java/cfa/vo/sed/science/stacker/SedStackerStacker.java
@@ -63,7 +63,7 @@ public class SedStackerStacker {
 
 	if(stack.getSeds().isEmpty()) {
 	    NarrowOptionPane.showMessageDialog(null,
-                    "Stack is empty. Please add SEDs to the stack to normalize.",
+                    "Stack is empty. Please add SEDs to the stack to stack.",
                     "Empty Stack",
                     NarrowOptionPane.ERROR_MESSAGE);
             throw new SedNoDataException();


### PR DESCRIPTION
Add error message if user presses 'Redshift' or 'Create SED' buttons and Stack is empty