### PR TITLE
140 setup travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language: java
+
+jdk:
+  - oraclejdk8
+  - oraclejdk7
+
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.m2
+    - $HOME/miniconda
+
+install: true
+
+before_install:
+  - export PATH=$HOME/miniconda/bin:$PATH
+  - command -v conda >/dev/null || { wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+     bash miniconda.sh -b -f; }
+  - conda update --yes conda
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION astropy=0.4.4 scipy
+  - conda install --yes -c https://conda.anaconda.org/sherpa sherpa
+  - pip install sampy
+  - pip install astlib
+  - cd sherpa-samp; python setup.py develop; cd ..
+  - cd sedstacker; python setup.py develop; cd ..
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+
+script: mvn test


### PR DESCRIPTION
[release-note]
N/A
[release-note]

[story] #140 [/story]

# Description
This PR introduces a basic Travis CI configuration for Iris.
The `maven` repository as well as the `miniconda` installation are cached for efficiency.
xfvb is configured although it should not really be used at this point.

# Testing
The following Travis CI build shows that Travis builds are active and the Iris tests pass:
https://travis-ci.org/ChandraCXC/iris/builds/86906266