### PR TITLE
141 setup coverage analysis jacoco

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,8 @@ before_install:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
 
-script: mvn -U test
+# This runs without instrumentation
+script: mvn -U verify
+
+# This runs with instrumentation
+after_success: mvn -Pjacoco clean verify coveralls:report

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ $ pip install sampy
 $ pip install astlib
 $ cd sherpa-samp; python setup.py develop; cd ..
 $ cd sedstacker; python setup.py develop; cd ..
-$ mvn test
 ````
 
 You should also make sure that `sherpa-samp` is working.
@@ -30,3 +29,34 @@ $ chmod u+x Iris
 $ ./Iris smoketest
 ````
 
+## How to run the unit and integration tests
+
+### Without coverage analysis
+
+````
+$ mvn clean test # Unit tests
+$ mvn clean test-compile failsafe:integration-test # Integration tests only
+$ mvn clean verify # All tests
+````
+
+### With JaCoCo coverage analysis
+
+````
+$ mvn -Pjacoco test # Unit tests
+$ mvn -Pjacoco verify # All tests
+$ mvn -Pjacoco jacoco:report # generate report
+````
+
+Note that individual reports will be created in each individual submodule.
+
+### With Sonar
+
+A [[http://www.sonarqube.org/ | SonarQube]] instance must be running.
+The configuration for the SonarQube instance must be placed into
+the maven local `settings.xml` file for connecting with the database
+backing the SonarQube instance.
+
+````
+$ mvn -Psonar install # All tests
+$ mvn sonar:sonar
+````

--- a/iris/src/test/java/cfa/vo/gui/BuilderMainViewIT.java
+++ b/iris/src/test/java/cfa/vo/gui/BuilderMainViewIT.java
@@ -45,9 +45,6 @@ public class BuilderMainViewIT extends UISpecTestCase {
 
     public void setUp() throws Exception {
         super.setUp();
-        if (!TestApp.hasComponent(SedBuilder.class)) {
-            TestApp.addComponent(new SedBuilder());
-        }
         setAdapter(new IrisUISpecAdapter(Iris.class, new String[0]));
         mainWindow = getMainWindow();
         desktop = mainWindow.getDesktop();

--- a/iris/src/test/java/cfa/vo/gui/BuilderMainViewIT.java
+++ b/iris/src/test/java/cfa/vo/gui/BuilderMainViewIT.java
@@ -20,6 +20,7 @@
  */
 package cfa.vo.gui;
 
+import cfa.vo.iris.Iris;
 import cfa.vo.iris.sed.ExtSed;
 import cfa.vo.iris.sed.SedlibSedManager;
 import cfa.vo.sed.builder.SedBuilder;
@@ -37,7 +38,7 @@ import org.uispec4j.*;
  *
  * @author olaurino
  */
-public class BuilderMainViewTest extends UISpecTestCase {
+public class BuilderMainViewIT extends UISpecTestCase {
 
     private static Window mainWindow;
     private Desktop desktop;
@@ -47,7 +48,7 @@ public class BuilderMainViewTest extends UISpecTestCase {
         if (!TestApp.hasComponent(SedBuilder.class)) {
             TestApp.addComponent(new SedBuilder());
         }
-        setAdapter(new IrisUISpecAdapter(TestApp.class, new String[0]));
+        setAdapter(new IrisUISpecAdapter(Iris.class, new String[0]));
         mainWindow = getMainWindow();
         desktop = mainWindow.getDesktop();
     }

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,32 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.18.1</version>
+                <configuration>
+                    <!--<failIfNoTests>true</failIfNoTests>-->
+                    <includes>
+                        <include>**/*Test.*</include>
+                    </includes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.18.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <!--<failIfNoTests>true</failIfNoTests>-->
+                    <includes>
+                        <include>**/*IT.*</include>
+                    </includes>
+                </configuration>
             </plugin>
 
             <plugin>
@@ -125,6 +151,17 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <java.awt.headless>false</java.awt.headless>
+                                <awt.toolkit>net.java.openjdk.cacio.ctc.CTCToolkit</awt.toolkit>
+                                <java.awt.graphicsenv>net.java.openjdk.cacio.ctc.CTCGraphicsEnvironment</java.awt.graphicsenv>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
                             <systemPropertyVariables>
                                 <java.awt.headless>false</java.awt.headless>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,12 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <!-- Sonar -->
+        <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
+        <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
+        <sonar.jacoco.reportPath>${project.basedir}/../target/jacoco.exec</sonar.jacoco.reportPath>
+        <sonar.language>java</sonar.language>
+        <sonar.exclusions>**cfa/vo/iris/test/**</sonar.exclusions>
     </properties>
 
     <build>
@@ -93,6 +99,11 @@
                         <source>1.6</source>
                         <target>1.6</target>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>0.7.2.201409121644</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -202,6 +213,80 @@
                     <scope>test</scope>
                 </dependency>
             </dependencies>
+        </profile>
+        <profile>
+            <id>jacoco</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>agent-for-ut</id>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>agent-for-it</id>
+                                <goals>
+                                    <goal>prepare-agent-integration</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>jacoco-site</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.eluder.coveralls</groupId>
+                        <artifactId>coveralls-maven-plugin</artifactId>
+                        <version>4.0.0</version>
+                    </plugin>
+
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>sonar</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <configuration>
+                            <destFile>${sonar.jacoco.reportPath}</destFile>
+                            <append>true</append>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>agent-for-ut</id>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>agent-for-it</id>
+                                <goals>
+                                    <goal>prepare-agent-integration</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>jacoco-site</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
[release-note]
N/A
[/release-note]

Resolve #141.

# Description
This PR introduces separate configurations for the unit (`test` phase) and integration (`verify` phase) tests. Coverage analysis plugins are also configured so that coverage information can be created and used for reports. In particular, coverage information is sent to the coveralls service after a successful Travis CI builds.
https://coveralls.io/builds/3975496

The aggregation of the coverage information is performed by coveralls in the `jacoco` profile, and by Sonar in the `sonar` profile, with some configuration tweaks in the `pom` itself.

I also updated the README with information on how to run the different test suites and the coverage analysis plugins.

# Testing
The following Travis Build:
https://travis-ci.org/ChandraCXC/iris/jobs/87897375

resulted in the following Coveralls report:
https://travis-ci.org/ChandraCXC/iris/jobs/87897375

Locally I set up a SonarQube instance and I tested that one can run the whole test suite with the sonar plugin and visualize information in the Sonar web app. The coverage information, in this case, is more accurate and accounts for hits in integration tests from more 

# Caveats
This PR does not refactor tests to be proper integration and unit tests. Historically, most of the Iris tests have been integration tests, and automated GUI testing was not working. Also, some tests are currently ignored as they need to be run locally with the python services running. Similarly, the smoke test only runs with the whole infrastructure up, and again this is not captured by the coverage analysis.
More work will be required to refactor such tests.

JaCoCo and Cobertura do not properly aggregate coverage information and miss the hits coming from integration tests in external jars, even under the same parent module. Sonar properly aggregates the coverage information, but it requires an infrastructure that goes beyond the scope of this PR. Also, the coverage information seems to oscillate with the builds, but the reason is unclear.

For the reasons above, the code coverage identified by coveralls is much lower than the actual code coverage. This is at least twice as much the one advertised by coveralls just by accounting for integration tests outside of `iris-common`. Plus, more coverage is provided by the SedStacker tests that are currently ignored and by the smoke test that is not run as part of the test suite.

The coveralls coverage is actually an estimate of the unit tests coverage.

The `pom` can be configured to allow Sonar to correctly display unit and integration tests coverage disjointly, but we need to evaluate Sonar before spending more work into its configuration.
