### PR TITLE
Logging for Unit Tests Cleanup

### DIFF
--- a/iris-common/src/main/java/cfa/vo/iris/AbstractIrisApplication.java
+++ b/iris-common/src/main/java/cfa/vo/iris/AbstractIrisApplication.java
@@ -43,57 +43,51 @@ import org.astrogrid.samp.client.SampException;
 import org.jdesktop.application.Application;
 
 /**
+ * Base Iris application. Handles startup, shutdown, etc.
  *
- * @author olaurino
  */
 public abstract class AbstractIrisApplication extends Application implements IrisApplication {
-
-    private static SedSAMPController sampController;
+    
+    private static final Logger logger = Logger.getLogger(AbstractIrisApplication.class.getName());
+    
     private static boolean isTest = false;
-    private Map<String, IrisComponent> components = new TreeMap();
-    private IrisWorkspace ws;
-    private IrisDesktop desktop;
-    public static final File CONFIGURATION_DIR = new File(System.getProperty("user.home") + "/.vao/iris/");
-    public final boolean MAC_OS_X = System.getProperty("os.name").toLowerCase().startsWith("mac os x");
     static boolean SAMP_ENABLED = System.getProperty("samp", "true").toLowerCase().equals("false") ? false : true;
     public static final boolean SAMP_FALLBACK = false;
+    public static final File CONFIGURATION_DIR = new File(System.getProperty("user.home") + "/.vao/iris/");
+    public static final boolean MAC_OS_X = System.getProperty("os.name").toLowerCase().startsWith("mac os x");
 
-    public void addConnectionListener(SAMPConnectionListener listener) {
-        sampController.addConnectionListener(listener);
-    }
+    private static SedSAMPController sampController;
+    
+    protected String[] componentArgs;
+    protected String componentName;
+    protected boolean isBatch = false;
 
-    public void addMessageHandler(MessageHandler handler) {
-        sampController.addMessageHandler(handler);
-    }
+    protected IrisWorkspace ws;
+    protected IrisDesktop desktop;
+    protected Map<String, IrisComponent> components = new TreeMap<>();
 
-    public void exitApp() {
-        for (IrisComponent component : components.values()) {
-            component.shutdown();
-        }
-        sampShutdown();
-        System.exit(0);
-    }
+    // Default constructor
+    protected AbstractIrisApplication() {}
 
     public abstract String getName();
-
     public abstract String getDescription();
-
     public abstract URL getSAMPIcon();
+    public abstract List<IrisComponent> getComponents() throws Exception;
+    public abstract JDialog getAboutBox();
+    public abstract URL getDesktopIcon();
+    public abstract void setProperties(List<String> properties);
 
     public static AbstractIrisApplication getInstance() {
         return Application.getInstance(AbstractIrisApplication.class);
     }
 
-    public void sampSetup() {
-        if (SAMP_ENABLED) {
-            sampController = new SedSAMPController(getName(), getDescription(), getSAMPIcon().toString());
-            try {
-                sampController.startWithResourceServer("sedImporter/", !isTest);
-            } catch (Exception ex) {
-                System.err.println("SAMP Error. Disabling SAMP support.");
-                System.err.println("Error message: " + ex.getMessage());
-                SAMP_ENABLED = false;
-            }
+    public static void setTest(boolean t) {
+        isTest = t;
+    }
+
+    public static void setAutoRunHub(boolean autoRunHub) {
+        if (sampController != null) {
+            sampController.setAutoRunHub(autoRunHub);
         }
     }
 
@@ -104,24 +98,6 @@ public abstract class AbstractIrisApplication extends Application implements Iri
         }
     }
 
-    public static void setAutoRunHub(boolean autoRunHub) {
-        sampController.setAutoRunHub(autoRunHub);
-    }
-
-    public static void setTest(boolean t) {
-        isTest = t;
-    }
-    protected String[] componentArgs;
-    protected String componentName;
-    protected boolean isBatch = false;
-
-    protected AbstractIrisApplication() {
-    }
-
-    public abstract List<IrisComponent> getComponents() throws Exception;
-
-    public abstract JDialog getAboutBox();
-
     @Override
     public File getConfigurationDir() {
         return CONFIGURATION_DIR;
@@ -129,8 +105,8 @@ public abstract class AbstractIrisApplication extends Application implements Iri
 
     @Override
     protected void initialize(String[] args) {
-        List<String> properties = new ArrayList();
-        List<String> arguments = new ArrayList();
+        List<String> properties = new ArrayList<>();
+        List<String> arguments = new ArrayList<>();
         for (String arg : args) {
             if (arg.startsWith("--")) {
                 arg = arg.replaceFirst("--", "");
@@ -148,15 +124,107 @@ public abstract class AbstractIrisApplication extends Application implements Iri
             }
         }
         setProperties(properties);
+    }
+
+    @Override
+    protected void startup() {
+        if (!CONFIGURATION_DIR.exists()) {
+            CONFIGURATION_DIR.mkdirs();
+        }
+        if (isBatch) {
+            if (!components.containsKey(componentName)) {
+                System.out.println("Component " + componentName + " does not exist.");
+            } else {
+                components.get(componentName).getCli().call(componentArgs);
+            }
+
+            exitApp();
+        }
+
+        if (MAC_OS_X) {
+            System.setProperty("apple.laf.useScreenMenuBar", "true");
+        }
+        System.out.println("Launching GUI...");
+        
+        // Read and construct components
+        initComponents();
+        
+        // Setup samp call
+        sampSetup();
+        
+        // Initialize the desktop/main view and set visible to true
+        initDesktop(); 
+        
+        // Initialize iris workspace and add components
+        initWorkspace();
+
+        // Add plugin manager
+        setupPluginManager();
+    }
+    
+    protected void initComponents() {
         try {
             for (IrisComponent component : getComponents()) {
                 component.initCli(this);
                 components.put(component.getCli().getName(), component);
             }
         } catch (Exception ex) {
-            System.out.println("Error reading component file");
+            // Do we want to application to continue if we can't load any components?
+            System.err.println("Error reading component file"); 
+            logger.log(Level.SEVERE, "Error reading component file", ex);
+        }
+    }
+
+    public void sampSetup() {
+        if (SAMP_ENABLED) {
+            sampController = new SedSAMPController(getName(), getDescription(), getSAMPIcon().toString());
+            try {
+                sampController.startWithResourceServer("sedImporter/", !isTest);
+            } catch (Exception ex) {
+                System.err.println("SAMP Error. Disabling SAMP support.");
+                System.err.println("Error message: " + ex.getMessage());
+                logger.log(Level.SEVERE, "SAMP Error. Disabling SAMP support.", ex);
+                SAMP_ENABLED = false;
+            }
+        }
+    }
+    
+    protected void initDesktop() {
+        try {
+            desktop = new IrisDesktop(this);
+        } catch (Exception ex) {
+            System.err.println("Error initializing components");
+            logger.log(Level.SEVERE, null, ex);
+            exitApp();
         }
 
+        desktop.setVisible(true);
+    }
+    
+    protected void initWorkspace() {
+        ws = new IrisWorkspace();
+        ws.setDesktop(desktop);
+        desktop.setWorkspace(ws);
+        for (final IrisComponent component : components.values()) {
+            component.init(this, ws);
+        }
+    }
+    
+    protected void setupPluginManager() {
+        PluginManager manager = new PluginManager();
+        components.put(manager.getCli().getName(), manager);
+        manager.init(this, ws);
+        desktop.setPluginManager(manager);
+        desktop.reset(new ArrayList<>(components.values()));
+        manager.load();
+    }
+
+    public void exitApp() {
+        for (IrisComponent component : components.values()) {
+            component.shutdown();
+        }
+        sampShutdown();
+        System.exit(0);
     }
 
     @Override
@@ -175,67 +243,19 @@ public abstract class AbstractIrisApplication extends Application implements Iri
     }
 
     @Override
-    protected void startup() {
-        if (!CONFIGURATION_DIR.exists()) {
-            CONFIGURATION_DIR.mkdirs();
-        }
-        if (isBatch) {
-            if (!components.containsKey(componentName)) {
-                System.out.println("Component " + componentName + " does not exist.");
-            } else {
-                components.get(componentName).getCli().call(componentArgs);
-            }
-
-            exitApp();
-        } else {
-
-            if (MAC_OS_X) {
-                System.setProperty("apple.laf.useScreenMenuBar", "true");
-            }
-            System.out.println("Launching GUI...");
-
-            sampSetup();
-            
-            try {
-                desktop = new IrisDesktop(AbstractIrisApplication.this);
-            } catch (Exception ex) {
-                System.out.println("Error initializing components");
-                Logger.getLogger(AbstractIrisApplication.class.getName()).log(Level.SEVERE, null, ex);
-                exitApp();
-            }
-            
-            desktop.setVisible(true);
-            
-            ws = new IrisWorkspace();
-            ws.setDesktop(desktop);
-            desktop.setWorkspace(ws);
-            for (final IrisComponent component : components.values()) {
-
-                component.init(AbstractIrisApplication.this, ws);
-
-            }
-            
-            PluginManager manager = new PluginManager();
-            
-            components.put(manager.getCli().getName(), manager);
-            
-            manager.init(AbstractIrisApplication.this, ws);
-            
-            desktop.setPluginManager(manager);
-            
-            desktop.reset(new ArrayList(components.values()));
-            
-            manager.load();
-
-        }
-    }
-
-    @Override
     public SAMPController getSAMPController() {
         return sampController;
     }
+    
+    public void addConnectionListener(SAMPConnectionListener listener) {
+        if (sampController != null) {
+            sampController.addConnectionListener(listener);
+        }
+    }
 
-    public abstract URL getDesktopIcon();
-
-    public abstract void setProperties(List<String> properties);
+    public void addMessageHandler(MessageHandler handler) {
+        if (sampController != null) {
+            sampController.addMessageHandler(handler);
+        }
+    }
 }

--- a/iris-common/src/test/java/cfa/vo/iris/common/SedMessageTest.java
+++ b/iris-common/src/test/java/cfa/vo/iris/common/SedMessageTest.java
@@ -22,6 +22,10 @@ import cfa.vo.iris.sed.ExtSed;
 import cfa.vo.sedlib.Sed;
 import cfa.vo.sedlib.Segment;
 import cfa.vo.sedlib.io.SedFormat;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -34,6 +38,9 @@ import org.junit.Test;
  * @author olaurino
  */
 public class SedMessageTest {
+    
+    private static final Logger logger = Logger.getLogger(SedMessageTest.class.getName());
+    
     private Sed mySed;
 
     public SedMessageTest() {
@@ -70,7 +77,7 @@ public class SedMessageTest {
         sampReceiver.setAutoRunHub(false);
 
         while(!sampSender.isConnected()) {
-            System.out.println("waiting connection");
+            logger.log(Level.INFO, "waiting connection...");
             Thread.sleep(1000);
         }
 

--- a/iris-common/src/test/java/cfa/vo/iris/common/SedTest.java
+++ b/iris-common/src/test/java/cfa/vo/iris/common/SedTest.java
@@ -29,6 +29,9 @@ import cfa.vo.sedlib.io.SedFormat;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -40,6 +43,9 @@ import org.junit.Test;
  * @author olaurino
  */
 public class SedTest {
+
+    private static final Logger logger = Logger.getLogger(SedTest.class.getName());
+    
     private Sed mySed;
 
     public SedTest() {
@@ -63,7 +69,7 @@ public class SedTest {
 
      @Test
      public void sedMessageTest() throws Exception {
-//        System.out.println(getClass().getResource("/test_data/3C273.vot").getPath());
+//        logger.log(Level.INFO, getClass().getResource("/test_data/3C273.vot").getPath());
 //        Sed sed = Sed.read(getClass().getResource("/test_data/3C273.vot").getPath(), SedFormat.VOT);
 //        SedManager man = new SedManager();
 //        SedManager.SpecviewSed s = man.new SpecviewSed(sed, "3c273");

--- a/iris/src/test/resources/log.properties
+++ b/iris/src/test/resources/log.properties
@@ -1,0 +1,4 @@
+handlers = java.util.logging.ConsoleHandler
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+java.util.logging.SimpleFormatter.format = %1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %2$s [%4$s] %5$s%6$s%n
+.level = FINE

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,12 @@
                     <includes>
                         <include>**/*Test.*</include>
                     </includes>
+                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                    <systemPropertyVariables>
+                        <java.util.logging.config.file>
+                            ${project.parent.basedir}/iris/src/test/resources/log.properties
+                        </java.util.logging.config.file>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
             <plugin>

--- a/samp-factory/src/test/java/cfa/vo/interop/SAMPFactoryTest.java
+++ b/samp-factory/src/test/java/cfa/vo/interop/SAMPFactoryTest.java
@@ -59,7 +59,6 @@ public class SAMPFactoryTest extends TestCase {
      * Test of get method, of class SAMPFactory.
      */
     public void testGet_Class() {
-        System.out.println("get");
         TestInterface result = (TestInterface) SAMPFactory.get(TestInterface.class);
         List<String> methods = new ArrayList();
         List<String> exp_methods = new ArrayList();
@@ -92,7 +91,6 @@ public class SAMPFactoryTest extends TestCase {
      * Test of createMessage method, of class SAMPFactory.
      */
     public void testCreateMessage() throws Exception {
-        System.out.println("createMessage");
         String mtype = "test";
         Object instance = getInstance();
 
@@ -111,8 +109,6 @@ public class SAMPFactoryTest extends TestCase {
      * Test of get method, of class SAMPFactory.
      */
     public void testGet_SAMPMessage_Class() throws Exception {
-        System.out.println("get");
-
         String mtype = "test";
         Object instance = getInstance();
 
@@ -128,7 +124,6 @@ public class SAMPFactoryTest extends TestCase {
      * Test of get method, of class SAMPFactory.
      */
     public void testGet_Map_Class() throws Exception {
-        System.out.println("get");
 
         String mtype = "test";
         Object instance = getInstance();

--- a/sed-builder/src/main/java/cfa/vo/sed/builder/AsciiConf.java
+++ b/sed-builder/src/main/java/cfa/vo/sed/builder/AsciiConf.java
@@ -107,7 +107,6 @@ public class AsciiConf {
             conf.setXAxisColumnNumber(0);
             conf.setYAxisColumnNumber(1);
             conf.setXAxisQuantity(xquantity.getName().toUpperCase());
-	    System.out.println("");
             conf.setXAxisUnit(metadata.get("XUNIT").toString());
             conf.setYAxisQuantity(yquantity.getName().toUpperCase());
             conf.setYAxisUnit(metadata.get("YUNIT").toString());    

--- a/sed-builder/src/main/java/cfa/vo/sed/science/stacker/StackTableModel.java
+++ b/sed-builder/src/main/java/cfa/vo/sed/science/stacker/StackTableModel.java
@@ -21,6 +21,8 @@
  */
 package cfa.vo.sed.science.stacker;
 
+import java.util.logging.Logger;
+
 import cfa.vo.iris.sed.ExtSed;
 import static cfa.vo.sed.science.stacker.SedStackerAttachments.NORM_CONSTANT;
 import static cfa.vo.sed.science.stacker.SedStackerAttachments.ORIG_REDSHIFT;
@@ -29,90 +31,102 @@ import javax.swing.event.TableModelListener;
 import javax.swing.table.AbstractTableModel;
 
 /**
- *
+ * 
  * @author jbudynk
  */
 public class StackTableModel extends AbstractTableModel {
     
-    String[][] data = new String[][]{};
-    String[] columnNames = new String[] {"Sed ID", "Redshift", "Normalization Constant", "#Points"};
-    
+    private static final Logger logger = Logger.getLogger(StackTableModel.class.getName());
+
+    String[][] data = new String[][] {};
+    String[] columnNames = new String[] { "Sed ID", "Redshift",
+            "Normalization Constant", "#Points" };
+
     public StackTableModel() {
-	
+
     }
 
     public StackTableModel(final SedStack stack) {
-	data = new String[stack.getSeds().size()][4];
-	int i =0;
-	for (ExtSed sed : stack.getSeds()) {
-	    data[i][0] = sed.getId();
-	    data[i][1] = (String) sed.getAttachment(ORIG_REDSHIFT);
-	    data[i][2] = sed.getAttachment(NORM_CONSTANT).toString();
-	    data[i][3] = getNumOfPoints(sed).toString();
-	    i++;
-	}
-	
-	this.addTableModelListener(new TableModelListener() {
+        data = new String[stack.getSeds().size()][4];
+        int i = 0;
+        for (ExtSed sed : stack.getSeds()) {
+            data[i][0] = sed.getId();
+            data[i][1] = (String) sed.getAttachment(ORIG_REDSHIFT);
+            data[i][2] = sed.getAttachment(NORM_CONSTANT).toString();
+            data[i][3] = getNumOfPoints(sed).toString();
+            i++;
+        }
 
-	    @Override
-	    public void tableChanged(TableModelEvent e) {
-		if (e.getType() == TableModelEvent.UPDATE) {
-		    int row = e.getFirstRow();
-		    int column = e.getColumn();
-		    Object value = ((StackTableModel) e.getSource()).getValueAt(row, column);
-		    stack.getSed(row).addAttachment(SedStackerAttachments.REDSHIFT, value);
-		    stack.getSed(row).addAttachment(SedStackerAttachments.ORIG_REDSHIFT, value);
-		    stack.getOrigSeds().get(row).addAttachment(SedStackerAttachments.REDSHIFT, value);
-		    stack.getOrigSeds().get(row).addAttachment(SedStackerAttachments.ORIG_REDSHIFT, value);
-		}
-	    }
-	});
+        this.addTableModelListener(new TableModelListener() {
+
+            @Override
+            public void tableChanged(TableModelEvent e) {
+                if (e.getType() == TableModelEvent.UPDATE) {
+                    int row = e.getFirstRow();
+                    int column = e.getColumn();
+                    Object value = ((StackTableModel) e.getSource())
+                            .getValueAt(row, column);
+                    stack.getSed(row).addAttachment(
+                            SedStackerAttachments.REDSHIFT, value);
+                    stack.getSed(row).addAttachment(
+                            SedStackerAttachments.ORIG_REDSHIFT, value);
+                    stack.getOrigSeds()
+                            .get(row)
+                            .addAttachment(SedStackerAttachments.REDSHIFT,
+                                    value);
+                    stack.getOrigSeds()
+                            .get(row)
+                            .addAttachment(SedStackerAttachments.ORIG_REDSHIFT,
+                                    value);
+                }
+            }
+        });
     }
-    
+
     @Override
     public int getRowCount() {
-	return data.length;
+        return data.length;
     }
 
     @Override
     public int getColumnCount() {
-	return columnNames.length;
+        return columnNames.length;
     }
 
     @Override
     public Object getValueAt(int row, int column) {
-	return data[row][column];
+        return data[row][column];
     }
-    
+
     @Override
     public String getColumnName(int col) {
-	return columnNames[col];
+        return columnNames[col];
     }
-    
+
     @Override
     public boolean isCellEditable(int rowIndex, int columnIndex) {
-	    return (columnIndex == 1);
+        return (columnIndex == 1);
     }
-    
+
     @Override
     public void setValueAt(Object value, int row, int col) {
-	data[row][col] = (String) value;
-	fireTableCellUpdated(row, col);
+        data[row][col] = (String) value;
+        fireTableCellUpdated(row, col);
     }
 
     private Integer getNumOfPoints(ExtSed sed) {
-	int numOfPoints = 0;
-	for (int i = 0; i<sed.getNumberOfSegments(); i++) {
-	    numOfPoints += sed.getSegment(i).getLength();
-	}
-	return numOfPoints;
+        int numOfPoints = 0;
+        for (int i = 0; i < sed.getNumberOfSegments(); i++) {
+            numOfPoints += sed.getSegment(i).getLength();
+        }
+        return numOfPoints;
     }
-    
+
     public void addRow(String[] rowData) {
-	System.out.println(getRowCount());
+        logger.info("row count: " + getRowCount());
         data[getRowCount()] = rowData;
-	System.out.println(getRowCount());
+        logger.info("row count: " + getRowCount());
         fireTableRowsInserted(getRowCount() - 1, getRowCount() - 1);
     }
-    
+
 }

--- a/sed-builder/src/test/java/cfa/vo/sed/builder/AsciiConfTest.java
+++ b/sed-builder/src/test/java/cfa/vo/sed/builder/AsciiConfTest.java
@@ -50,8 +50,6 @@ public class AsciiConfTest {
 	@Test
 	public void testMakeConf() throws Exception {
 		
-		System.out.println("makeConf");
-		
 		URL filenameOK = AsciiConf.class.getResource("/test_data/ascii-conf-test.dat");
 		SetupBean resultOK = new AsciiConf().makeConf(filenameOK);
 		

--- a/sed-builder/src/test/java/cfa/vo/sed/builder/NEDImporterTest.java
+++ b/sed-builder/src/test/java/cfa/vo/sed/builder/NEDImporterTest.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.*;
  *
  * @author olaurino
  */
-public class NEDImporter {
+public class NEDImporterTest {
 
 //    public NEDImporter() {
 //    }
@@ -59,7 +59,6 @@ public class NEDImporter {
 //     */
 //    @Test
 //    public void testGetSedFromWrongName() throws Exception {
-//        System.out.println("getSedFromName");
 //        String targetName = "pippo";
 //        Sed result = NEDImporter.getSedFromName(targetName);
 //        assertEquals(0, result.getNumberOfSegments());
@@ -70,7 +69,6 @@ public class NEDImporter {
 //     */
 //    @Test
 //    public void testGetSedFor3C186() throws Exception {
-//        System.out.println("getSedFor3C186");
 //        String targetName = "3c186";
 //        Sed result = NEDImporter.getSedFromName(targetName);
 //        assertEquals(1, result.getNumberOfSegments());
@@ -81,7 +79,6 @@ public class NEDImporter {
 //     */
 //    @Test
 //    public void testGetSedFor3C273() throws Exception {
-//        System.out.println("getSedFor3C273");
 //        String targetName = "3c273";
 //        Sed result = NEDImporter.getSedFromName(targetName);
 //        assertEquals(1, result.getNumberOfSegments());

--- a/sed-builder/src/test/java/cfa/vo/sed/builder/SegmentImporterTest.java
+++ b/sed-builder/src/test/java/cfa/vo/sed/builder/SegmentImporterTest.java
@@ -49,8 +49,6 @@ public class SegmentImporterTest {
 
     @BeforeClass
     public static void setUpClass() throws Exception {
-        System.out.println("Creating configuration files");
-
         URL fileURL = URLTestConverter.getURL("test:///test_data/fileformats.ini");
 
         List<ISetup> confList = ConfigFactory.getAllFormatsConfigurations();

--- a/sed-builder/src/test/java/cfa/vo/sed/filters/ConfigurationManagerTest.java
+++ b/sed-builder/src/test/java/cfa/vo/sed/filters/ConfigurationManagerTest.java
@@ -49,10 +49,8 @@ public class ConfigurationManagerTest {
 
     @BeforeClass
     public static void setUpClass() throws Exception {
-        System.out.println("Creating configuration files");
 
         URL fileURL = URLTestConverter.getURL("test:///test_data/spvquantities.ini");
-        System.out.println(fileURL);
         List<ISetup> confList = ConfigFactory.getAllQuantitiesConfigurations();
 
         SetupManager.write(confList, fileURL);
@@ -76,9 +74,7 @@ public class ConfigurationManagerTest {
      */
     @Test
     public void testConfigurationIOQuantities() throws Exception {
-        System.out.println("read all configurations in spvquantities.ini");
         URL fileURL = URLTestConverter.getURL("test:///test_data/spvquantities.ini");
-        System.out.println(fileURL);
         List<ISetup> expResult = ConfigFactory.getAllQuantitiesConfigurations();
         List<ISetup> result = SetupManager.read(fileURL);
         assertEquals(expResult.size(), result.size());

--- a/sed-builder/src/test/java/cfa/vo/sed/filters/FileFormatsTest.java
+++ b/sed-builder/src/test/java/cfa/vo/sed/filters/FileFormatsTest.java
@@ -53,10 +53,8 @@ public class FileFormatsTest {
 
     @BeforeClass
     public static void setUpClass() throws Exception {
-        System.out.println("Creating configuration files");
 
         URL fileURL = URLTestConverter.getURL("test:///test_data/fileformats.ini");
-        System.out.println(fileURL);
         List<ISetup> confList = ConfigFactory.getAllFormatsConfigurations();
 
         SetupManager.write(confList, fileURL);
@@ -83,9 +81,7 @@ public class FileFormatsTest {
         SedBuilder builder = new SedBuilder();
         builder.init(new App(), new Ws());
 
-        System.out.println("read all configurations in fileformats.ini");
         URL fileURL = URLTestConverter.getURL("test:///test_data/fileformats.ini");
-        System.out.println(fileURL);
         List<ISetup> expResult = ConfigFactory.getAllFormatsConfigurations();
         List<ISetup> result = SetupManager.read(fileURL);
         assertEquals(expResult.size(), result.size());

--- a/sed-builder/src/test/java/cfa/vo/sed/filters/PhotometryCatalogTest.java
+++ b/sed-builder/src/test/java/cfa/vo/sed/filters/PhotometryCatalogTest.java
@@ -38,6 +38,9 @@ import cfa.vo.sed.test.App;
 import cfa.vo.iris.test.Oracle;
 import cfa.vo.sed.test.Ws;
 import cfa.vo.sedlib.io.SedFormat;
+
+import java.util.logging.Logger;
+
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -49,6 +52,8 @@ import org.junit.Test;
  * @author olaurino
  */
 public class PhotometryCatalogTest {
+    
+    private static final Logger logger = Logger.getLogger(PhotometryCatalogTest.class.getName());
 
     public PhotometryCatalogTest() {
     }
@@ -144,15 +149,15 @@ public class PhotometryCatalogTest {
         int c = 0;
 
         for(PhotometryCatalogEntry entry : catalog) {
-            System.out.println("Entry "+(++c));
+            logger.info("Entry "+(++c));
             for(PhotometryPointSegment segment : entry) {
                 PhotometryPoint point = segment.getPoint();
-                System.out.println("\tPoint: " + point.getId());
-                System.out.println("\t\tFilter: "+ point.getSpectralAxis().getFilter().toString());
-                System.out.println("\t\tFlux: " + point.getFluxAxis().getValue());
-                System.out.println("\t\tError: " + point.getFluxAxis().getError());
-                System.out.println("\t\tQuantity: " + point.getFluxAxis().getQuantity());
-                System.out.println("\t\tUnit: " + point.getFluxAxis().getUnit());
+                logger.info("\tPoint: " + point.getId());
+                logger.info("\t\tFilter: "+ point.getSpectralAxis().getFilter().toString());
+                logger.info("\t\tFlux: " + point.getFluxAxis().getValue());
+                logger.info("\t\tError: " + point.getFluxAxis().getError());
+                logger.info("\t\tQuantity: " + point.getFluxAxis().getQuantity());
+                logger.info("\t\tUnit: " + point.getFluxAxis().getUnit());
             }
         }
 

--- a/sed-builder/src/test/java/cfa/vo/sed/filters/PhotometryPointCloneTest.java
+++ b/sed-builder/src/test/java/cfa/vo/sed/filters/PhotometryPointCloneTest.java
@@ -38,6 +38,9 @@ import cfa.vo.sed.test.App;
 import cfa.vo.iris.test.Oracle;
 import cfa.vo.sed.test.Ws;
 import cfa.vo.sedlib.io.SedFormat;
+
+import java.util.logging.Logger;
+
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -49,6 +52,8 @@ import org.junit.Test;
  * @author olaurino
  */
 public class PhotometryPointCloneTest {
+    
+    private static final Logger logger = Logger.getLogger(PhotometryPointCloneTest.class.getName());
 
     public PhotometryPointCloneTest() {
     }
@@ -147,15 +152,15 @@ public class PhotometryPointCloneTest {
         int c = 0;
 
         for(PhotometryCatalogEntry entry : catalog) {
-            System.out.println("Entry "+(++c));
+            logger.info("Entry "+(++c));
             for(PhotometryPointSegment segment : entry) {
                 PhotometryPoint point = segment.getPoint();
-                System.out.println("\tPoint: " + point.getId());
-                System.out.println("\t\tFilter: "+ point.getSpectralAxis().getFilter().toString());
-                System.out.println("\t\tFlux: " + point.getFluxAxis().getValue());
-                System.out.println("\t\tError: " + point.getFluxAxis().getError());
-                System.out.println("\t\tQuantity: " + point.getFluxAxis().getQuantity());
-                System.out.println("\t\tUnit: " + point.getFluxAxis().getUnit());
+                logger.info("\tPoint: " + point.getId());
+                logger.info("\t\tFilter: "+ point.getSpectralAxis().getFilter().toString());
+                logger.info("\t\tFlux: " + point.getFluxAxis().getValue());
+                logger.info("\t\tError: " + point.getFluxAxis().getError());
+                logger.info("\t\tQuantity: " + point.getFluxAxis().getQuantity());
+                logger.info("\t\tUnit: " + point.getFluxAxis().getUnit());
             }
         }
 

--- a/sed-builder/src/test/java/cfa/vo/sed/science/interpolation/SherpaRedshifterTest.java
+++ b/sed-builder/src/test/java/cfa/vo/sed/science/interpolation/SherpaRedshifterTest.java
@@ -32,6 +32,7 @@ import cfa.vo.sedlib.Param;
 import cfa.vo.sherpa.SherpaClient;
 
 import java.util.Arrays;
+import java.util.logging.Logger;
 
 import org.astrogrid.samp.Response;
 import org.junit.After;
@@ -48,6 +49,8 @@ import spv.spectrum.SEDMultiSegmentSpectrum;
  * @author jbudynk
  */
 public class SherpaRedshifterTest {
+    
+    private static final Logger logger = Logger.getLogger(SherpaRedshifterTest.class.getName());
 
     private SAMPController controller;
     private static String REDSHIFT_MTYPE = "spectrum.redshift.calc";
@@ -72,7 +75,7 @@ public class SherpaRedshifterTest {
         // including that the flux errors are sorted along with their
         // corresponding (x, y) points
 
-        System.out.println("To run this test, you need a SAMP Hub running with Sherpa-SAMP connected.");
+        logger.info("To run this test, you need a SAMP Hub running with Sherpa-SAMP connected.");
 
         double[] y = new double[]{
                 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30
@@ -91,10 +94,9 @@ public class SherpaRedshifterTest {
         controller.start(false);
 
         Thread.sleep(2000);
-        System.out.println();
 
         while (!controller.isConnected()) {
-            System.out.println("waiting connection");
+            logger.info("waiting connection");
             Thread.sleep(1000);
         }
 

--- a/sed-builder/src/test/java/cfa/vo/sed/science/stacker/SedStackTest.java
+++ b/sed-builder/src/test/java/cfa/vo/sed/science/stacker/SedStackTest.java
@@ -33,6 +33,8 @@ import cfa.vo.sedlib.Segment;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Logger;
+
 import org.apache.commons.lang.StringUtils;
 import org.junit.After;
 import static org.junit.Assert.*;
@@ -51,129 +53,134 @@ public class SedStackTest {
     
     @Before
     public void setUp() throws Exception {
-	
-	SedBuilder builder = new SedBuilder();
+
+        SedBuilder builder = new SedBuilder();
         builder.init(new App(), new Ws());
-	
-	URL filename1 = AsciiConf.class.getResource("/test_data/ascii-conf-test.dat");
-	SetupBean result1 = new AsciiConf().makeConf(filename1);
-	seg1 = SegmentImporter.getSegments(result1).get(0);
-	
-	URL filename2 = AsciiConf.class.getResource("/test_data/ascii-conf-no-y_error.dat");
-	SetupBean result2 = new AsciiConf().makeConf(filename2);
-	seg2 = SegmentImporter.getSegments(result2).get(0);
-	
+
+        URL filename1 = AsciiConf.class
+                .getResource("/test_data/ascii-conf-test.dat");
+        SetupBean result1 = new AsciiConf().makeConf(filename1);
+        seg1 = SegmentImporter.getSegments(result1).get(0);
+
+        URL filename2 = AsciiConf.class
+                .getResource("/test_data/ascii-conf-no-y_error.dat");
+        SetupBean result2 = new AsciiConf().makeConf(filename2);
+        seg2 = SegmentImporter.getSegments(result2).get(0);
+
     }
-    
+
     @After
     public void tearDown() {
-	
+
     }
-    
+
     @Test
     public void testRename() throws Exception {
-	
-	List<String> names = new ArrayList();
-	names.add("Stack");
-	for (int i=0; i<54; i++) {
-	    add(names, "Stack");
-	}
-	
-	add(names, "Stack");
-	System.out.println(names);
-	
+
+        List<String> names = new ArrayList<>();
+        names.add("Stack");
+        for (int i = 0; i < 54; i++) {
+            add(names, "Stack");
+        }
+
+        add(names, "Stack");
+
     }
-    
+
     @Test
     public void testAddSedsFrameAddButton() throws Exception {
-	SedStack stack = new SedStack("Stack");
-	ExtSed sed = new ExtSed("Sed");
-	sed.addSegment(seg1);
-	sed.addSegment(seg2);
-	ExtSed sed2 = new ExtSed("Sed2");
-	sed2.addSegment(seg1);
-	sed2.addSegment(seg2);
-	stack.add(sed);
-	stack.add(sed2);
-	
-	ExtSed sed3 = new ExtSed("Sed3");
-	sed3.addSegment(seg1);
-	sed3.addSegment(seg2);
-	List<ExtSed> newSedList = new ArrayList();
-	newSedList.add(sed3);
-	
-	addSedsFrame(stack, newSedList, false);
-	
-	System.out.println("");
+        SedStack stack = new SedStack("Stack");
+        ExtSed sed = new ExtSed("Sed");
+        sed.addSegment(seg1);
+        sed.addSegment(seg2);
+        ExtSed sed2 = new ExtSed("Sed2");
+        sed2.addSegment(seg1);
+        sed2.addSegment(seg2);
+        stack.add(sed);
+        stack.add(sed2);
+
+        ExtSed sed3 = new ExtSed("Sed3");
+        sed3.addSegment(seg1);
+        sed3.addSegment(seg2);
+        List<ExtSed> newSedList = new ArrayList<>();
+        newSedList.add(sed3);
+
+        addSedsFrame(stack, newSedList, false);
     }
-    
+
     @Test
     public void testNormHashCodeChanged() throws Exception {
-	
-	SedStack stack = new SedStack("Stack");
-	ExtSed sed = new ExtSed("Sed");
-	sed.addSegment(seg1);
-	sed.addSegment(seg2);
-	ExtSed sed2 = new ExtSed("Sed2");
-	sed2.addSegment(seg1);
-	sed2.addSegment(seg2);
-	stack.add(sed);
-	stack.add(sed2);
-	ExtSed sed3 = new ExtSed("Sed3");
-	sed3.addSegment(seg1);
-	sed3.addSegment(seg2);
-	
-	NormalizationConfiguration normConf = new NormalizationConfiguration();
-	
-	sed3.addAttachment("sedstacker: normConfHash", normConf.hashCode());
-	sed.addAttachment("sedstacker: normConfHash", normConf.hashCode());
-	sed2.addAttachment("sedstacker: normConfHash", normConf.hashCode());
-	
-	normConf.setIntegrate(true);
-	normConf.setIntegrate(false);
-	normConf.setIntegrate(true);
-	normConf.setIntegrate(false);
-	
-	assertFalse(Integer.parseInt(sed3.getAttachment("sedstacker: normConfHash").toString()) == normConf.hashCode());
+
+        SedStack stack = new SedStack("Stack");
+        ExtSed sed = new ExtSed("Sed");
+        sed.addSegment(seg1);
+        sed.addSegment(seg2);
+        ExtSed sed2 = new ExtSed("Sed2");
+        sed2.addSegment(seg1);
+        sed2.addSegment(seg2);
+        stack.add(sed);
+        stack.add(sed2);
+        ExtSed sed3 = new ExtSed("Sed3");
+        sed3.addSegment(seg1);
+        sed3.addSegment(seg2);
+
+        NormalizationConfiguration normConf = new NormalizationConfiguration();
+
+        sed3.addAttachment("sedstacker: normConfHash", normConf.hashCode());
+        sed.addAttachment("sedstacker: normConfHash", normConf.hashCode());
+        sed2.addAttachment("sedstacker: normConfHash", normConf.hashCode());
+
+        normConf.setIntegrate(true);
+        normConf.setIntegrate(false);
+        normConf.setIntegrate(true);
+        normConf.setIntegrate(false);
+
+        assertFalse(
+                Integer.parseInt(sed3.getAttachment("sedstacker: normConfHash")
+                        .toString()) == normConf.hashCode());
     }
-    
+
     public void add(List<String> names, String newName) {
-	
-	char c = '@';
-	int i = 1;
-	int j = 1;
-        while (names.contains(newName + (c == '@' ? "" : "." + StringUtils.repeat(String.valueOf(c), j)))) {
-	    int val = j*26;
-	    if (i % val == 0) {
-		c = '@';
-		j++;
-	    }
-	    c++;
-	    i++;
+
+        char c = '@';
+        int i = 1;
+        int j = 1;
+        while (names.contains(newName + (c == '@' ? ""
+                : "." + StringUtils.repeat(String.valueOf(c), j)))) {
+            int val = j * 26;
+            if (i % val == 0) {
+                c = '@';
+                j++;
+            }
+            c++;
+            i++;
         }
-        names.add(newName + (c == '@' ? "" : "." + StringUtils.repeat(String.valueOf(c), j)));
-	
+        names.add(newName + (c == '@' ? ""
+                : "." + StringUtils.repeat(String.valueOf(c), j)));
+
     }
-    
-    public void addSedsFrame(SedStack stack, List<ExtSed> seds, boolean isSegmentAsSeds) throws Exception {
-	for (ExtSed sed : seds) {
-	    
-	    if (!isSegmentAsSeds) {
-		
-		stack.add(sed);
-		
-	    } else {
 
-		for (int j=0; j<sed.getNumberOfSegments(); j++) {
+    public void addSedsFrame(SedStack stack, List<ExtSed> seds,
+            boolean isSegmentAsSeds) throws Exception {
+        for (ExtSed sed : seds) {
 
-		    Segment seg = sed.getSegment(j);
-		    ExtSed nsed = new ExtSed(seg.getTarget().getName().getName());
-		    nsed.addSegment(seg);
-		    stack.add(nsed);
+            if (!isSegmentAsSeds) {
 
-		}
-	    }
-	}
+                stack.add(sed);
+
+            } else {
+
+                for (int j = 0; j < sed.getNumberOfSegments(); j++) {
+
+                    Segment seg = sed.getSegment(j);
+                    ExtSed nsed = new ExtSed(
+                            seg.getTarget().getName().getName());
+                    nsed.addSegment(seg);
+                    stack.add(nsed);
+
+                }
+            }
+        }
     }
     
 }

--- a/sed-builder/src/test/java/cfa/vo/sed/science/stacker/SedStackerNormalizerTest.java
+++ b/sed-builder/src/test/java/cfa/vo/sed/science/stacker/SedStackerNormalizerTest.java
@@ -34,6 +34,7 @@ import cfa.vo.sherpa.SherpaClient;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Logger;
 
 import org.astrogrid.samp.Response;
 import org.junit.After;
@@ -50,6 +51,8 @@ import spv.spectrum.SEDMultiSegmentSpectrum;
  * @author jbudynk
  */
 public class SedStackerNormalizerTest {
+    
+    private static final Logger logger = Logger.getLogger(SedStackerNormalizerTest.class.getName());
 
     double[] x1;
     double[] y1;
@@ -119,10 +122,9 @@ public class SedStackerNormalizerTest {
         controller.start(false);
 
         Thread.sleep(2000);
-        System.out.println();
 
         while (!controller.isConnected()) {
-            System.out.println("waiting connection");
+            logger.info("waiting connection");
             Thread.sleep(1000);
         }
 
@@ -184,10 +186,9 @@ public class SedStackerNormalizerTest {
         controller.start(false);
 
         Thread.sleep(2000);
-        System.out.println();
 
         while (!controller.isConnected()) {
-            System.out.println("waiting connection");
+            logger.info("waiting connection");
             Thread.sleep(1000);
         }
 
@@ -291,10 +292,8 @@ public class SedStackerNormalizerTest {
         controller.start(false);
 
         Thread.sleep(2000);
-        System.out.println();
 
         while (!controller.isConnected()) {
-            System.out.println("waiting connection");
             Thread.sleep(1000);
         }
 

--- a/sed-builder/src/test/java/cfa/vo/sed/science/stacker/SedStackerRedshifterTest.java
+++ b/sed-builder/src/test/java/cfa/vo/sed/science/stacker/SedStackerRedshifterTest.java
@@ -34,6 +34,7 @@ import cfa.vo.sherpa.SherpaClient;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Logger;
 
 import org.astrogrid.samp.Response;
 import org.junit.After;
@@ -50,6 +51,8 @@ import spv.spectrum.SEDMultiSegmentSpectrum;
  * @author jbudynk
  */
 public class SedStackerRedshifterTest {
+    
+    private static final Logger logger = Logger.getLogger(SedStackerRedshifterTest.class.getName());
 
     double[] x1;
     double[] y1;
@@ -130,10 +133,9 @@ public class SedStackerRedshifterTest {
         controller.start(false);
 
         Thread.sleep(2000);
-        System.out.println();
 
         while (!controller.isConnected()) {
-            System.out.println("waiting connection");
+            logger.info("waiting connection");
             Thread.sleep(1000);
         }
 
@@ -196,10 +198,9 @@ public class SedStackerRedshifterTest {
         controller.start(false);
 
         Thread.sleep(2000);
-        System.out.println();
-
+        
         while (!controller.isConnected()) {
-            System.out.println("waiting connection");
+            logger.info("waiting connection");
             Thread.sleep(1000);
         }
 
@@ -309,10 +310,9 @@ public class SedStackerRedshifterTest {
         controller.start(false);
 
         Thread.sleep(2000);
-        System.out.println();
 
         while (!controller.isConnected()) {
-            System.out.println("waiting connection");
+            logger.info("waiting connection");
             Thread.sleep(1000);
         }
 

--- a/sed-builder/src/test/java/cfa/vo/sed/science/stacker/SedStackerStackerTest.java
+++ b/sed-builder/src/test/java/cfa/vo/sed/science/stacker/SedStackerStackerTest.java
@@ -34,6 +34,7 @@ import cfa.vo.sherpa.SherpaClient;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Logger;
 
 import org.astrogrid.samp.Response;
 import org.junit.After;
@@ -50,7 +51,9 @@ import spv.spectrum.SEDMultiSegmentSpectrum;
  * @author jbudynk
  */
 public class SedStackerStackerTest {
-
+    
+    private static final Logger logger = Logger.getLogger(SedStackerStackerTest.class.getName());
+    
     double[] x1;
     double[] y1;
     double[] yerr1;
@@ -112,10 +115,9 @@ public class SedStackerStackerTest {
         controller.start(false);
 
         Thread.sleep(2000);
-        System.out.println();
 
         while (!controller.isConnected()) {
-            System.out.println("waiting connection");
+            logger.info("waiting connection");
             Thread.sleep(1000);
         }
 
@@ -180,10 +182,9 @@ public class SedStackerStackerTest {
         controller.start(false);
 
         Thread.sleep(2000);
-        System.out.println();
 
         while (!controller.isConnected()) {
-            System.out.println("waiting connection");
+            logger.info("waiting connection");
             Thread.sleep(1000);
         }
 

--- a/test-components/src/main/java/cfa/vo/iris/test/TestBuilder.java
+++ b/test-components/src/main/java/cfa/vo/iris/test/TestBuilder.java
@@ -34,6 +34,8 @@ import cfa.vo.iris.sed.SedlibSedManager;
 import cfa.vo.sedlib.Segment;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Logger;
+
 import org.astrogrid.samp.client.MessageHandler;
 
 /**
@@ -41,6 +43,8 @@ import org.astrogrid.samp.client.MessageHandler;
  * @author olaurino
  */
 public class TestBuilder implements IrisComponent {
+    
+    private static final Logger logger = Logger.getLogger(TestBuilder.class.getName());
 
     private static IrisApplication app;
 
@@ -122,7 +126,7 @@ public class TestBuilder implements IrisComponent {
 
         @Override
         public void call(String[] args) {
-            System.out.println(getName()+" called with arguments: "+args);
+            logger.info(getName()+" called with arguments: "+args);
         }
 
     }

--- a/test-components/src/main/java/cfa/vo/iris/test/TestLogger.java
+++ b/test-components/src/main/java/cfa/vo/iris/test/TestLogger.java
@@ -30,8 +30,11 @@ import cfa.vo.iris.NullCommandLineInterface;
 import cfa.vo.iris.logging.LogEntry;
 import cfa.vo.iris.logging.LogEvent;
 import cfa.vo.iris.logging.LogListener;
+
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Logger;
+
 import org.astrogrid.samp.client.MessageHandler;
 
 /**
@@ -39,6 +42,8 @@ import org.astrogrid.samp.client.MessageHandler;
  * @author olaurino
  */
 public class TestLogger implements IrisComponent, LogListener {
+    
+    private static final Logger logger = Logger.getLogger(TestLogger.class.getName());
 
     @Override
     public void init(IrisApplication app, IWorkspace workspace) {
@@ -72,7 +77,7 @@ public class TestLogger implements IrisComponent, LogListener {
 
     @Override
     public void process(Object source, LogEntry payload) {
-        System.out.println(payload.getFormatted());
+        logger.info(payload.getFormatted());
     }
 
     @Override

--- a/test-components/src/main/java/cfa/vo/iris/test/r/RComponent.java
+++ b/test-components/src/main/java/cfa/vo/iris/test/r/RComponent.java
@@ -49,6 +49,8 @@ import org.rosuda.JRI.Rengine;
  * @author olaurino
  */
 public class RComponent implements IrisComponent {
+    
+    private static final Logger logger = Logger.getLogger(RComponent.class.getName());
 
     private IrisApplication app;
     private IWorkspace ws;
@@ -107,7 +109,7 @@ public class RComponent implements IrisComponent {
                     if(re==null) {
                         re = new Rengine(new String[]{}, false, new TextConsole());
                         if (!re.waitForR()) {
-                            System.out.println("Cannot load R");
+                            logger.info("Cannot load R");
                             return;
                         }
 
@@ -148,7 +150,7 @@ public class RComponent implements IrisComponent {
 
         @Override
         public void rBusy(Rengine re, int which) {
-            System.out.println("rBusy(" + which + ")");
+            logger.info("rBusy(" + which + ")");
         }
 
         @Override
@@ -159,14 +161,14 @@ public class RComponent implements IrisComponent {
                 String s = br.readLine();
                 return (s == null || s.length() == 0) ? s : s + "\n";
             } catch (Exception e) {
-                System.out.println("jriReadConsole exception: " + e.getMessage());
+                logger.log(Level.WARNING, "jriReadConsole exception: ", e);
             }
             return null;
         }
 
         @Override
         public void rShowMessage(Rengine re, String message) {
-            System.out.println("rShowMessage \"" + message + "\"");
+            logger.info("rShowMessage \"" + message + "\"");
         }
 
         @Override


### PR DESCRIPTION
Building off Omar's change.

Logs for units tests are dumped into surefire output. 
Removed most of the prints to std out - those that are left are only in the CLI and visible for Consumers' sake.
Formatted logfiles for readability, no longer split across lines, e.g.:

2015-11-06 11:48:32 cfa.vo.iris.ComponentLoader initComponents [INFO] Loading class: cfa.vo.iris.ComponentLoaderTest$BrokenTestIrisComponent
2015-11-06 11:48:32 cfa.vo.iris.ComponentLoader initComponents [SEVERE] Could not construct component cfa.vo.iris.ComponentLoaderTest$BrokenTestIrisComponent
java.lang.RuntimeException: I don't work
	at cfa.vo.iris.ComponentLoaderTest$BrokenTestIrisComponent.<init>(ComponentLoaderTest.java:73)

Ultimately I think we should setup an option for specifying log files for the Iris application VIA the CLI or the preferences config file.

All tests pass, verified that log files have appropriate format, travis builds are much easier to read. Failed tests/processes still dump their exceptions into the log.

