### PR TITLE
Docs migration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "sedlib"]
 	path = sedlib
 	url = https://github.com/ChandraCXC/sedlib
+[submodule "iris-docs"]
+	path = iris-docs
+	url = https://github.com/jbudynk/iris-docs.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -15,4 +15,4 @@
 	url = https://github.com/ChandraCXC/sedlib
 [submodule "iris-docs"]
 	path = iris-docs
-	url = https://github.com/jbudynk/iris-docs.git
+	url = https://github.com/ChandraCXC/iris-docs.git

--- a/iris-common/pom.xml
+++ b/iris-common/pom.xml
@@ -29,6 +29,11 @@
         <version>3.0-SNAPSHOT</version>
     </parent>
 
+    <!-- To help with site creation directory, specify the parent directory -->
+    <properties>
+        <main.basedir>${project.parent.basedir}</main.basedir>
+    </properties>
+
     <build>
         <plugins>
             <plugin>
@@ -42,6 +47,26 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>3.4</version>
+                <configuration>
+                    <siteDirectory>./src/site/</siteDirectory>
+                    <outputDirectory>${project.parent.basedir}/target/site/iris-common/</outputDirectory>
+                </configuration>
+<!-- 
+                <dependencies>
+                    <dependency>
+                        <!~~ add support for ssh/scp ~~>
+                        <groupId>org.apache.maven.wagon</groupId>
+                        <artifactId>wagon-ssh</artifactId>
+                        <version>1.0</version>
+                    </dependency>
+                </dependencies>
+-->
             </plugin>
         </plugins>
     </build>
@@ -104,5 +129,4 @@
             <version>0.9.7</version>
         </dependency>
     </dependencies>
-
 </project>

--- a/iris-common/pom.xml
+++ b/iris-common/pom.xml
@@ -29,11 +29,6 @@
         <version>3.0-SNAPSHOT</version>
     </parent>
 
-    <!-- To help with site creation directory, specify the parent directory -->
-    <properties>
-        <main.basedir>${project.parent.basedir}</main.basedir>
-    </properties>
-
     <build>
         <plugins>
             <plugin>
@@ -47,16 +42,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-site-plugin</artifactId>
-                <version>3.4</version>
-                <configuration>
-                    <siteDirectory>./src/site/</siteDirectory>
-                    <outputDirectory>${project.parent.basedir}/target/site/iris-common/</outputDirectory>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/iris-common/pom.xml
+++ b/iris-common/pom.xml
@@ -57,16 +57,6 @@
                     <siteDirectory>./src/site/</siteDirectory>
                     <outputDirectory>${project.parent.basedir}/target/site/iris-common/</outputDirectory>
                 </configuration>
-<!-- 
-                <dependencies>
-                    <dependency>
-                        <!~~ add support for ssh/scp ~~>
-                        <groupId>org.apache.maven.wagon</groupId>
-                        <artifactId>wagon-ssh</artifactId>
-                        <version>1.0</version>
-                    </dependency>
-                </dependencies>
--->
             </plugin>
         </plugins>
     </build>

--- a/iris-common/src/site/markdown/index.md
+++ b/iris-common/src/site/markdown/index.md
@@ -1,0 +1,11 @@
+# iris-common
+
+This page contains developer information for the Iris software 
+development kit (SDK).
+
+Please see the [Project Documentation][proj-info] for more details.
+
+Otherwise, return to the main [Iris user documentation][user-docs].
+
+[proj-info]: ./project-info.html
+[user-docs]: ../index.html

--- a/iris-common/src/site/site.xml
+++ b/iris-common/src/site/site.xml
@@ -1,0 +1,97 @@
+<project xmlns="http://maven.apache.org/DECORATION/1.6.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/DECORATION/1.6.0 http://maven.apache.org/xsd/decoration-1.6.0.xsd"
+         name="Iris">
+
+	<bannerLeft>
+		<name>Chandra CXC</name>
+		<src>../imgs/Iris_logo_padding.png</src>
+		<href>../index.html</href>
+	</bannerLeft>
+
+
+    <body>
+    
+        <links>
+            <item name="Chandra CXC" href="http://cxc.cfa.harvard.edu"/>
+        </links>
+    
+        <menu ref="parent"/>
+        <menu name="Information">
+			<item name="Introduction" href="./index.html"/>
+			<item name="Sybling Modules" href="../modules.html"/>
+		</menu>
+        <menu ref="reports"/>
+		  
+<!-- 
+		<menu name="Iris" >
+		  <item name="Homepage" href="../../../index.html"/>
+		</menu>
+		  <menu name="Introduction">
+			<item name="About" href="../../../intro/index.html"/>
+			<item name="Features" href="../../intro/features.html"/>
+			<item name="Future" href="../../../intro/future.html"/>
+		  </menu>
+		  <menu name="Download Iris">
+			<item name="Download &amp; Installation" href="../../../download/index.html"/>
+			<item name="Smoke Test" href="../../../download/smoke_tests.html"/>
+			<item name="Troubleshooting" href="../../../bugs/smoke.html"/>
+		  </menu>
+		  <menu name="Documentation">
+			<item name="How-To Guide" href="../../../guide.html" collapse="true">
+			  <item name="Loading SED Data into Iris" href="../../../threads/entry/index.html"/>
+			  <item name="Building and Managing SEDs" href="../../../threads/importer/index.html"/>
+			  <item name="Visualizing SED Data" href="../../../threads/plot/index.html"/>
+			  <item name="Modeling and Fiting SED Data" href="../../../threads/fit/index.html"/>
+			  <item name="Saving SED Data" href="../../../threads/save/index.html"/>
+			  <item name="Shifting, Interpolating, and Integrating SED Data" href="../../../threads/science/index.html"/>
+			  <item name="Statistically Combining SEDs" href="../../../threads/science/sedstacker/index.html"/>
+			  <item name="Creating Iris Plugins: The Iris Software Development Kit" href="../../../threads/sdk/index.html"/>
+			  <item name="Installing Iris Plugins" href="../../../threads/plugin_manager/index.html"/>
+			</item>
+			<item name="Bugs &amp; Caveats" href="../../../bugs/index.html"/>
+			<item name="FAQs" href="../../../faq/index.html"/>
+			<item name="Release Notes" href="../../../releasenotes/index.html"/>
+		  </menu>
+		  <menu name="References">
+			<item name="Iris Models" href="../../../references/models.html"/>
+			<item name="Supported File Formats" href="../../../references/importer_files.html"/>
+			<item name="Publications" href="../../../publications/index.html"/>
+		  </menu>
+		  <menu name="Help Desk">
+			<item name="CXC HelpDesk" href="http://cxc.cfa.harvard.edu/helpdesk"/>
+		  </menu>
+		  <menu name="Release Versions">
+		  	<item name="Latest Release" href="../../../latest/index.html"/>
+		  	<item name="Previous Releases" href="../../../archive.html"/>
+		  </menu>
+		  <menu name="Project Documentation">
+		    <item name="Project Informaiton" href="./project-info.html"/>
+		    <item name=""/>
+		  </menu>
+ -->
+	
+    </body>
+    
+    <skin>
+        <groupId>org.apache.maven.skins</groupId>
+        <artifactId>maven-fluido-skin</artifactId>
+        <version>1.4</version>
+
+    </skin>
+
+    
+    <custom>
+        <fluidoSkin>
+            <googleSearch>
+                <sitesearch>http://cxc.cfa.harvard.edu/iris/v${project.version}</sitesearch>
+            </googleSearch>
+            <gitHub>
+                <projectId>ChandraCXC/iris</projectId>
+                <ribbonOrientation>left</ribbonOrientation>
+                <ribbonColor>orange</ribbonColor>
+            </gitHub>
+            <sideBarEnabled>true</sideBarEnabled>
+        </fluidoSkin>
+    </custom>
+
+</project>

--- a/iris-specview/src/site/markdown/index.md
+++ b/iris-specview/src/site/markdown/index.md
@@ -1,0 +1,10 @@
+# iris-specview
+
+This page contains developer information for the `iris-specview` package.
+
+Please see the [Project Documentation][proj-info] for more details.
+
+Otherwise, return to the main [Iris user documentation][user-docs].
+
+[proj-info]: ./project-info.html
+[user-docs]: ../index.html

--- a/iris-specview/src/site/site.xml
+++ b/iris-specview/src/site/site.xml
@@ -1,0 +1,48 @@
+<project xmlns="http://maven.apache.org/DECORATION/1.6.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/DECORATION/1.6.0 http://maven.apache.org/xsd/decoration-1.6.0.xsd"
+         name="Iris">
+
+	<bannerLeft>
+		<name>Chandra CXC</name>
+		<src>../imgs/Iris_logo_padding.png</src>
+		<href>../index.html</href>
+	</bannerLeft>
+
+    <body>
+    
+        <links>
+            <item name="Chandra CXC" href="http://cxc.cfa.harvard.edu"/>
+        </links>
+
+        <menu ref="parent"/>
+        <menu name="Information">
+			<item name="Introduction" href="./index.html"/>
+			<item name="Sybling Modules" href="../modules.html"/>
+		</menu>
+        <menu ref="reports"/>
+        	
+    </body>
+    
+    <skin>
+        <groupId>org.apache.maven.skins</groupId>
+        <artifactId>maven-fluido-skin</artifactId>
+        <version>1.4</version>
+
+    </skin>
+
+    
+    <custom>
+        <fluidoSkin>
+            <googleSearch>
+                <sitesearch>http://cxc.cfa.harvard.edu/iris/v${project.version}</sitesearch>
+            </googleSearch>
+            <gitHub>
+                <projectId>ChandraCXC/iris</projectId>
+                <ribbonOrientation>left</ribbonOrientation>
+                <ribbonColor>orange</ribbonColor>
+            </gitHub>
+            <sideBarEnabled>true</sideBarEnabled>
+        </fluidoSkin>
+    </custom>
+
+</project>

--- a/iris-visualizer/pom.xml
+++ b/iris-visualizer/pom.xml
@@ -58,16 +58,6 @@
                     <siteDirectory>./src/site/</siteDirectory>
                     <outputDirectory>${project.parent.basedir}/target/site/iris-specview/</outputDirectory>
                 </configuration>
-<!-- 
-                <dependencies>
-                    <dependency>
-                        <!~~ add support for ssh/scp ~~>
-                        <groupId>org.apache.maven.wagon</groupId>
-                        <artifactId>wagon-ssh</artifactId>
-                        <version>1.0</version>
-                    </dependency>
-                </dependencies>
--->
             </plugin>
         </plugins>
     </build>

--- a/iris-visualizer/pom.xml
+++ b/iris-visualizer/pom.xml
@@ -29,11 +29,6 @@
         <version>3.0-SNAPSHOT</version>
     </parent>
 
-    <!-- To help with site creation directory, specify the parent directory -->
-    <properties>
-        <main.basedir>${project.parent.basedir}</main.basedir>
-    </properties>
-
     <build>
         <plugins>
             <plugin>
@@ -46,17 +41,6 @@
                 <artifactId>maven-license-plugin</artifactId>
                 <configuration>
                     <header>etc/header.txt</header>
-                </configuration>
-            </plugin>
-
-            <!--  For the site creation -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-site-plugin</artifactId>
-                <version>3.4</version>
-                <configuration>
-                    <siteDirectory>./src/site/</siteDirectory>
-                    <outputDirectory>${project.parent.basedir}/target/site/iris-specview/</outputDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/iris-visualizer/pom.xml
+++ b/iris-visualizer/pom.xml
@@ -29,6 +29,49 @@
         <version>3.0-SNAPSHOT</version>
     </parent>
 
+    <!-- To help with site creation directory, specify the parent directory -->
+    <properties>
+        <main.basedir>${project.parent.basedir}</main.basedir>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>com.mycila.maven-license-plugin</groupId>
+                <artifactId>maven-license-plugin</artifactId>
+                <configuration>
+                    <header>etc/header.txt</header>
+                </configuration>
+            </plugin>
+
+            <!--  For the site creation -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>3.4</version>
+                <configuration>
+                    <siteDirectory>./src/site/</siteDirectory>
+                    <outputDirectory>${project.parent.basedir}/target/site/iris-specview/</outputDirectory>
+                </configuration>
+<!-- 
+                <dependencies>
+                    <dependency>
+                        <!~~ add support for ssh/scp ~~>
+                        <groupId>org.apache.maven.wagon</groupId>
+                        <artifactId>wagon-ssh</artifactId>
+                        <version>1.0</version>
+                    </dependency>
+                </dependencies>
+-->
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/iris/pom.xml
+++ b/iris/pom.xml
@@ -23,12 +23,13 @@
     <packaging>jar</packaging>
     <name>iris</name>
     <scm>
-     <developerConnection>scm:git:https://github.com/ChandraCXC/iris.git</developerConnection>
+        <developerConnection>scm:git:https://github.com/ChandraCXC/iris.git</developerConnection>
     </scm>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.build.timestamp.format>yyyy/MM/dd</maven.build.timestamp.format>
         <buildDate>${maven.build.timestamp}</buildDate>
+        <main.basedir>${project.parent.basedir}</main.basedir>
     </properties>
 
     <parent>
@@ -159,6 +160,28 @@
                     </execution>
                 </executions>
             </plugin>
+            
+            <!-- for the site -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>3.4</version>
+                <configuration>
+                    <siteDirectory>./src/site/</siteDirectory>
+                    <outputDirectory>${project.parent.basedir}/target/site/iris/</outputDirectory>
+                </configuration>
+<!-- 
+                <dependencies>
+                    <dependency>
+                        <!~~ add support for ssh/scp ~~>
+                        <groupId>org.apache.maven.wagon</groupId>
+                        <artifactId>wagon-ssh</artifactId>
+                        <version>1.0</version>
+                    </dependency>
+                </dependencies>
+-->
+            </plugin>
+            
         </plugins>
     </build>
 

--- a/iris/pom.xml
+++ b/iris/pom.xml
@@ -29,7 +29,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.build.timestamp.format>yyyy/MM/dd</maven.build.timestamp.format>
         <buildDate>${maven.build.timestamp}</buildDate>
-        <main.basedir>${project.parent.basedir}</main.basedir>
     </properties>
 
     <parent>
@@ -159,17 +158,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-            
-            <!-- for the site -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-site-plugin</artifactId>
-                <version>3.4</version>
-                <configuration>
-                    <siteDirectory>./src/site/</siteDirectory>
-                    <outputDirectory>${project.parent.basedir}/target/site/iris/</outputDirectory>
-                </configuration>
             </plugin>
             
         </plugins>

--- a/iris/pom.xml
+++ b/iris/pom.xml
@@ -170,16 +170,6 @@
                     <siteDirectory>./src/site/</siteDirectory>
                     <outputDirectory>${project.parent.basedir}/target/site/iris/</outputDirectory>
                 </configuration>
-<!-- 
-                <dependencies>
-                    <dependency>
-                        <!~~ add support for ssh/scp ~~>
-                        <groupId>org.apache.maven.wagon</groupId>
-                        <artifactId>wagon-ssh</artifactId>
-                        <version>1.0</version>
-                    </dependency>
-                </dependencies>
--->
             </plugin>
             
         </plugins>

--- a/iris/src/site/markdown/index.md
+++ b/iris/src/site/markdown/index.md
@@ -1,0 +1,10 @@
+# iris
+
+This page contains developer information for the `iris` module.
+
+Please see the [Project Documentation][proj-info] for more details.
+
+Otherwise, return to the main [Iris user documentation][user-docs].
+
+[proj-info]: ./project-info.html
+[user-docs]: ../index.html

--- a/iris/src/site/site.xml
+++ b/iris/src/site/site.xml
@@ -1,0 +1,48 @@
+<project xmlns="http://maven.apache.org/DECORATION/1.6.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/DECORATION/1.6.0 http://maven.apache.org/xsd/decoration-1.6.0.xsd"
+         name="Iris">
+
+	<bannerLeft>
+		<name>Chandra CXC</name>
+		<src>../imgs/Iris_logo_padding.png</src>
+		<href>../index.html</href>
+	</bannerLeft>
+
+    <body>
+    
+        <links>
+            <item name="Chandra CXC" href="http://cxc.cfa.harvard.edu"/>
+        </links>
+
+        <menu ref="parent"/>
+        <menu name="Information">
+			<item name="Introduction" href="./index.html"/>
+			<item name="Sybling Modules" href="../modules.html"/>
+		</menu>
+        <menu ref="reports"/>
+        	
+    </body>
+    
+    <skin>
+        <groupId>org.apache.maven.skins</groupId>
+        <artifactId>maven-fluido-skin</artifactId>
+        <version>1.4</version>
+
+    </skin>
+
+    
+    <custom>
+        <fluidoSkin>
+            <googleSearch>
+                <sitesearch>http://cxc.cfa.harvard.edu/iris/v${project.version}</sitesearch>
+            </googleSearch>
+            <gitHub>
+                <projectId>ChandraCXC/iris</projectId>
+                <ribbonOrientation>left</ribbonOrientation>
+                <ribbonColor>orange</ribbonColor>
+            </gitHub>
+            <sideBarEnabled>true</sideBarEnabled>
+        </fluidoSkin>
+    </custom>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
                 <version>3.4</version>
+                <inherited>false</inherited>
                 <configuration>
                     <siteDirectory>${project.basedir}/iris-docs</siteDirectory>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -378,6 +378,24 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>stage-local</id>
+            <distributionManagement>
+                <site>
+                    <id>cxc.cfa.harvard.edu</id>
+                    <url>file:///proj/web-cxc-dmz-prev/htdocs/iris/v${project.version}/</url>
+                </site>
+            </distributionManagement>
+        </profile>
+        <profile>
+            <id>deploy-local</id>
+            <distributionManagement>
+                <site>
+                    <id>cxc.cfa.harvard.edu</id>
+                    <url>file:///data/da/Docs/irisweb/iris/v${project.version}/</url>
+                </site>
+            </distributionManagement>
+        </profile>
     </profiles>
 
     <reporting>
@@ -417,13 +435,6 @@
     <scm>
         <url>https://github.com/ChandraCXC/iris</url>
     </scm>
-
-    <distributionManagement>
-        <site>
-            <id>cxc.cfa.harvard.edu</id>
-            <url>scp://newdevel10.cfa.harvard.edu/proj/web-cxc-dmz-prev/htdocs/iris/v${project.version}/</url>
-        </site>
-    </distributionManagement>
     
 </project>
 

--- a/pom.xml
+++ b/pom.xml
@@ -187,16 +187,6 @@
             </plugins>
         </pluginManagement>
         
-        <extensions>
-            <!-- Enabling the use of SSH -->
-            <extension>
-                <groupId>org.apache.maven.wagon</groupId>
-                <artifactId>wagon-ssh</artifactId>
-                <version>2.10</version>
-            </extension>
-        </extensions>
-
-        
     </build>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -163,16 +163,7 @@
                 <version>3.4</version>
                 <configuration>
                     <siteDirectory>${project.basedir}/iris-docs</siteDirectory>
-<!--                     <outputDirectory>${basedir}/target/site</outputDirectory> -->
                 </configuration>
-                <dependencies>
-                    <dependency>
-                        <!-- add support for ssh/scp -->
-                        <groupId>org.apache.maven.wagon</groupId>
-                        <artifactId>wagon-ssh</artifactId>
-                        <version>1.0</version>
-                    </dependency>
-              </dependencies>
             </plugin>
 
         </plugins>
@@ -199,10 +190,11 @@
             <!-- Enabling the use of SSH -->
             <extension>
                 <groupId>org.apache.maven.wagon</groupId>
-                <artifactId>wagon-ssh-external</artifactId>
-                <version>1.0-beta-6</version>
+                <artifactId>wagon-ssh</artifactId>
+                <version>2.10</version>
             </extension>
         </extensions>
+
         
     </build>
 
@@ -428,7 +420,7 @@
     <distributionManagement>
         <site>
             <id>cxc.cfa.harvard.edu</id>
-            <url>scp://newdevel10.cfa.harvard.edu/data/da/Docs/irisweb/iris/v${project.version}/</url>
+            <url>scp://newdevel10.cfa.harvard.edu/proj/web-cxc-dmz-prev/htdocs/iris/v${project.version}/</url>
         </site>
     </distributionManagement>
     

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,19 @@
     <packaging>pom</packaging>
     <version>3.0-SNAPSHOT</version>
     <name>Iris</name>
+    <description>
+        Iris is a desktop application for building and analyzing 
+        spectral energy distributions within a Virtual Observatory environment.
+    </description>
+    <url>http://cxc.cfa.harvard.edu/iris</url>
+    
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
 
     <modules>
         <module>iris</module>
@@ -37,6 +50,10 @@
         <module>iris-visualizer</module>
     </modules>
 
+    <!-- 
+    To help with site creation directory, define the parent directory
+    Childern modules use this to define the parent module.
+    -->
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Sonar -->
@@ -45,7 +62,53 @@
         <sonar.jacoco.reportPath>${project.basedir}/../target/jacoco.exec</sonar.jacoco.reportPath>
         <sonar.language>java</sonar.language>
         <sonar.exclusions>**cfa/vo/iris/test/**</sonar.exclusions>
+        <main.basedir>${project.basedir}</main.basedir>
     </properties>
+
+    <organization>
+        <name>Chandra X-Ray Observatory</name>
+        <url>http://cxc.cfa.harvard.edu</url>
+    </organization>
+
+    <developers>
+
+        <developer>
+            <name>Janet DePonte Evans</name>
+            <email>janet@cfa.harvard.edu</email>
+            <organization>Harvard-Smithsonian Center For Astrophysics</organization>
+            <organizationUrl>http://www.cfa.harvard.edu</organizationUrl>
+            <roles>
+                <role>project manager</role>
+            </roles>
+        </developer>
+        <developer>
+            <name>Omar Laurino</name>
+            <email>olaurino@cfa.harvard.edu</email>
+            <organization>Harvard-Smithsonian Center For Astrophysics</organization>
+            <organizationUrl>http://www.cfa.harvard.edu</organizationUrl>
+            <roles>
+                <role>group lead</role>
+            </roles>
+        </developer>
+        <developer>
+            <name>Jamie Budynkiewicz</name>
+            <email>jbudynkiewicz@cfa.harvard.edu</email>
+            <organization>Harvard-Smithsonian Center For Astrophysics</organization>
+            <organizationUrl>http://www.cfa.harvard.edu</organizationUrl>
+            <roles>
+                <role>developer</role>
+            </roles>
+        </developer>
+        <developer>
+            <name>Erik Holum</name>
+            <email>eholum@cfa.harvard.edu</email>
+            <organization>Harvard-Smithsonian Center For Astrophysics</organization>
+            <organizationUrl>http://www.cfa.harvard.edu</organizationUrl>
+            <roles>
+                <role>developer</role>
+            </roles>
+        </developer>
+    </developers>
 
     <build>
         <plugins>
@@ -94,6 +157,24 @@
                 </configuration>
             </plugin>
 
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>3.4</version>
+                <configuration>
+                    <siteDirectory>${project.basedir}/iris-docs</siteDirectory>
+<!--                     <outputDirectory>${basedir}/target/site</outputDirectory> -->
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <!-- add support for ssh/scp -->
+                        <groupId>org.apache.maven.wagon</groupId>
+                        <artifactId>wagon-ssh</artifactId>
+                        <version>1.0</version>
+                    </dependency>
+              </dependencies>
+            </plugin>
+
         </plugins>
         
         <pluginManagement>
@@ -113,6 +194,16 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        
+        <extensions>
+            <!-- Enabling the use of SSH -->
+            <extension>
+                <groupId>org.apache.maven.wagon</groupId>
+                <artifactId>wagon-ssh-external</artifactId>
+                <version>1.0-beta-6</version>
+            </extension>
+        </extensions>
+        
     </build>
 
     <dependencies>
@@ -295,5 +386,51 @@
             </build>
         </profile>
     </profiles>
+
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-project-info-reports-plugin</artifactId>
+                <version>2.8</version>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <report>license</report>
+                            <report>modules</report>
+                            <report>scm</report>
+                            <report>project-team</report>
+                            <report>issue-tracking</report>
+                            <report>cim</report>
+                            <report>dependencies</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+
+            </plugin>
+        </plugins>
+    </reporting>
+
+    <issueManagement>
+        <system>GitHub</system>
+        <url>http://github.com/ChandraCXC/iris/issues</url>
+    </issueManagement>
+
+    <ciManagement>
+        <system>Travis-CI</system>
+        <url>http://travis-ci.org/ChandraCXC/iris</url>
+    </ciManagement>
+    
+    <scm>
+        <url>https://github.com/ChandraCXC/iris</url>
+    </scm>
+
+    <distributionManagement>
+        <site>
+            <id>cxc.cfa.harvard.edu</id>
+            <url>scp://newdevel10.cfa.harvard.edu/data/da/Docs/irisweb/iris/v${project.version}/</url>
+        </site>
+    </distributionManagement>
+    
 </project>
 

--- a/samp-factory/pom.xml
+++ b/samp-factory/pom.xml
@@ -30,7 +30,35 @@
        <version>3.0-SNAPSHOT</version>
     </parent>
 
+    <!-- To help with site creation directory, specify the parent directory -->
+    <properties>
+        <main.basedir>${project.parent.basedir}</main.basedir>
+    </properties>
 
+    <build>
+        <plugins>
+            <!--  For the site creation -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>3.4</version>
+                <configuration>
+                    <siteDirectory>./src/site/</siteDirectory>
+                    <outputDirectory>${project.parent.basedir}/target/site/samp-factory/</outputDirectory>
+                </configuration>
+<!-- 
+                <dependencies>
+                    <dependency>
+                        <!~~ add support for ssh/scp ~~>
+                        <groupId>org.apache.maven.wagon</groupId>
+                        <artifactId>wagon-ssh</artifactId>
+                        <version>1.0</version>
+                    </dependency>
+                </dependencies>
+-->
+            </plugin>
+        </plugins>
+    </build>
 
     <dependencies>
         
@@ -50,5 +78,5 @@
             <version>1.3</version>
             <classifier>2</classifier>
         </dependency>
-    </dependencies>
+    </dependencies> 
 </project>

--- a/samp-factory/pom.xml
+++ b/samp-factory/pom.xml
@@ -30,26 +30,6 @@
        <version>3.0-SNAPSHOT</version>
     </parent>
 
-    <!-- To help with site creation directory, specify the parent directory -->
-    <properties>
-        <main.basedir>${project.parent.basedir}</main.basedir>
-    </properties>
-
-    <build>
-        <plugins>
-            <!--  For the site creation -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-site-plugin</artifactId>
-                <version>3.4</version>
-                <configuration>
-                    <siteDirectory>./src/site/</siteDirectory>
-                    <outputDirectory>${project.parent.basedir}/target/site/samp-factory/</outputDirectory>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencies>
         
         <dependency>

--- a/samp-factory/pom.xml
+++ b/samp-factory/pom.xml
@@ -46,16 +46,6 @@
                     <siteDirectory>./src/site/</siteDirectory>
                     <outputDirectory>${project.parent.basedir}/target/site/samp-factory/</outputDirectory>
                 </configuration>
-<!-- 
-                <dependencies>
-                    <dependency>
-                        <!~~ add support for ssh/scp ~~>
-                        <groupId>org.apache.maven.wagon</groupId>
-                        <artifactId>wagon-ssh</artifactId>
-                        <version>1.0</version>
-                    </dependency>
-                </dependencies>
--->
             </plugin>
         </plugins>
     </build>

--- a/samp-factory/src/site/markdown/index.md
+++ b/samp-factory/src/site/markdown/index.md
@@ -1,0 +1,10 @@
+# samp-factory
+
+This page contains developer information for the `samp-factory` module.
+
+Please see the [Project Documentation][proj-info] for more details.
+
+Otherwise, return to the main [Iris user documentation][user-docs].
+
+[proj-info]: ./project-info.html
+[user-docs]: ../index.html

--- a/samp-factory/src/site/site.xml
+++ b/samp-factory/src/site/site.xml
@@ -1,0 +1,48 @@
+<project xmlns="http://maven.apache.org/DECORATION/1.6.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/DECORATION/1.6.0 http://maven.apache.org/xsd/decoration-1.6.0.xsd"
+         name="Iris">
+
+	<bannerLeft>
+		<name>Chandra CXC</name>
+		<src>../imgs/Iris_logo_padding.png</src>
+		<href>../index.html</href>
+	</bannerLeft>
+
+    <body>
+    
+        <links>
+            <item name="Chandra CXC" href="http://cxc.cfa.harvard.edu"/>
+        </links>
+
+        <menu ref="parent"/>
+        <menu name="Information">
+			<item name="Introduction" href="./index.html"/>
+			<item name="Sybling Modules" href="../modules.html"/>
+		</menu>
+        <menu ref="reports"/>
+        	
+    </body>
+    
+    <skin>
+        <groupId>org.apache.maven.skins</groupId>
+        <artifactId>maven-fluido-skin</artifactId>
+        <version>1.4</version>
+
+    </skin>
+
+    
+    <custom>
+        <fluidoSkin>
+            <googleSearch>
+                <sitesearch>http://cxc.cfa.harvard.edu/iris/v${project.version}</sitesearch>
+            </googleSearch>
+            <gitHub>
+                <projectId>ChandraCXC/iris</projectId>
+                <ribbonOrientation>left</ribbonOrientation>
+                <ribbonColor>orange</ribbonColor>
+            </gitHub>
+            <sideBarEnabled>true</sideBarEnabled>
+        </fluidoSkin>
+    </custom>
+
+</project>

--- a/sed-builder/pom.xml
+++ b/sed-builder/pom.xml
@@ -29,6 +29,36 @@
         <version>3.0-SNAPSHOT</version>
     </parent>
 
+    <!-- To help with site creation directory, specify the parent directory -->
+    <properties>
+        <main.basedir>${project.parent.basedir}</main.basedir>
+    </properties>
+
+    <build>
+        <plugins>
+            <!--  For the site creation -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>3.4</version>
+                <configuration>
+                    <siteDirectory>./src/site/</siteDirectory>
+                    <outputDirectory>${project.parent.basedir}/target/site/sed-builder/</outputDirectory>
+                </configuration>
+<!-- 
+                <dependencies>
+                    <dependency>
+                        <!~~ add support for ssh/scp ~~>
+                        <groupId>org.apache.maven.wagon</groupId>
+                        <artifactId>wagon-ssh</artifactId>
+                        <version>1.0</version>
+                    </dependency>
+                </dependencies>
+-->
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/sed-builder/pom.xml
+++ b/sed-builder/pom.xml
@@ -45,16 +45,6 @@
                     <siteDirectory>./src/site/</siteDirectory>
                     <outputDirectory>${project.parent.basedir}/target/site/sed-builder/</outputDirectory>
                 </configuration>
-<!-- 
-                <dependencies>
-                    <dependency>
-                        <!~~ add support for ssh/scp ~~>
-                        <groupId>org.apache.maven.wagon</groupId>
-                        <artifactId>wagon-ssh</artifactId>
-                        <version>1.0</version>
-                    </dependency>
-                </dependencies>
--->
             </plugin>
         </plugins>
     </build>

--- a/sed-builder/pom.xml
+++ b/sed-builder/pom.xml
@@ -29,26 +29,6 @@
         <version>3.0-SNAPSHOT</version>
     </parent>
 
-    <!-- To help with site creation directory, specify the parent directory -->
-    <properties>
-        <main.basedir>${project.parent.basedir}</main.basedir>
-    </properties>
-
-    <build>
-        <plugins>
-            <!--  For the site creation -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-site-plugin</artifactId>
-                <version>3.4</version>
-                <configuration>
-                    <siteDirectory>./src/site/</siteDirectory>
-                    <outputDirectory>${project.parent.basedir}/target/site/sed-builder/</outputDirectory>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/sed-builder/src/site/markdown/index.md
+++ b/sed-builder/src/site/markdown/index.md
@@ -1,0 +1,10 @@
+# sed-builder
+
+This page contains developer information for the `sed-builder` module.
+
+Please see the [Project Documentation][proj-info] for more details.
+
+Otherwise, return to the main [Iris user documentation][user-docs].
+
+[proj-info]: ./project-info.html
+[user-docs]: ../index.html

--- a/sed-builder/src/site/site.xml
+++ b/sed-builder/src/site/site.xml
@@ -1,0 +1,48 @@
+<project xmlns="http://maven.apache.org/DECORATION/1.6.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/DECORATION/1.6.0 http://maven.apache.org/xsd/decoration-1.6.0.xsd"
+         name="Iris">
+
+	<bannerLeft>
+		<name>Chandra CXC</name>
+		<src>../imgs/Iris_logo_padding.png</src>
+		<href>../index.html</href>
+	</bannerLeft>
+
+    <body>
+    
+        <links>
+            <item name="Chandra CXC" href="http://cxc.cfa.harvard.edu"/>
+        </links>
+
+        <menu ref="parent"/>
+        <menu name="Information">
+			<item name="Introduction" href="./index.html"/>
+			<item name="Sybling Modules" href="../modules.html"/>
+		</menu>
+        <menu ref="reports"/>
+        	
+    </body>
+    
+    <skin>
+        <groupId>org.apache.maven.skins</groupId>
+        <artifactId>maven-fluido-skin</artifactId>
+        <version>1.4</version>
+
+    </skin>
+
+    
+    <custom>
+        <fluidoSkin>
+            <googleSearch>
+                <sitesearch>http://cxc.cfa.harvard.edu/iris/v${project.version}</sitesearch>
+            </googleSearch>
+            <gitHub>
+                <projectId>ChandraCXC/iris</projectId>
+                <ribbonOrientation>left</ribbonOrientation>
+                <ribbonColor>orange</ribbonColor>
+            </gitHub>
+            <sideBarEnabled>true</sideBarEnabled>
+        </fluidoSkin>
+    </custom>
+
+</project>

--- a/test-components/pom.xml
+++ b/test-components/pom.xml
@@ -45,16 +45,6 @@
                     <siteDirectory>./src/site/</siteDirectory>
                     <outputDirectory>${project.parent.basedir}/target/site/test-components/</outputDirectory>
                 </configuration>
-<!-- 
-                <dependencies>
-                    <dependency>
-                        <!~~ add support for ssh/scp ~~>
-                        <groupId>org.apache.maven.wagon</groupId>
-                        <artifactId>wagon-ssh</artifactId>
-                        <version>1.0</version>
-                    </dependency>
-                </dependencies>
--->
             </plugin>
         </plugins>
     </build>

--- a/test-components/pom.xml
+++ b/test-components/pom.xml
@@ -29,26 +29,6 @@
         <version>3.0-SNAPSHOT</version>
     </parent>
 
-    <!-- To help with site creation directory, specify the parent directory -->
-    <properties>
-        <main.basedir>${project.parent.basedir}</main.basedir>
-    </properties>
-    
-    <build>
-        <plugins>
-            <!--  For the site creation -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-site-plugin</artifactId>
-                <version>3.4</version>
-                <configuration>
-                    <siteDirectory>./src/site/</siteDirectory>
-                    <outputDirectory>${project.parent.basedir}/target/site/test-components/</outputDirectory>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/test-components/pom.xml
+++ b/test-components/pom.xml
@@ -24,10 +24,40 @@
     <name>test-components</name>
 
     <parent>
-       <groupId>cfa.vo</groupId>
-       <artifactId>iris2</artifactId>
-       <version>3.0-SNAPSHOT</version>
+        <groupId>cfa.vo</groupId>
+        <artifactId>iris2</artifactId>
+        <version>3.0-SNAPSHOT</version>
     </parent>
+
+    <!-- To help with site creation directory, specify the parent directory -->
+    <properties>
+        <main.basedir>${project.parent.basedir}</main.basedir>
+    </properties>
+    
+    <build>
+        <plugins>
+            <!--  For the site creation -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>3.4</version>
+                <configuration>
+                    <siteDirectory>./src/site/</siteDirectory>
+                    <outputDirectory>${project.parent.basedir}/target/site/test-components/</outputDirectory>
+                </configuration>
+<!-- 
+                <dependencies>
+                    <dependency>
+                        <!~~ add support for ssh/scp ~~>
+                        <groupId>org.apache.maven.wagon</groupId>
+                        <artifactId>wagon-ssh</artifactId>
+                        <version>1.0</version>
+                    </dependency>
+                </dependencies>
+-->
+            </plugin>
+        </plugins>
+    </build>
 
     <dependencies>
         <dependency>

--- a/test-components/src/site/markdown/index.md
+++ b/test-components/src/site/markdown/index.md
@@ -1,0 +1,10 @@
+# test-components
+
+This page contains developer information for the `test-components` module.
+
+Please see the [Project Documentation][proj-info] for more details.
+
+Otherwise, return to the main [Iris user documentation][user-docs].
+
+[proj-info]: ./project-info.html
+[user-docs]: ../index.html

--- a/test-components/src/site/site.xml
+++ b/test-components/src/site/site.xml
@@ -1,0 +1,48 @@
+<project xmlns="http://maven.apache.org/DECORATION/1.6.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/DECORATION/1.6.0 http://maven.apache.org/xsd/decoration-1.6.0.xsd"
+         name="Iris">
+
+	<bannerLeft>
+		<name>Chandra CXC</name>
+		<src>../imgs/Iris_logo_padding.png</src>
+		<href>../index.html</href>
+	</bannerLeft>
+
+    <body>
+    
+        <links>
+            <item name="Chandra CXC" href="http://cxc.cfa.harvard.edu"/>
+        </links>
+
+        <menu ref="parent"/>
+        <menu name="Information">
+			<item name="Introduction" href="./index.html"/>
+			<item name="Sybling Modules" href="../modules.html"/>
+		</menu>
+        <menu ref="reports"/>
+        	
+    </body>
+    
+    <skin>
+        <groupId>org.apache.maven.skins</groupId>
+        <artifactId>maven-fluido-skin</artifactId>
+        <version>1.4</version>
+
+    </skin>
+
+    
+    <custom>
+        <fluidoSkin>
+            <googleSearch>
+                <sitesearch>http://cxc.cfa.harvard.edu/iris/v${project.version}</sitesearch>
+            </googleSearch>
+            <gitHub>
+                <projectId>ChandraCXC/iris</projectId>
+                <ribbonOrientation>left</ribbonOrientation>
+                <ribbonColor>orange</ribbonColor>
+            </gitHub>
+            <sideBarEnabled>true</sideBarEnabled>
+        </fluidoSkin>
+    </custom>
+
+</project>


### PR DESCRIPTION
Address #144, #150

# Description

This PR:

   - migrates the current Iris v2.1 user documentation from the home-grown CXC site building system to Maven site.
   - adds very simple sites for each project module so that developers can view the dependencies and other build information. E.g., `sed-builder/src/site/`.
   - adds a new repository, [iris-docs](https://github.com/jbudynk/iris-docs), as a submodule to the Iris project. This contains all the Iris user documentation and images (#144).
   - the site can now be pushed to versioned sites on the CXC server using `mvn site:deploy` (#150). This requires the CXC server to be added to the developer's `settings.xml` file. The site directory name is ${project.version}.

The site build still needs the following additions before completion:

   - create profiles to push the site to the CXC test and live sites.
      - write instructions to pushing the site to the preview and live servers.
   - fix repository blacklist warnings. When running `mvn site:site`, a number of repositories that don't exist are shown to be blacklisted. I don't know what's causing these warnings, but these should be understood before we release the site to the live server.
   - remove redundant dependencies. The project module reports show a few redundant dependencies. 
   - fix typo in project modules' `site.xml`. "Sybling Modules" should be "Sibling Modules."

Another issue to tackle is that the `iris-docs` repo is under my account, not ChandraCXC. We should address this before merging the PR.