### PR TITLE
Fix docs migration

### DIFF
--- a/iris-common/src/site/site.xml
+++ b/iris-common/src/site/site.xml
@@ -13,7 +13,9 @@
     
         <head>
 	    <!-- meta keywords for SI / HEA -->
-            <meta http-equiv="keywords" content="chandra, axaf, x-ray, astronomy, astrophysics, catalog, multi-wavelength, multiwavelength, vao, VAO, sed, SED, SEDs"/>
+            <meta http-equiv="keywords" content="chandra, axaf, x-ray,
+            astronomy, astrophysics, catalog, multi-wavelength,
+            multiwavelength, vao, VAO, sed, SED, SEDs, spectral energy distribution"/>
             <meta http-equiv="description" content="Iris: VO SED Analysis Tool"/>
             <meta name="creator" content="SAO-HEA"/>
             <meta name="keywords" content="SI,Smithsonian,Smithsonian Institute"/>

--- a/iris-common/src/site/site.xml
+++ b/iris-common/src/site/site.xml
@@ -11,6 +11,16 @@
 
     <body>
     
+        <head>
+	    <!-- meta keywords for SI / HEA -->
+            <meta http-equiv="keywords" content="chandra, axaf, x-ray, astronomy, astrophysics, catalog, multi-wavelength, multiwavelength, vao, VAO, sed, SED, SEDs"/>
+            <meta http-equiv="description" content="Iris: VO SED Analysis Tool"/>
+            <meta name="creator" content="SAO-HEA"/>
+            <meta name="keywords" content="SI,Smithsonian,Smithsonian Institute"/>
+            <meta name="keywords" content="CfA,SAO,Harvard-Smithsonian,Center for Astrophysics"/>
+            <meta name="keywords" content="HEA,HEAD,High Energy Astrophysics Division"/>	    
+        </head>
+
         <links>
             <item name="Chandra CXC" href="http://cxc.cfa.harvard.edu"/>
         </links>
@@ -18,7 +28,7 @@
         <menu ref="parent"/>
         <menu name="Information">
 			<item name="Introduction" href="./index.html"/>
-			<item name="Sybling Modules" href="../modules.html"/>
+			<item name="Sibling Modules" href="../modules.html"/>
 		</menu>
         <menu ref="reports"/>
 		  

--- a/iris-specview/src/site/site.xml
+++ b/iris-specview/src/site/site.xml
@@ -10,6 +10,16 @@
 
     <body>
     
+        <head>
+	    <!-- meta keywords for SI / HEA -->
+            <meta http-equiv="keywords" content="chandra, axaf, x-ray, astronomy, astrophysics, catalog, multi-wavelength, multiwavelength, vao, VAO, sed, SED, SEDs"/>
+            <meta http-equiv="description" content="Iris: VO SED Analysis Tool"/>
+            <meta name="creator" content="SAO-HEA"/>
+            <meta name="keywords" content="SI,Smithsonian,Smithsonian Institute"/>
+            <meta name="keywords" content="CfA,SAO,Harvard-Smithsonian,Center for Astrophysics"/>
+            <meta name="keywords" content="HEA,HEAD,High Energy Astrophysics Division"/>
+	</head>
+
         <links>
             <item name="Chandra CXC" href="http://cxc.cfa.harvard.edu"/>
         </links>
@@ -17,7 +27,7 @@
         <menu ref="parent"/>
         <menu name="Information">
 			<item name="Introduction" href="./index.html"/>
-			<item name="Sybling Modules" href="../modules.html"/>
+			<item name="Sibling Modules" href="../modules.html"/>
 		</menu>
         <menu ref="reports"/>
         	

--- a/iris-visualizer/pom.xml
+++ b/iris-visualizer/pom.xml
@@ -29,23 +29,6 @@
         <version>3.0-SNAPSHOT</version>
     </parent>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-            </plugin>
-
-            <plugin>
-                <groupId>com.mycila.maven-license-plugin</groupId>
-                <artifactId>maven-license-plugin</artifactId>
-                <configuration>
-                    <header>etc/header.txt</header>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/iris-visualizer/src/site/markdown/index.md
+++ b/iris-visualizer/src/site/markdown/index.md
@@ -1,6 +1,6 @@
-# iris-specview
+# iris-visualizer
 
-This page contains developer information for the `iris-specview` package.
+This page contains developer information for the `iris-visualizer` package.
 
 Please see the [Project Documentation][proj-info] for more details.
 

--- a/iris-visualizer/src/site/site.xml
+++ b/iris-visualizer/src/site/site.xml
@@ -24,7 +24,6 @@
             <item name="Chandra CXC" href="http://cxc.cfa.harvard.edu"/>
         </links>
 
-        <menu ref="parent"/>
         <menu name="Information">
 			<item name="Introduction" href="./index.html"/>
 			<item name="Sibling Modules" href="../modules.html"/>

--- a/iris-visualizer/src/site/site.xml
+++ b/iris-visualizer/src/site/site.xml
@@ -12,7 +12,9 @@
     
         <head>
 	    <!-- meta keywords for SI / HEA -->
-            <meta http-equiv="keywords" content="chandra, axaf, x-ray, astronomy, astrophysics, catalog, multi-wavelength, multiwavelength, vao, VAO, sed, SED, SEDs"/>
+            <meta http-equiv="keywords" content="chandra, axaf, x-ray,
+            astronomy, astrophysics, catalog, multi-wavelength,
+            multiwavelength, vao, VAO, sed, SED, SEDs, spectral energy distribution"/>
             <meta http-equiv="description" content="Iris: VO SED Analysis Tool"/>
             <meta name="creator" content="SAO-HEA"/>
             <meta name="keywords" content="SI,Smithsonian,Smithsonian Institute"/>
@@ -24,6 +26,7 @@
             <item name="Chandra CXC" href="http://cxc.cfa.harvard.edu"/>
         </links>
 
+        <menu ref="parent"/>
         <menu name="Information">
 			<item name="Introduction" href="./index.html"/>
 			<item name="Sibling Modules" href="../modules.html"/>

--- a/iris/src/site/site.xml
+++ b/iris/src/site/site.xml
@@ -12,7 +12,9 @@
     
         <head>
 	    <!-- meta keywords for SI / HEA -->
-            <meta http-equiv="keywords" content="chandra, axaf, x-ray, astronomy, astrophysics, catalog, multi-wavelength, multiwavelength, vao, VAO, sed, SED, SEDs"/>
+            <meta http-equiv="keywords" content="chandra, axaf, x-ray,
+            astronomy, astrophysics, catalog, multi-wavelength,
+            multiwavelength, vao, VAO, sed, SED, SEDs, spectral energy distribution"/>
             <meta http-equiv="description" content="Iris: VO SED Analysis Tool"/>
             <meta name="creator" content="SAO-HEA"/>
             <meta name="keywords" content="SI,Smithsonian,Smithsonian Institute"/>

--- a/iris/src/site/site.xml
+++ b/iris/src/site/site.xml
@@ -10,6 +10,16 @@
 
     <body>
     
+        <head>
+	    <!-- meta keywords for SI / HEA -->
+            <meta http-equiv="keywords" content="chandra, axaf, x-ray, astronomy, astrophysics, catalog, multi-wavelength, multiwavelength, vao, VAO, sed, SED, SEDs"/>
+            <meta http-equiv="description" content="Iris: VO SED Analysis Tool"/>
+            <meta name="creator" content="SAO-HEA"/>
+            <meta name="keywords" content="SI,Smithsonian,Smithsonian Institute"/>
+            <meta name="keywords" content="CfA,SAO,Harvard-Smithsonian,Center for Astrophysics"/>
+            <meta name="keywords" content="HEA,HEAD,High Energy Astrophysics Division"/>
+	</head>
+
         <links>
             <item name="Chandra CXC" href="http://cxc.cfa.harvard.edu"/>
         </links>
@@ -17,7 +27,7 @@
         <menu ref="parent"/>
         <menu name="Information">
 			<item name="Introduction" href="./index.html"/>
-			<item name="Sybling Modules" href="../modules.html"/>
+			<item name="Sibling Modules" href="../modules.html"/>
 		</menu>
         <menu ref="reports"/>
         	

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,6 @@
 
         <developer>
             <name>Janet DePonte Evans</name>
-            <email>janet@cfa.harvard.edu</email>
             <organization>Harvard-Smithsonian Center For Astrophysics</organization>
             <organizationUrl>http://www.cfa.harvard.edu</organizationUrl>
             <roles>
@@ -83,7 +82,7 @@
         </developer>
         <developer>
             <name>Omar Laurino</name>
-            <email>olaurino@cfa.harvard.edu</email>
+            <email>olaurino @ cfa.harvard.edu</email>
             <organization>Harvard-Smithsonian Center For Astrophysics</organization>
             <organizationUrl>http://www.cfa.harvard.edu</organizationUrl>
             <roles>
@@ -92,7 +91,7 @@
         </developer>
         <developer>
             <name>Jamie Budynkiewicz</name>
-            <email>jbudynkiewicz@cfa.harvard.edu</email>
+            <email>jbudynkiewicz @ cfa.harvard.edu</email>
             <organization>Harvard-Smithsonian Center For Astrophysics</organization>
             <organizationUrl>http://www.cfa.harvard.edu</organizationUrl>
             <roles>
@@ -101,7 +100,7 @@
         </developer>
         <developer>
             <name>Erik Holum</name>
-            <email>eholum@cfa.harvard.edu</email>
+            <email>eholum @ cfa.harvard.edu</email>
             <organization>Harvard-Smithsonian Center For Astrophysics</organization>
             <organizationUrl>http://www.cfa.harvard.edu</organizationUrl>
             <roles>
@@ -382,7 +381,7 @@
             <distributionManagement>
                 <site>
                     <id>cxc.cfa.harvard.edu</id>
-                    <url>file:///data/da/Docs/irisweb/iris/v${project.version}/</url>
+                    <url>file:///proj/web-cxc-dmz/htdocs/iris/v${project.version}/</url>
                 </site>
             </distributionManagement>
         </profile>
@@ -425,6 +424,14 @@
     <scm>
         <url>https://github.com/ChandraCXC/iris</url>
     </scm>
+    
+    <distributionManagement>
+        <site>
+            <id>cxc.cfa.harvard.edu</id>
+            <!-- by default, save to the test site -->
+            <url>file:///proj/web-cxc-dmz-prev/htdocs/iris/v${project.version}/</url>
+        </site>
+    </distributionManagement>
     
 </project>
 

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         </developer>
         <developer>
             <name>Omar Laurino</name>
-            <email>olaurino @ cfa.harvard.edu</email>
+            <email>olaurino_at_cfa.harvard.edu</email>
             <organization>Harvard-Smithsonian Center For Astrophysics</organization>
             <organizationUrl>http://www.cfa.harvard.edu</organizationUrl>
             <roles>
@@ -91,7 +91,7 @@
         </developer>
         <developer>
             <name>Jamie Budynkiewicz</name>
-            <email>jbudynkiewicz @ cfa.harvard.edu</email>
+            <email>jbudynkiewicz_at_cfa.harvard.edu</email>
             <organization>Harvard-Smithsonian Center For Astrophysics</organization>
             <organizationUrl>http://www.cfa.harvard.edu</organizationUrl>
             <roles>
@@ -100,7 +100,7 @@
         </developer>
         <developer>
             <name>Erik Holum</name>
-            <email>eholum @ cfa.harvard.edu</email>
+            <email>eholum_at_cfa.harvard.edu</email>
             <organization>Harvard-Smithsonian Center For Astrophysics</organization>
             <organizationUrl>http://www.cfa.harvard.edu</organizationUrl>
             <roles>

--- a/samp-factory/src/site/site.xml
+++ b/samp-factory/src/site/site.xml
@@ -12,7 +12,9 @@
     
         <head>
 	    <!-- meta keywords for SI / HEA -->
-            <meta http-equiv="keywords" content="chandra, axaf, x-ray, astronomy, astrophysics, catalog, multi-wavelength, multiwavelength, vao, VAO, sed, SED, SEDs"/>
+            <meta http-equiv="keywords" content="chandra, axaf, x-ray,
+            astronomy, astrophysics, catalog, multi-wavelength,
+            multiwavelength, vao, VAO, sed, SED, SEDs, spectral energy distribution"/>
             <meta http-equiv="description" content="Iris: VO SED Analysis Tool"/>
             <meta name="creator" content="SAO-HEA"/>
             <meta name="keywords" content="SI,Smithsonian,Smithsonian Institute"/>

--- a/samp-factory/src/site/site.xml
+++ b/samp-factory/src/site/site.xml
@@ -10,6 +10,16 @@
 
     <body>
     
+        <head>
+	    <!-- meta keywords for SI / HEA -->
+            <meta http-equiv="keywords" content="chandra, axaf, x-ray, astronomy, astrophysics, catalog, multi-wavelength, multiwavelength, vao, VAO, sed, SED, SEDs"/>
+            <meta http-equiv="description" content="Iris: VO SED Analysis Tool"/>
+            <meta name="creator" content="SAO-HEA"/>
+            <meta name="keywords" content="SI,Smithsonian,Smithsonian Institute"/>
+            <meta name="keywords" content="CfA,SAO,Harvard-Smithsonian,Center for Astrophysics"/>
+            <meta name="keywords" content="HEA,HEAD,High Energy Astrophysics Division"/>
+	</head>
+
         <links>
             <item name="Chandra CXC" href="http://cxc.cfa.harvard.edu"/>
         </links>
@@ -17,7 +27,7 @@
         <menu ref="parent"/>
         <menu name="Information">
 			<item name="Introduction" href="./index.html"/>
-			<item name="Sybling Modules" href="../modules.html"/>
+			<item name="Sibling Modules" href="../modules.html"/>
 		</menu>
         <menu ref="reports"/>
         	

--- a/sed-builder/src/site/site.xml
+++ b/sed-builder/src/site/site.xml
@@ -12,7 +12,9 @@
     
         <head>
 	    <!-- meta keywords for SI / HEA -->
-            <meta http-equiv="keywords" content="chandra, axaf, x-ray, astronomy, astrophysics, catalog, multi-wavelength, multiwavelength, vao, VAO, sed, SED, SEDs"/>
+            <meta http-equiv="keywords" content="chandra, axaf, x-ray,
+            astronomy, astrophysics, catalog, multi-wavelength,
+            multiwavelength, vao, VAO, sed, SED, SEDs, spectral energy distribution"/>
             <meta http-equiv="description" content="Iris: VO SED Analysis Tool"/>
             <meta name="creator" content="SAO-HEA"/>
             <meta name="keywords" content="SI,Smithsonian,Smithsonian Institute"/>

--- a/sed-builder/src/site/site.xml
+++ b/sed-builder/src/site/site.xml
@@ -10,6 +10,16 @@
 
     <body>
     
+        <head>
+	    <!-- meta keywords for SI / HEA -->
+            <meta http-equiv="keywords" content="chandra, axaf, x-ray, astronomy, astrophysics, catalog, multi-wavelength, multiwavelength, vao, VAO, sed, SED, SEDs"/>
+            <meta http-equiv="description" content="Iris: VO SED Analysis Tool"/>
+            <meta name="creator" content="SAO-HEA"/>
+            <meta name="keywords" content="SI,Smithsonian,Smithsonian Institute"/>
+            <meta name="keywords" content="CfA,SAO,Harvard-Smithsonian,Center for Astrophysics"/>
+            <meta name="keywords" content="HEA,HEAD,High Energy Astrophysics Division"/>
+	</head>
+
         <links>
             <item name="Chandra CXC" href="http://cxc.cfa.harvard.edu"/>
         </links>
@@ -17,7 +27,7 @@
         <menu ref="parent"/>
         <menu name="Information">
 			<item name="Introduction" href="./index.html"/>
-			<item name="Sybling Modules" href="../modules.html"/>
+			<item name="Sibling Modules" href="../modules.html"/>
 		</menu>
         <menu ref="reports"/>
         	

--- a/test-components/src/site/site.xml
+++ b/test-components/src/site/site.xml
@@ -12,7 +12,9 @@
     
         <head>
 	    <!-- meta keywords for SI / HEA -->
-            <meta http-equiv="keywords" content="chandra, axaf, x-ray, astronomy, astrophysics, catalog, multi-wavelength, multiwavelength, vao, VAO, sed, SED, SEDs"/>
+            <meta http-equiv="keywords" content="chandra, axaf, x-ray,
+            astronomy, astrophysics, catalog, multi-wavelength,
+            multiwavelength, vao, VAO, sed, SED, SEDs, spectral energy distribution"/>
             <meta http-equiv="description" content="Iris: VO SED Analysis Tool"/>
             <meta name="creator" content="SAO-HEA"/>
             <meta name="keywords" content="SI,Smithsonian,Smithsonian Institute"/>

--- a/test-components/src/site/site.xml
+++ b/test-components/src/site/site.xml
@@ -10,6 +10,16 @@
 
     <body>
     
+        <head>
+	    <!-- meta keywords for SI / HEA -->
+            <meta http-equiv="keywords" content="chandra, axaf, x-ray, astronomy, astrophysics, catalog, multi-wavelength, multiwavelength, vao, VAO, sed, SED, SEDs"/>
+            <meta http-equiv="description" content="Iris: VO SED Analysis Tool"/>
+            <meta name="creator" content="SAO-HEA"/>
+            <meta name="keywords" content="SI,Smithsonian,Smithsonian Institute"/>
+            <meta name="keywords" content="CfA,SAO,Harvard-Smithsonian,Center for Astrophysics"/>
+            <meta name="keywords" content="HEA,HEAD,High Energy Astrophysics Division"/>
+	</head>
+
         <links>
             <item name="Chandra CXC" href="http://cxc.cfa.harvard.edu"/>
         </links>
@@ -17,7 +27,7 @@
         <menu ref="parent"/>
         <menu name="Information">
 			<item name="Introduction" href="./index.html"/>
-			<item name="Sybling Modules" href="../modules.html"/>
+			<item name="Sibling Modules" href="../modules.html"/>
 		</menu>
         <menu ref="reports"/>
         	


### PR DESCRIPTION
# Description

This PR is in response to PR #182. Not all the necessary changes were added to the docs migration in PR #182, so I've added the following updates to fix this:

   - I put spaces between the email parts, like "jbudynkiewicz @ cfa.harvard.edu". Please let me know if you'd prefer me to just get rid of them, or if we should just provide irisdev as the email, or anything else. Also, I removed Janet's email because I figure she wouldn't want people emailing her about Iris (and we'd want to get the emails first anyhow) - let me know if I should add it back in.
   - I introduced the <distributionManagement> section back into the main POM so that site:stage works. By default, the website built with site:stage is stored in `target/staging`, despite the fact that the <url> element says to store it at the preview CXC server. One can specify the directory to store the staged site at using `-DstageLocation=/path/to/directory`
   - Updates the iris-docs module to include typo fixes and fixes the "#top" anchors on each page. For background: each page had an anchor for going back to the top of a page. The anchor was written in-line with the page header in Markdown like

        # <a name="top"></a> Thread Title

   Before commit 88baf67, hovering over the site tab in the web browser showed "`Iris - <a name="top"></a> Thread Title`" instead of "`Iris - Thread Title`." I moved the `<a name="top"></a> to the `<head>` block in `iris-docs/site.xml` so that each page has a top anchor.
   - The Iris desktop image in `download/index.md` that was supposedly missing was just extraneous Markdown syntax that tried to center the image, but it didn't work. I removed the extraneous lines.
   - I moved / renamed `iris-specview/src/site` to is replacement, `iris-visualizer/src/site`.

If needed, review PR #182 for the rest of the docs migration details. 

Note that I cherry-picked commits from the deleted branch `docs_migration` (was at commit bb9296c) to `fix_docs_migration`.