### PR TITLE
Iris 191 implement abstract test for it

### DIFF
--- a/iris-common/pom.xml
+++ b/iris-common/pom.xml
@@ -32,6 +32,13 @@
     <build>
         <plugins>
             <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <groupId>org.apache.maven.plugins</groupId>
+	    </plugin>
+	    <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>2.2</version>

--- a/iris-common/src/test/java/cfa/vo/iris/common/SedMessageIT.java
+++ b/iris-common/src/test/java/cfa/vo/iris/common/SedMessageIT.java
@@ -67,13 +67,11 @@ public class SedMessageIT extends AbstractSAMPTest {
     public void sedMessageTest() throws Exception {
         System.setProperty("jsamp.hub.profiles", "std");
 
-        SedSAMPController sampSender = new SedSAMPController("TestSender", "An SED builder from the Virtual Astronomical Observatory", this.getClass().getResource("/iris_button_tiny.png").toString());
         SedSAMPController sampReceiver = new SedSAMPController("TestReceiver", "An SED builder from the Virtual Astronomical Observatory", this.getClass().getResource("/iris_button_tiny.png").toString());
         
-        connectToSAMPHub(sampSender);
         connectToSAMPHub(sampReceiver);
         
-        sampSender.startWithResourceServer("/test", false);
+        controller.startWithResourceServer("/test", false);
 
         sampReceiver.addMessageHandler(new SedHandler());
 
@@ -81,7 +79,7 @@ public class SedMessageIT extends AbstractSAMPTest {
 
         Thread.sleep(5000);
 
-        sampSender.sendSedMessage(sed);
+        controller.sendSedMessage(sed);
 
         int i=0;
 
@@ -97,8 +95,6 @@ public class SedMessageIT extends AbstractSAMPTest {
         sampReceiver.stop();
 
         Thread.sleep(2000);
-
-        sampSender.stop();
 
         Segment segment = sed.getSegment(0);
 

--- a/iris-common/src/test/java/cfa/vo/iris/common/SedMessageIT.java
+++ b/iris-common/src/test/java/cfa/vo/iris/common/SedMessageIT.java
@@ -19,6 +19,7 @@ package cfa.vo.iris.common;
 import cfa.vo.iris.interop.AbstractSedMessageHandler;
 import cfa.vo.iris.interop.SedSAMPController;
 import cfa.vo.iris.sed.ExtSed;
+import cfa.vo.iris.test.unit.it.AbstractSAMPTest;
 import cfa.vo.sedlib.Sed;
 import cfa.vo.sedlib.Segment;
 import cfa.vo.sedlib.io.SedFormat;
@@ -37,13 +38,13 @@ import org.junit.Test;
  *
  * @author olaurino
  */
-public class SedMessageTest {
+public class SedMessageIT extends AbstractSAMPTest {
     
-    private static final Logger logger = Logger.getLogger(SedMessageTest.class.getName());
+    private static final Logger logger = Logger.getLogger(SedMessageIT.class.getName());
     
     private Sed mySed;
 
-    public SedMessageTest() {
+    public SedMessageIT() {
     }
 
     @BeforeClass
@@ -55,35 +56,24 @@ public class SedMessageTest {
     }
 
     @Before
-    public void setUp() {
+    public void setup() {
     }
 
     @After
-    public void tearDown() {
+    public void teardown() {
     }
 
-     @Test
-     public void sedMessageTest() throws Exception {
+    @Test
+    public void sedMessageTest() throws Exception {
         System.setProperty("jsamp.hub.profiles", "std");
 
         SedSAMPController sampSender = new SedSAMPController("TestSender", "An SED builder from the Virtual Astronomical Observatory", this.getClass().getResource("/iris_button_tiny.png").toString());
         SedSAMPController sampReceiver = new SedSAMPController("TestReceiver", "An SED builder from the Virtual Astronomical Observatory", this.getClass().getResource("/iris_button_tiny.png").toString());
-
+        
+        connectToSAMPHub(sampSender);
+        connectToSAMPHub(sampReceiver);
+        
         sampSender.startWithResourceServer("/test", false);
-
-        Thread.sleep(2000);
-
-        sampReceiver.start(false);
-        sampReceiver.setAutoRunHub(false);
-
-        while(!sampSender.isConnected()) {
-            logger.log(Level.INFO, "waiting connection...");
-            Thread.sleep(1000);
-        }
-
-        while(!sampReceiver.isConnected()) {
-            Thread.sleep(1000);
-        }
 
         sampReceiver.addMessageHandler(new SedHandler());
 
@@ -116,15 +106,15 @@ public class SedMessageTest {
 
         Assert.assertEquals("3c273", sed.getId());
 
-     }
+    }
 
-     private class SedHandler extends AbstractSedMessageHandler {
+    private class SedHandler extends AbstractSedMessageHandler {
 
         @Override
         public void processSed(Sed sed, String sedId) {
             mySed = sed;
         }
 
-     }
+    }
 
 }

--- a/iris-common/src/test/java/cfa/vo/iris/common/SedMessageIT.java
+++ b/iris-common/src/test/java/cfa/vo/iris/common/SedMessageIT.java
@@ -24,7 +24,6 @@ import cfa.vo.sedlib.Sed;
 import cfa.vo.sedlib.Segment;
 import cfa.vo.sedlib.io.SedFormat;
 
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.junit.After;

--- a/iris-common/src/test/java/cfa/vo/iris/test/unit/it/AbstractSAMPTest.java
+++ b/iris-common/src/test/java/cfa/vo/iris/test/unit/it/AbstractSAMPTest.java
@@ -20,9 +20,7 @@ import cfa.vo.iris.interop.SedSAMPController;
 import cfa.vo.sherpa.SherpaClient;
 import java.util.logging.Logger;
 import org.astrogrid.samp.client.SampException;
-import org.junit.After;
 import static org.junit.Assert.*;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.ExternalResource;
 
@@ -52,39 +50,29 @@ public class AbstractSAMPTest {
     }
     
     
-//    /**
-//     * This rule allows the component loader to be initialized only once for the whole suite.
-//     * This works around the fact that @BeforeClass and @AfterClass methods need to be static.
-//     */
-//    @Rule
-//    public ExternalResource resource = new ExternalResource() {
-//        @Override
-//        protected void before() throws Exception {
-//            // asserts that the SAMP Hub is up, and that sherpa-samp is connected.
-//	    connectToSAMPHub();
-//	    isSherpaConnected();
-//        }
-//        @Override
-//        protected void after() {
-//            // disconnect controller
-//	    controller.stop();
-//        }
-//    };
-    
-    // forces the concrete classes to make their own before class, and it will 
-    // not override this Before class
-    @Before
-    public final void setUp() throws Exception {
-    
-        // asserts that the SAMP Hub is up, and that sherpa-samp is connected.
-        connectToSAMPHub();
-        isSherpaConnected();
-    }
-    
-    @After
-    public void tearDown() {
-        controller.stop();
-    }
+    /**
+     * Create before/after methods for each test class that extends this class.
+     * Setup/teardown SedSAMPControllers after each test.
+     * 
+     * Note that in the future we can implement the ExternalResource interface
+     * for various kinds of tests (NED Service, SAMP, Sherpa, etc.) in 
+     * independent classes. Then a test that needs multiple setup/teardown 
+     * methods can just instantiate the necessary Rules.
+     */
+    @Rule
+    public ExternalResource resource = new ExternalResource() {
+        @Override
+        protected void before() throws Exception {
+            // asserts that the SAMP Hub is up, and that sherpa-samp is connected.
+            connectToSAMPHub();
+            isSherpaConnected();
+        }
+        @Override
+        protected void after() {
+            // disconnect controller
+            controller.stop();
+        }
+    };
     
     /*
     * Creates a SedSAMPController and connects it to a SAMP Hub. Fails if

--- a/iris-common/src/test/java/cfa/vo/iris/test/unit/it/AbstractSAMPTest.java
+++ b/iris-common/src/test/java/cfa/vo/iris/test/unit/it/AbstractSAMPTest.java
@@ -34,7 +34,7 @@ public class AbstractSAMPTest {
     
     private final Logger logger = Logger.getLogger(AbstractSAMPTest.class.getName());
     
-    private final int SAMP_CONN_RETRIES = 3;
+    private final int SAMP_CONN_RETRIES = 5;
     
     protected SedSAMPController controller;
     private int TIMEOUT;
@@ -90,16 +90,14 @@ public class AbstractSAMPTest {
     }
 
     /*
-    Connects a SedSAMPController to a SAMP Hub. Fails if it does not connect to a 
-    SAMP Hub.
+    * Connects a SedSAMPController to a SAMP Hub. Fails if it does not connect to a 
+    * SAMP Hub.
     */
     public void connectToSAMPHub(SedSAMPController controller) throws InterruptedException, Exception {
         controller.setAutoRunHub(false);
         controller.start(false);
-        Thread.sleep(2000); // wait 2 seconds for connection
-	
-        // If the controller doesn't connect after 2 seconds, add additional
-        // wait time.
+
+        // Wait SAMP_CONN_RETRIES for the controller to connect to the SAMP hub.
         int count = 0;
         while (!controller.isConnected()) {
             if (++count > SAMP_CONN_RETRIES) {
@@ -113,7 +111,10 @@ public class AbstractSAMPTest {
         assertTrue(controller.isConnected());
     }
     
-    
+
+    /*
+    * Checks if Sherpa is connected to the SAMP hub
+    */    
     public void isSherpaConnected() throws SampException {
 	
         this.client = new SherpaClient(this.controller);

--- a/iris-common/src/test/java/cfa/vo/iris/test/unit/it/AbstractSAMPTest.java
+++ b/iris-common/src/test/java/cfa/vo/iris/test/unit/it/AbstractSAMPTest.java
@@ -34,10 +34,9 @@ public class AbstractSAMPTest {
     
     private final Logger logger = Logger.getLogger(AbstractSAMPTest.class.getName());
     
-    private final int SAMP_CONN_RETRIES = 5;
+    private final int SAMP_CONN_RETRIES = 3;
     
     protected SedSAMPController controller;
-    private int TIMEOUT;
     private String controller_name;
     protected SherpaClient client;
     
@@ -45,7 +44,7 @@ public class AbstractSAMPTest {
         this.controller_name = "Iris Test Controller";
     }
     
-    public AbstractSAMPTest(int timeout, String controller_name) {
+    public AbstractSAMPTest(String controller_name) {
         this.controller_name = controller_name;
     }
     
@@ -101,7 +100,7 @@ public class AbstractSAMPTest {
         int count = 0;
         while (!controller.isConnected()) {
             if (++count > SAMP_CONN_RETRIES) {
-                String msg = "Failed to connect to SAMP, failing Unit tests";
+                String msg = "Failed to connect to SAMP, failing tests";
                 logger.info(msg);
                 fail(msg);
             }
@@ -115,9 +114,12 @@ public class AbstractSAMPTest {
     /*
     * Checks if Sherpa is connected to the SAMP hub
     */    
-    public void isSherpaConnected() throws SampException {
+    public void isSherpaConnected() throws SampException, InterruptedException {
 	
         this.client = new SherpaClient(this.controller);
+        // Give Sherpa some time to connect to SAMP Hub
+        // TODO: do this smarter, like in connectToSAMPHub()
+        Thread.sleep(SAMP_CONN_RETRIES*1000);
         assertTrue(!this.client.findSherpa().isEmpty());
     }
 }

--- a/iris-common/src/test/java/cfa/vo/iris/test/unit/it/AbstractSAMPTest.java
+++ b/iris-common/src/test/java/cfa/vo/iris/test/unit/it/AbstractSAMPTest.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (C) 2015 Smithsonian Astrophysical Observatory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package cfa.vo.iris.test.unit.it;
+
+import cfa.vo.interop.SAMPController;
+import cfa.vo.sherpa.SherpaClient;
+import org.astrogrid.samp.client.SampException;
+import org.junit.After;
+import static org.junit.Assert.*;
+import org.junit.Before;
+
+/**
+ * Abstract integration test class for tests that need SAMP/sherpa-samp 
+ * to run. This class will verify that there is a SAMP Hub up and running, and, 
+ * if necessary, that sherpa-samp is connected. Only tests that use SAMP/sherpa
+ * should extend this class.
+ */
+public class AbstractSAMPTest {
+    
+    protected SAMPController controller;
+    private int TIMEOUT;
+    private String controller_name;
+    protected SherpaClient client;
+    
+    public AbstractSAMPTest() {
+	this.TIMEOUT = 5;
+	this.controller_name = "Iris Component";
+    }
+    
+    public AbstractSAMPTest(int timeout, String controller_name) {
+	this.TIMEOUT = timeout;
+	this.controller_name = controller_name;
+    }
+    
+    
+    // forces the concrete classes to make their own before class, and it will 
+    // not override this Before class
+    @Before
+    public final void setUp() throws Exception {
+    
+	// asserts that the SAMP Hub is up, and that sherpa-samp is connected.
+	connectToSAMPHub();
+	isSherpaConnected();
+    }
+    
+    @After
+    public void tearDown() {
+	controller.stop();
+    }
+    
+    public void connectToSAMPHub() throws InterruptedException, Exception {
+	
+	// setup the SAMP controller
+	controller = new SAMPController(
+		this.controller_name, 
+		this.controller_name, 
+		this.getClass().getResource("/tools_tiny.png").toString()
+	);
+	controller.setAutoRunHub(false);
+        controller.start(false);
+	Thread.sleep(2000); // wait 2 seconds for connection
+	
+	// If the controller doesn't connect after 2 seconds, add additional
+	// wait time.
+	int time = 0;
+	while (!controller.isConnected()) {
+	    time += TIMEOUT*1000;
+	    Thread.sleep(time);
+	    
+	    // If the controller doesn't connect within the additional time, 
+	    // fail.
+	    if (time >= TIMEOUT*1000) {
+		fail("Could not connect to SAMP Hub.");
+	    }
+	}
+	assertTrue(controller.isConnected());
+    }
+    
+    
+    public void isSherpaConnected() throws SampException {
+	
+	this.client = new SherpaClient(this.controller);
+	assertTrue(!this.client.findSherpa().isEmpty());
+    }
+}

--- a/iris-common/src/test/java/cfa/vo/iris/test/unit/it/AbstractSAMPTest.java
+++ b/iris-common/src/test/java/cfa/vo/iris/test/unit/it/AbstractSAMPTest.java
@@ -16,13 +16,15 @@
  
 package cfa.vo.iris.test.unit.it;
 
-import cfa.vo.interop.SAMPController;
+import cfa.vo.iris.interop.SedSAMPController;
 import cfa.vo.sherpa.SherpaClient;
 import java.util.logging.Logger;
 import org.astrogrid.samp.client.SampException;
 import org.junit.After;
 import static org.junit.Assert.*;
 import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.ExternalResource;
 
 /**
  * Abstract integration test class for tests that need SAMP/sherpa-samp 
@@ -36,17 +38,17 @@ public class AbstractSAMPTest {
     
     private final int SAMP_CONN_RETRIES = 3;
     
-    protected SAMPController controller;
+    protected SedSAMPController controller;
     private int TIMEOUT;
     private String controller_name;
     protected SherpaClient client;
     
     public AbstractSAMPTest() {
-	this.controller_name = "Iris Test Controller";
+        this.controller_name = "Iris Test Controller";
     }
     
     public AbstractSAMPTest(int timeout, String controller_name) {
-	this.controller_name = controller_name;
+        this.controller_name = controller_name;
     }
     
     
@@ -74,31 +76,43 @@ public class AbstractSAMPTest {
     @Before
     public final void setUp() throws Exception {
     
-	// asserts that the SAMP Hub is up, and that sherpa-samp is connected.
-	connectToSAMPHub();
-	isSherpaConnected();
+        // asserts that the SAMP Hub is up, and that sherpa-samp is connected.
+        connectToSAMPHub();
+        isSherpaConnected();
     }
     
     @After
     public void tearDown() {
-	controller.stop();
+        controller.stop();
     }
     
+    /*
+    * Creates a SedSAMPController and connects it to a SAMP Hub. Fails if
+    * it does not connect to a SAMP Hub.
+    */
     public void connectToSAMPHub() throws InterruptedException, Exception {
 	
 	// setup the SAMP controller
-	controller = new SAMPController(
-		this.controller_name, 
-		this.controller_name, 
-		this.getClass().getResource("/tools_tiny.png").toString()
+    controller = new SedSAMPController(
+            this.controller_name, 
+            this.controller_name, 
+            this.getClass().getResource("").toString()
 	);
-	controller.setAutoRunHub(false);
+    connectToSAMPHub(controller);
+    }
+
+    /*
+    Connects a SedSAMPController to a SAMP Hub. Fails if it does not connect to a 
+    SAMP Hub.
+    */
+    public void connectToSAMPHub(SedSAMPController controller) throws InterruptedException, Exception {
+        controller.setAutoRunHub(false);
         controller.start(false);
-	Thread.sleep(2000); // wait 2 seconds for connection
+        Thread.sleep(2000); // wait 2 seconds for connection
 	
-	// If the controller doesn't connect after 2 seconds, add additional
-	// wait time.
-	int count = 0;
+        // If the controller doesn't connect after 2 seconds, add additional
+        // wait time.
+        int count = 0;
         while (!controller.isConnected()) {
             if (++count > SAMP_CONN_RETRIES) {
                 String msg = "Failed to connect to SAMP, failing Unit tests";
@@ -108,13 +122,13 @@ public class AbstractSAMPTest {
             logger.info("waiting connection");
             Thread.sleep(1000);
         }
-	assertTrue(controller.isConnected());
+        assertTrue(controller.isConnected());
     }
     
     
     public void isSherpaConnected() throws SampException {
 	
-	this.client = new SherpaClient(this.controller);
-	assertTrue(!this.client.findSherpa().isEmpty());
+        this.client = new SherpaClient(this.controller);
+        assertTrue(!this.client.findSherpa().isEmpty());
     }
 }

--- a/sed-builder/src/test/java/cfa/vo/sed/science/interpolation/SherpaRedshifterIT.java
+++ b/sed-builder/src/test/java/cfa/vo/sed/science/interpolation/SherpaRedshifterIT.java
@@ -22,16 +22,10 @@
 
 package cfa.vo.sed.science.interpolation;
 
-import cfa.vo.interop.SAMPController;
 import cfa.vo.interop.SAMPFactory;
 import cfa.vo.interop.SAMPMessage;
-import cfa.vo.iris.interop.SedSAMPController;
-import cfa.vo.iris.sed.ExtSed;
-import cfa.vo.iris.sed.SedlibSedManager;
-import cfa.vo.sedlib.Param;
-import cfa.vo.sherpa.SherpaClient;
+import cfa.vo.iris.test.unit.it.AbstractSAMPTest;
 
-import java.util.Arrays;
 import java.util.logging.Logger;
 
 import org.astrogrid.samp.Response;
@@ -46,23 +40,21 @@ import static org.junit.Assert.*;
  *
  * @author jbudynk
  */
-public class SherpaRedshifterTest {
+public class SherpaRedshifterIT extends AbstractSAMPTest {
     
-    private static final Logger logger = Logger.getLogger(SherpaRedshifterTest.class.getName());
-
-    private SAMPController controller;
+    private static final Logger logger = Logger.getLogger(SherpaRedshifterIT.class.getName());
     private static String REDSHIFT_MTYPE = "spectrum.redshift.calc";
 
-    public SherpaRedshifterTest() {
+    public SherpaRedshifterIT() {
 
     }
 
     @Before
-    public void setUp() {
+    public void setup() {
     }
 
     @After
-    public void tearDown() {
+    public void teardown() {
     }
 
     @Ignore("need sherpa-samp running")
@@ -85,19 +77,6 @@ public class SherpaRedshifterTest {
                 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
         };
 
-
-        // Start the SAMP controller
-        controller = new SedSAMPController("SEDStacker", "SEDStacker", this.getClass().getResource("/tools_tiny.png").toString());
-        controller.setAutoRunHub(false); //set to 'true' when I figure out how to start Sherpa in the test...
-        controller.start(false);
-
-        Thread.sleep(2000);
-
-        while (!controller.isConnected()) {
-            logger.info("waiting connection");
-            Thread.sleep(1000);
-        }
-
 //	ExtSed inputSed = ExtSed.flatten(sed, "Angstrom", "Jy");
 
         RedshiftPayload payload = (RedshiftPayload) SAMPFactory.get(RedshiftPayload.class);
@@ -107,8 +86,6 @@ public class SherpaRedshifterTest {
         payload.setFromRedshift(1);
         payload.setToRedshift(0);
         SAMPMessage message = SAMPFactory.createMessage(REDSHIFT_MTYPE, payload, RedshiftPayload.class);
-
-        SherpaClient client = new SherpaClient(controller);
 
         Response rspns = controller.callAndWait(client.findSherpa(), message.get(), 10);
         if (client.isException(rspns)) {
@@ -122,15 +99,9 @@ public class SherpaRedshifterTest {
                 1, 21, 11, 2, 22, 12, 3, 23, 13, 4, 24, 14, 25, 15, 5, 16, 6, 26, 17, 7, 27, 18, 8, 28, 29, 19, 9, 20, 10, 30
         };
 
-        // tests
         // Make sure flux errors are sorted correctly with the SED points.
         for (int i = 0; i < response.getY().length; i++) {
             assertEquals(controlYerr[i], response.getYerr()[i], 0.00001);
         }
-
-        controller.stop();
-
     }
-
-
 }

--- a/sed-builder/src/test/java/cfa/vo/sed/science/stacker/AbstracSEDStackerIT.java
+++ b/sed-builder/src/test/java/cfa/vo/sed/science/stacker/AbstracSEDStackerIT.java
@@ -2,26 +2,19 @@ package cfa.vo.sed.science.stacker;
 
 import java.util.logging.Logger;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
-
-import cfa.vo.interop.SAMPController;
 import cfa.vo.interop.SAMPFactory;
-import cfa.vo.iris.interop.SedSAMPController;
+import cfa.vo.iris.test.unit.it.AbstractSAMPTest;
 
 /**
  * Abstract class for integration testing of SAMP integration. Tests will fail if they are
  * unable to connect to the SAMP hub.
  * 
  */
-public abstract class AbstracSEDStackerIT {
+public abstract class AbstracSEDStackerIT extends AbstractSAMPTest {
     
     private static final Logger logger = Logger.getLogger(AbstracSEDStackerIT.class.getName());
     
-    private static final int SAMP_CONN_RETRIES = 3;
     protected static final double EPSILON = 0.00001;
 
     protected double[] x1;
@@ -38,26 +31,11 @@ public abstract class AbstracSEDStackerIT {
     protected SegmentPayload segment2;
     protected SegmentPayload segment3;
 
-    protected static SAMPController controller;
-    
-    @BeforeClass
-    public static void beforeClass() throws Exception {
-        startSamp();
-    }
-    
-    @AfterClass
-    public static void afterClass() throws Exception {
-        terminate();
-    }
+ 
     
     @Before
-    public void setUp() throws Exception {
+    public void setup() throws Exception {
         initVariables();
-    }
-    
-    @After
-    public void tearDown() {
-        terminate();
     }
     
     protected void initVariables() throws Exception {
@@ -95,29 +73,4 @@ public abstract class AbstracSEDStackerIT {
         segment3.setId("Sed3");
     }
     
-    private static void startSamp() throws Exception {
-        // Start the SAMP controller
-        controller = new SedSAMPController("SEDStacker", "SEDStacker", AbstracSEDStackerIT.class.getResource("/tools_tiny.png")
-                .toString());
-        controller.setAutoRunHub(false);
-        controller.start(false);
-        
-        // Wait for start
-        Thread.sleep(2000);
-
-        int count = 0;
-        while (!controller.isConnected()) {
-            if (++count > SAMP_CONN_RETRIES) {
-                String msg = "Failed to connect to SAMP, failing Unit tests";
-                logger.info(msg);
-                Assert.fail(msg);
-            }
-            logger.info("waiting connection");
-            Thread.sleep(1000);
-        }
-    }
-
-    protected static void terminate() {
-        controller.stop();
-    }
 }

--- a/sed-builder/src/test/java/cfa/vo/sed/science/stacker/AbstractSEDStackerIT.java
+++ b/sed-builder/src/test/java/cfa/vo/sed/science/stacker/AbstractSEDStackerIT.java
@@ -11,9 +11,9 @@ import cfa.vo.iris.test.unit.it.AbstractSAMPTest;
  * unable to connect to the SAMP hub.
  * 
  */
-public abstract class AbstracSEDStackerIT extends AbstractSAMPTest {
+public abstract class AbstractSEDStackerIT extends AbstractSAMPTest {
     
-    private static final Logger logger = Logger.getLogger(AbstracSEDStackerIT.class.getName());
+    private static final Logger logger = Logger.getLogger(AbstractSEDStackerIT.class.getName());
     
     protected static final double EPSILON = 0.00001;
 

--- a/sed-builder/src/test/java/cfa/vo/sed/science/stacker/SedStackerNormalizerIT.java
+++ b/sed-builder/src/test/java/cfa/vo/sed/science/stacker/SedStackerNormalizerIT.java
@@ -44,7 +44,7 @@ import static org.junit.Assert.*;
  * 
  * @author jbudynk
  */
-public class SedStackerNormalizerIT extends AbstracSEDStackerIT {
+public class SedStackerNormalizerIT extends AbstractSEDStackerIT {
 
     SedStackerNormalizePayload payload;
     

--- a/sed-builder/src/test/java/cfa/vo/sed/science/stacker/SedStackerNormalizerIT.java
+++ b/sed-builder/src/test/java/cfa/vo/sed/science/stacker/SedStackerNormalizerIT.java
@@ -29,7 +29,6 @@ import static cfa.vo.sed.science.stacker.SedStackerAttachments.NORM_CONSTANT;
 import cfa.vo.iris.utils.Default;
 import cfa.vo.iris.utils.UTYPE;
 import cfa.vo.sedlib.Segment;
-import cfa.vo.sherpa.SherpaClient;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -83,8 +82,6 @@ public class SedStackerNormalizerIT extends AbstracSEDStackerIT {
         SAMPMessage message = SAMPFactory.createMessage("stack.normalize",
                 payload, SedStackerNormalizePayload.class);
 
-        SherpaClient client = new SherpaClient(controller);
-
         Response rspns = controller.callAndWait(client.findSherpa(),
                 message.get(), 10);
         if (client.isException(rspns)) {
@@ -114,7 +111,6 @@ public class SedStackerNormalizerIT extends AbstracSEDStackerIT {
         }
         assertEquals(1.1529274, resnorm3, EPSILON);
 
-        controller.stop();
     }
 
     @Ignore("need sherpa-samp running")

--- a/sed-builder/src/test/java/cfa/vo/sed/science/stacker/SedStackerRedshifterIT.java
+++ b/sed-builder/src/test/java/cfa/vo/sed/science/stacker/SedStackerRedshifterIT.java
@@ -44,7 +44,7 @@ import static org.junit.Assert.*;
  * 
  * @author jbudynk
  */
-public class SedStackerRedshifterIT extends AbstracSEDStackerIT {
+public class SedStackerRedshifterIT extends AbstractSEDStackerIT {
     
     double[] controlY1;
     double[] controlX1;

--- a/sed-builder/src/test/java/cfa/vo/sed/science/stacker/SedStackerRedshifterIT.java
+++ b/sed-builder/src/test/java/cfa/vo/sed/science/stacker/SedStackerRedshifterIT.java
@@ -29,7 +29,6 @@ import static cfa.vo.sed.science.stacker.SedStackerAttachments.REDSHIFT;
 import cfa.vo.iris.utils.Default;
 import cfa.vo.iris.utils.UTYPE;
 import cfa.vo.sedlib.Segment;
-import cfa.vo.sherpa.SherpaClient;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -88,8 +87,6 @@ public class SedStackerRedshifterIT extends AbstracSEDStackerIT {
         // Setup and send SAMP message
         SAMPMessage message = SAMPFactory.createMessage("stack.redshift",
                 payload, SedStackerRedshiftPayload.class);
-
-        SherpaClient client = new SherpaClient(controller);
 
         Response rspns = controller.callAndWait(client.findSherpa(),
                 message.get(), 10);

--- a/sed-builder/src/test/java/cfa/vo/sed/science/stacker/SedStackerStackerIT.java
+++ b/sed-builder/src/test/java/cfa/vo/sed/science/stacker/SedStackerStackerIT.java
@@ -40,7 +40,7 @@ import static org.junit.Assert.*;
  *
  * @author jbudynk
  */
-public class SedStackerStackerIT extends AbstracSEDStackerIT {
+public class SedStackerStackerIT extends AbstractSEDStackerIT {
     
     SedStackerStackPayload payload;
     

--- a/sed-builder/src/test/java/cfa/vo/sed/science/stacker/SedStackerStackerIT.java
+++ b/sed-builder/src/test/java/cfa/vo/sed/science/stacker/SedStackerStackerIT.java
@@ -29,7 +29,6 @@ import cfa.vo.iris.utils.UTYPE;
 
 import static cfa.vo.sed.science.stacker.SedStackerAttachments.COUNTS;
 import cfa.vo.sedlib.Segment;
-import cfa.vo.sherpa.SherpaClient;
 import java.util.ArrayList;
 import java.util.List;
 import org.astrogrid.samp.Response;
@@ -65,8 +64,6 @@ public class SedStackerStackerIT extends AbstracSEDStackerIT {
 
         // Setup and send SAMP message
         SAMPMessage message = SAMPFactory.createMessage("stack.stack", payload, SedStackerStackPayload.class);
-
-        SherpaClient client = new SherpaClient(controller);
 
         Response rspns = controller.callAndWait(client.findSherpa(), message.get(), 10);
         if (client.isException(rspns)) {


### PR DESCRIPTION
Address #191 

Depends on #200 (or another way to setup SAMP and Sherpa)

# Description
This PR checks that a SAMP Hub and Sherpa are up and running before any non-GUI integration tests that require a SAMP connection are executed.

All tests that require a SAMP connection are extended from `AbstractSAMPTest.java`. Before a test is run, an attempt is made to connect a `SedSAMPController` to a SAMP hub; if a connection cannot be made within 5 seconds, the test fails. Similarly, a test is run to make sure Sherpa is attached to the SAMP Hub. 

`AbstractSAMPTest.java` uses the `@Rule` annotation to setup/tear down tests, instead of using `@Before`/`@After`. Reasons for this change are that `@Rule` and JUnit's `ExternalResource` class may prove to be more flexible in test infrastructure down the road.

Note that the Travis builds are NOT passing, as **this PR depends on a way to have the SAMP hub and Sherpa up before the tests run**. However, the Travis test failures are a good thing - it shows that the tests fail because they can't connect to a SAMP hub (see Travis build [#203](https://travis-ci.org/ChandraCXC/iris/builds/93584102)). On my local machine, I've merged #200 onto these changes to make sure that the tests run and pass as expected. If necessary, I will make this branch dependent on #200; as a result of this, I will need to add `maven-antrun-plugin` to `iris-common/pom.xml`.