### PR TITLE
Add CLI components to componentLoader. Closes #232.

### DIFF
--- a/iris-common/src/main/java/cfa/vo/iris/ComponentLoader.java
+++ b/iris-common/src/main/java/cfa/vo/iris/ComponentLoader.java
@@ -32,18 +32,28 @@ public class ComponentLoader {
     protected List<String> failures = new ArrayList<>();
 
     public ComponentLoader(Collection<Class<? extends IrisComponent>> componentList) {
-        for (Class c : componentList) {
-            loadComponent(c);
-        }
+        addComponents(componentList);
     }
     
-    public ComponentLoader(URL componentsURL) {
+    public ComponentLoader(URL componentsURL, Collection<Class<? extends IrisComponent>> componentList) {
         try {
             initComponents(readComponentsFile(componentsURL));
         } catch (IOException ex) {
             String message = "Cannot read components file at: " + componentsURL;
             System.err.println(message);
             Logger.getLogger(ComponentLoader.class.getName()).log(Level.SEVERE, message, ex);
+        }
+        
+        addComponents(componentList);
+    }
+    
+    private void addComponents(Collection<Class<? extends IrisComponent>> componentList) {
+        if (componentList == null) {
+            return;
+        }
+        
+        for (Class<? extends IrisComponent> c : componentList) {
+            loadComponent(c);
         }
     }
 

--- a/iris-common/src/test/java/cfa/vo/iris/ComponentLoaderTest.java
+++ b/iris-common/src/test/java/cfa/vo/iris/ComponentLoaderTest.java
@@ -40,7 +40,7 @@ public class ComponentLoaderTest {
 
     @Test
     public void testLoadComponents() {
-        ComponentLoader loader = new ComponentLoader(testUrl);
+        ComponentLoader loader = new ComponentLoader(testUrl, new ArrayList());
         Collection<IrisComponent> components = loader.getComponents();
 
         assertEquals(1, components.size());
@@ -54,6 +54,19 @@ public class ComponentLoaderTest {
         IrisComponent comp = loader.getComponent("testcomponent");
         assertNotNull(comp);
         assertTrue(comp instanceof TestIrisComponent);
+    }
+    
+    public void testLoadExtraComponents() {
+        Collection<Class<? extends IrisComponent>> comps = new ArrayList<>();
+        comps.add(TestIrisComponent.class);
+        ComponentLoader loader = new ComponentLoader(null, comps);
+        
+        Collection<IrisComponent> components = loader.getComponents();
+        
+        assertEquals(1, components.size());
+        Iterator<IrisComponent> it = components.iterator();
+        assertTrue(it.hasNext());
+        assertTrue(it.next() instanceof TestIrisComponent);
     }
 
     @Test

--- a/iris/src/main/java/cfa/vo/iris/Iris.java
+++ b/iris/src/main/java/cfa/vo/iris/Iris.java
@@ -122,7 +122,8 @@ public class Iris extends Application implements IrisApplication {
     protected void initialize(String[] args) {
         commandLine = new CommandLine(args);
         new Configuration(commandLine).apply();
-        componentLoader = new ComponentLoader(getClass().getResource("/components"));
+        componentLoader = new ComponentLoader(getClass().getResource("/components"),
+                                              commandLine.getAdditionalComponents());
         sampSetup();
     }
 


### PR DESCRIPTION
We were just missing a call to get the extra components from the Command Line.

Here's a potential fix.