### PR TITLE
fix sherpa connection icon and add unit tests

### DIFF
--- a/iris-common/src/main/java/cfa/vo/iris/desktop/IrisDesktop.java
+++ b/iris-common/src/main/java/cfa/vo/iris/desktop/IrisDesktop.java
@@ -71,7 +71,6 @@ public class IrisDesktop extends JFrame implements PluginListener {
         this.ws = ws;
     }
 
-    /** Creates new form SedImporterMainView */
     public IrisDesktop(final IrisApplication app) throws Exception {
 
         PluginJarEvent.getInstance().add(this);

--- a/iris-common/src/test/java/cfa/vo/iris/test/unit/ApplicationStub.java
+++ b/iris-common/src/test/java/cfa/vo/iris/test/unit/ApplicationStub.java
@@ -26,6 +26,7 @@ import org.astrogrid.samp.client.SampException;
 import javax.swing.*;
 import java.io.File;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Collection;
 
 /**
@@ -39,7 +40,7 @@ import java.util.Collection;
  *
  */
 public class ApplicationStub implements IrisApplication {
-    private StubWorkspace wSpace = new StubWorkspace();
+    protected StubWorkspace wSpace = new StubWorkspace();
     
     public IWorkspace getWorkspace() {
         return wSpace;

--- a/iris-common/src/test/java/cfa/vo/iris/test/unit/IMainWindow.java
+++ b/iris-common/src/test/java/cfa/vo/iris/test/unit/IMainWindow.java
@@ -1,0 +1,8 @@
+package cfa.vo.iris.test.unit;
+
+import javax.swing.*;
+
+public interface IMainWindow {
+    JDesktopPane getDesktop();
+    JFrame getMainFrame();
+}

--- a/iris-common/src/test/java/cfa/vo/iris/test/unit/MainWindow.java
+++ b/iris-common/src/test/java/cfa/vo/iris/test/unit/MainWindow.java
@@ -1,0 +1,20 @@
+package cfa.vo.iris.test.unit;
+
+import javax.swing.*;
+
+public class MainWindow extends JFrame implements IMainWindow {
+    private JDesktopPane desktop;
+
+    public MainWindow() {
+        super("Test App");
+        desktop = new JDesktopPane();
+    }
+
+    public JDesktopPane getDesktop() {
+        return desktop;
+    }
+
+    public JFrame getMainFrame() {
+        return this;
+    }
+}

--- a/iris-common/src/test/java/cfa/vo/iris/test/unit/StubAdapter.java
+++ b/iris-common/src/test/java/cfa/vo/iris/test/unit/StubAdapter.java
@@ -15,6 +15,7 @@
  */
 package cfa.vo.iris.test.unit;
 
+import cfa.vo.iris.IrisApplication;
 import org.uispec4j.UISpecAdapter;
 import org.uispec4j.Window;
 
@@ -22,9 +23,13 @@ public class StubAdapter implements UISpecAdapter {
     private ApplicationStub stub;
     private Window mainWindow;
 
+    public StubAdapter(ApplicationStub app) {
+        stub = app;
+        mainWindow = new Window(app.getWorkspace().getRootFrame());
+    }
+
     public StubAdapter() {
-        stub = new ApplicationStub();
-        mainWindow = new Window(stub.getWorkspace().getRootFrame());
+        this(new ApplicationStub());
     }
 
     @Override

--- a/iris-common/src/test/java/cfa/vo/iris/test/unit/StubWorkspace.java
+++ b/iris-common/src/test/java/cfa/vo/iris/test/unit/StubWorkspace.java
@@ -34,7 +34,7 @@ import javax.swing.*;
 
 public class StubWorkspace implements IWorkspace {
     private UnitsManager unitsManager = new DefaultUnitsManager();
-    private JFrame mainWindow = new JFrame("Test App");
+    private JFrame mainWindow;
     private JDesktopPane desktop;
     private SedlibSedManager manager = new SedlibSedManager();
     private JFileChooser chooser = new JFileChooser();
@@ -42,8 +42,12 @@ public class StubWorkspace implements IWorkspace {
     private JMenu toolsMenu = new JMenu("Tools");
 
     public StubWorkspace() {
-        mainWindow = new JFrame("Test App");
-        desktop = new JDesktopPane();
+        this(new MainWindow());
+    }
+
+    public StubWorkspace(IMainWindow window) {
+        mainWindow = window.getMainFrame();
+        desktop = window.getDesktop();
         JMenuBar menuBar = new JMenuBar();
         mainWindow.setContentPane(desktop);
         mainWindow.setJMenuBar(menuBar);
@@ -106,4 +110,5 @@ public class StubWorkspace implements IWorkspace {
     public void shutdown() {
         mainWindow.dispose();
     }
+
 }

--- a/iris/src/test/java/cfa/vo/gui/SAMPConnectionTest.java
+++ b/iris/src/test/java/cfa/vo/gui/SAMPConnectionTest.java
@@ -18,7 +18,7 @@ import static org.junit.Assert.*;
 
 public class SAMPConnectionTest extends AbstractUISpecTest {
 
-    private Logger logger = Logger.getLogger(IrisUISpecAdapter.class.getName());
+    private Logger logger = Logger.getLogger(SAMPConnectionTest.class.getName());
     private ExecutorService executor;
     private Window mainWindow;
 
@@ -91,6 +91,7 @@ public class SAMPConnectionTest extends AbstractUISpecTest {
 
         logger.log(Level.INFO, "making sure Iris disconnects");
         checkLabel(mainWindow, "SAMP", false);
+        checkLabel(mainWindow, "Sherpa", false);
 
         // But Iris should reconnect if a new hub is started
         logger.log(Level.INFO, "starting a new hub");

--- a/iris/src/test/java/cfa/vo/iris/desktop/IrisDesktopSampConnectionTest.java
+++ b/iris/src/test/java/cfa/vo/iris/desktop/IrisDesktopSampConnectionTest.java
@@ -1,0 +1,145 @@
+package cfa.vo.iris.desktop;
+
+import cfa.vo.interop.SAMPConnectionListener;
+import cfa.vo.iris.IrisComponent;
+import cfa.vo.iris.test.unit.*;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.uispec4j.Window;
+
+import javax.swing.*;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class IrisDesktopSampConnectionTest extends AbstractUISpecTest {
+    private StubAdapter stubAdapter;
+    private Window window;
+    private SampApplicationStub appStub;
+
+    private final String SAMP = "SAMP";
+    private final String SHERPA = "Sherpa";
+
+    @Before
+    public void setUp() throws Exception {
+        appStub = new SampApplicationStub();
+        StubWorkspace ws = new StubWorkspace(new SampMainWindow(appStub));
+        appStub.setWorkspace(ws);
+        stubAdapter = new StubAdapter(appStub);
+        window = stubAdapter.getMainWindow();
+        this.RETRY = 60;
+    }
+
+    @Test
+    public void testSampConnection() throws Exception {
+        // At first, SAMP is disconnected
+        checkLabel(window, SAMP, false);
+        // simulate connection
+        appStub.connectSAMP();
+        checkLabel(window, SAMP, true);
+        // simulate disconnection
+        appStub.disconnectSAMP();
+        checkLabel(window, SAMP, false);
+    }
+
+    @Test
+    public void testSherpaConnection() throws Exception {
+        // at first, sherpa is disconnected
+        checkLabel(window, SHERPA, false);
+        // simulate connection
+        appStub.connectSherpa();
+        checkLabel(window, SHERPA, true);
+        // simulate disconnection
+        appStub.disconnectSherpa();
+        checkLabel(window, SHERPA, false);
+        // simulate connection so we can emulate a samp failure
+        appStub.connectSherpa();
+        checkLabel(window, SHERPA, true);
+        // simulate a *samp* disconnection
+        appStub.disconnectSAMP();
+        checkLabel(window, SHERPA, false);
+    }
+
+    private class SampMainWindow implements IMainWindow {
+        private IrisDesktop desktop;
+        private JFrame mainFrame;
+
+        private SampMainWindow(ApplicationStub app) throws Exception {
+            desktop = new IrisDesktop(app);
+            mainFrame = app.getWorkspace().getRootFrame();
+        }
+
+        @Override
+        public JDesktopPane getDesktop() {
+            return desktop.getDesktopPane();
+        }
+
+        @Override
+        public JFrame getMainFrame() {
+            return mainFrame;
+        }
+    }
+
+    private class SampApplicationStub extends ApplicationStub {
+        private List<SAMPConnectionListener> sherpaListeners = new ArrayList<>();
+        private List<SAMPConnectionListener> sampListeners = new ArrayList<>();
+
+        public void setWorkspace(StubWorkspace wSpace) {
+            this.wSpace = wSpace;
+        }
+
+        @Override
+        public Collection<? extends IrisComponent> getComponents() {
+            return new ArrayList();
+        }
+
+        @Override
+        public URL getDesktopIcon() {
+            return ApplicationStub.class.getResource("/iris_button_tiny.png");
+        }
+
+        @Override
+        public boolean isSampEnabled() {
+            return true;
+        }
+
+        @Override
+        public void addSherpaConnectionListener(SAMPConnectionListener listener) {
+            sherpaListeners.add(listener);
+        }
+
+        @Override
+        public void addConnectionListener(SAMPConnectionListener listener) {
+            sampListeners.add(listener);
+        }
+
+        public void disconnectSherpa() {
+            for (SAMPConnectionListener l : sherpaListeners) {
+                l.run(false);
+            }
+        }
+
+        public void connectSherpa() {
+            for (SAMPConnectionListener l : sherpaListeners) {
+                l.run(true);
+            }
+        }
+
+        public void disconnectSAMP() {
+            for (SAMPConnectionListener l : sampListeners) {
+                l.run(false);
+            }
+
+            disconnectSherpa();
+        }
+
+        public void connectSAMP() {
+            for (SAMPConnectionListener l : sampListeners) {
+                l.run(true);
+            }
+        }
+    }
+
+}

--- a/samp-factory/src/main/java/cfa/vo/interop/SampService.java
+++ b/samp-factory/src/main/java/cfa/vo/interop/SampService.java
@@ -20,7 +20,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class SampService {
-    private final String PING_MTYPE = "samp.app.ping";
+    private final String PING_MTYPE = "sherpa.ping";
     private final int DEFAULT_TIMEOUT = 10;
     private final int RETRY = 100;
     private final int RETRY_INTERVAL = 100;


### PR DESCRIPTION
Resolve #233
Resolve #209  

# Description
This PR fixes an issue in #231 by which the Sherpa icon does not update when Sherpa is not connected.
There are unit tests exercising the relevant code in the IrisDesktop class, but integration tests are hard to implement as sherpa-samp is an external process, and we should reliably be able to shut it down and start it up again from Java, and we currently can't do it.

This PR relies on a change in sherpa-samp, namely the introduction of a `sherpa.ping` mtype handler.