### PR TITLE
subscribe plotter to events, unit tests

### DIFF
--- a/iris-common/src/main/java/cfa/vo/iris/sed/ExtSed.java
+++ b/iris-common/src/main/java/cfa/vo/iris/sed/ExtSed.java
@@ -26,6 +26,7 @@ import cfa.vo.iris.events.SedCommand;
 import cfa.vo.iris.events.SedEvent;
 import cfa.vo.iris.events.SegmentEvent;
 import cfa.vo.iris.events.SegmentEvent.SegmentPayload;
+import cfa.vo.iris.interop.SedPayload;
 import cfa.vo.iris.interop.SedServerResource;
 import cfa.vo.iris.interop.VaoMessage;
 import cfa.vo.iris.logging.LogEntry;
@@ -119,6 +120,7 @@ public class ExtSed extends Sed {
         super.removeSegment(i);
         if (managed) {
             SegmentEvent.getInstance().fire(seg, new SegmentPayload(this, SedCommand.REMOVED));
+            SedEvent.getInstance().fire(this, SedCommand.CHANGED);
             LogEvent.getInstance().fire(this, new LogEntry("Segment removed from SED: " + id, this));
         }
     }
@@ -163,6 +165,7 @@ public class ExtSed extends Sed {
         boolean resp = super.segmentList.remove(s);
         if (managed) {
             SegmentEvent.getInstance().fire(s, new SegmentPayload(this, SedCommand.REMOVED));
+            SedEvent.getInstance().fire(this, SedCommand.CHANGED);
             LogEvent.getInstance().fire(this, new LogEntry("Segments removed from SED: " + id, this));
         }
         return resp;
@@ -176,6 +179,7 @@ public class ExtSed extends Sed {
 
         if (managed) {
             MultipleSegmentEvent.getInstance().fire(segments, new SegmentPayload(this, SedCommand.REMOVED));
+            SedEvent.getInstance().fire(this, SedCommand.CHANGED);
             LogEvent.getInstance().fire(this, new LogEntry("Segments removed from SED: " + id, this));
         }
         return resp;

--- a/iris-common/src/test/java/cfa/vo/iris/test/unit/AbstractGUITest.java
+++ b/iris-common/src/test/java/cfa/vo/iris/test/unit/AbstractGUITest.java
@@ -41,7 +41,7 @@ public abstract class AbstractGUITest extends AbstractUISpecTest {
 
     protected Desktop desktop;
     protected Window window;
-    private ApplicationStub app;
+    protected ApplicationStub app;
     private StubAdapter adapter;
     
     @Before

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/VisualizerComponent.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/VisualizerComponent.java
@@ -27,7 +27,7 @@ public class VisualizerComponent implements IrisComponent {
     
     private IrisApplication app;
     private IWorkspace ws;
-    private List<IMenuItem> menuItems = new MenuItems();
+    private MenuItems menuItems = new MenuItems();
 
     @Override
     public void init(IrisApplication irisApplication, IWorkspace iWorkspace) {
@@ -66,6 +66,10 @@ public class VisualizerComponent implements IrisComponent {
 
     @Override
     public void shutdown() {
+    }
+
+    public PlotterView getDefaultPlotterView() {
+        return menuItems.view;
     }
 
     private class MenuItems extends ArrayList<IMenuItem> {

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
@@ -29,6 +29,8 @@ import javax.swing.JPopupMenu;
 import java.awt.Component;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.util.Collections;
+import java.util.Map;
 
 import javax.swing.JSpinner;
 import javax.swing.SpinnerListModel;
@@ -36,12 +38,16 @@ import javax.swing.plaf.basic.BasicArrowButton;
 import javax.swing.JTextField;
 import javax.swing.JCheckBox;
 import cfa.vo.iris.IrisApplication;
+import cfa.vo.iris.events.SedCommand;
+import cfa.vo.iris.events.SedEvent;
+import cfa.vo.iris.events.SedListener;
 import cfa.vo.iris.gui.GUIUtils;
 import cfa.vo.iris.gui.NarrowOptionPane;
 import cfa.vo.iris.sed.ExtSed;
 import cfa.vo.iris.sed.stil.SegmentStarTableAdapter;
 import cfa.vo.iris.sed.stil.StarTableAdapter;
 import cfa.vo.iris.visualizer.stil.StilPlotter;
+import cfa.vo.iris.visualizer.stil.preferences.SegmentLayer;
 import cfa.vo.sedlib.ISegment;
 import cfa.vo.iris.IWorkspace;
 import javax.swing.JFrame;
@@ -144,11 +150,20 @@ public class PlotterView extends JInternalFrame {
         // Action for resetting plot
         btnReset.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
-                resetPlot();
+                resetPlot(null);
             }
         });
+
+        SedEvent.getInstance().add(new PlotSedListener());
     }
 
+    public ExtSed getSed() {
+        return plotter.getSed();
+    }
+
+    public Map<ISegment, SegmentLayer> getSegmentsMap() {
+        return plotter.getSegmentsMap();
+    }
     
     private void openMetadataBrowser() throws Exception {
         if (!metadataBrowser.isVisible()) {
@@ -160,9 +175,9 @@ public class PlotterView extends JInternalFrame {
         }
     }
     
-    private void resetPlot() {
+    private void resetPlot(ExtSed sed) {
         this.metadataBrowser.reset();
-        this.plotter.reset();
+        this.plotter.reset(sed);
     }
     
     private static void addPopup(Component component, final JPopupMenu popup) {
@@ -346,5 +361,13 @@ public class PlotterView extends JInternalFrame {
         
         mntmCoplot = new JMenuItem("Coplot");
         mnView.add(mntmCoplot);
+    }
+
+    private class PlotSedListener implements SedListener {
+
+        @Override
+        public void process(ExtSed source, SedCommand payload) {
+            resetPlot(source);
+        }
     }
 }

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/VisualizerComponentTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/VisualizerComponentTest.java
@@ -73,7 +73,8 @@ public class VisualizerComponentTest extends AbstractComponentGUITest {
                 .getSubMenu(windowName)
                 .getSubMenu(windowName)
                 .click();
-        assertSame(sedManager.getSelected(), comp.getDefaultPlotterView().getSed());
+        ExtSed initialSed = sedManager.getSelected();
+        assertNull(initialSed);
 
         // Test the plotter reacts to a sed event
         final ExtSed sed = sedManager.newSed("sampleSed");
@@ -97,6 +98,27 @@ public class VisualizerComponentTest extends AbstractComponentGUITest {
                 assertTrue(comp.getDefaultPlotterView().getSegmentsMap().containsKey(segment));
             }
         });
+
+        // Just double checking this works more than once.
+        final ExtSed sed2 = sedManager.newSed("oneMoreSed");
+        // Make sure this is enqueued in the Swing EDT
+        SwingUtilities.invokeLater(new Runnable() {
+            @Override
+            public void run() {
+                assertSame(sed2, comp.getDefaultPlotterView().getSed());
+            }
+        });
+
+        // Just double checking we can go back through select
+        sedManager.select(sed);
+        // Make sure this is enqueued in the Swing EDT
+        SwingUtilities.invokeLater(new Runnable() {
+            @Override
+            public void run() {
+                assertSame(sed, comp.getDefaultPlotterView().getSed());
+            }
+        });
+
 
 //        assertEquals("sampleSed", comp.getDefaultPlotterView().getLegend().getTitle());
     }

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/VisualizerComponentTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/VisualizerComponentTest.java
@@ -15,10 +15,17 @@
  */
 package cfa.vo.iris.visualizer;
 
+import cfa.vo.iris.sed.ExtSed;
+import cfa.vo.iris.sed.SedlibSedManager;
 import cfa.vo.iris.test.unit.AbstractComponentGUITest;
 import cfa.vo.iris.IrisComponent;
+import cfa.vo.sedlib.Segment;
+import cfa.vo.sedlib.common.SedNoDataException;
 import org.junit.Before;
 import org.junit.Test;
+
+import javax.swing.*;
+
 import static org.junit.Assert.*;
 
 public class VisualizerComponentTest extends AbstractComponentGUITest {
@@ -51,5 +58,57 @@ public class VisualizerComponentTest extends AbstractComponentGUITest {
         mbButton.click();
         
         assertTrue(desktop.containsWindow("Metadata Browser").isTrue());
+    }
+
+    @Test
+    public void testEventSubscription() throws Exception {
+        SedlibSedManager sedManager = (SedlibSedManager) app.getWorkspace().getSedManager();
+
+        // No view when starting application up
+        assertNull(comp.getDefaultPlotterView());
+
+        // When the viewer button is clicked, the displayed SED should be the one selected in the SedManager
+        window.getMenuBar()
+                .getMenu("Tools")
+                .getSubMenu(windowName)
+                .getSubMenu(windowName)
+                .click();
+        assertSame(sedManager.getSelected(), comp.getDefaultPlotterView().getSed());
+
+        // Test the plotter reacts to a sed event
+        final ExtSed sed = sedManager.newSed("sampleSed");
+        // Make sure this is enqueued in the Swing EDT
+        SwingUtilities.invokeLater(new Runnable() {
+            @Override
+            public void run() {
+                assertSame(sed, comp.getDefaultPlotterView().getSed());
+            }
+        });
+
+
+        // Test the plotter reacts to a segment event (although this only requires subscribing to SedEvents)
+        final Segment segment = createSampleSegment();
+        sed.addSegment(segment);
+
+        // Make sure this is enqueued in the Swing EDT
+        SwingUtilities.invokeLater(new Runnable() {
+            @Override
+            public void run() {
+                assertTrue(comp.getDefaultPlotterView().getSegmentsMap().containsKey(segment));
+            }
+        });
+
+//        assertEquals("sampleSed", comp.getDefaultPlotterView().getLegend().getTitle());
+    }
+
+    private Segment createSampleSegment() throws SedNoDataException {
+        double[] x = new double[]{1.0, 2.0, 3.0};
+        double[] y = new double[]{1.0, 2.0, 3.0};
+        Segment segment = new Segment();
+        segment.setFluxAxisValues(y);
+        segment.setFluxAxisUnits("Jy");
+        segment.setSpectralAxisValues(x);
+        segment.setSpectralAxisUnits("Angstrom");
+        return segment;
     }
 }


### PR DESCRIPTION
Resolve #224 

# Description

This PR subscribes the plotter to sed events. All sed events trigger a reset of the plotter view. This may or may not be the desired eventual behavior, depending also on the work in #225.

For instance, the `reset` logic does not discriminate between resetting the viewport after a click of the "reset" button or plotting a new SED once it has been selected. Also, one may want to attach the viewport features as SED attachments and then restore the customized viewport once an SED regains focus, so that user's customization are preserved, at least during a session.

So, we may want to split `reset` into two methods with different scopes. This seems out of the scope of this PR, but we may decide otherwise.

There are many more unit tests that this PR may add, but it is hard to implement them without basic unit tests for the plotter itself, and much of the state of the plotter seems rather opaque at this point.