### PR TITLE
Iris 239 plotter performance test

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "iris-docs"]
 	path = iris-docs
 	url = https://github.com/ChandraCXC/iris-docs.git
+[submodule "iris-test-data"]
+	path = iris-test-data
+	url = https://github.com/ChandraCXC/iris-test-data.git

--- a/iris-common/src/main/java/cfa/vo/iris/sed/ExtSed.java
+++ b/iris-common/src/main/java/cfa/vo/iris/sed/ExtSed.java
@@ -26,6 +26,7 @@ import cfa.vo.iris.events.SedCommand;
 import cfa.vo.iris.events.SedEvent;
 import cfa.vo.iris.events.SegmentEvent;
 import cfa.vo.iris.events.SegmentEvent.SegmentPayload;
+import cfa.vo.iris.interop.SedPayload;
 import cfa.vo.iris.interop.SedServerResource;
 import cfa.vo.iris.interop.VaoMessage;
 import cfa.vo.iris.logging.LogEntry;
@@ -119,6 +120,7 @@ public class ExtSed extends Sed {
         super.removeSegment(i);
         if (managed) {
             SegmentEvent.getInstance().fire(seg, new SegmentPayload(this, SedCommand.REMOVED));
+            SedEvent.getInstance().fire(this, SedCommand.CHANGED);
             LogEvent.getInstance().fire(this, new LogEntry("Segment removed from SED: " + id, this));
         }
     }
@@ -163,6 +165,7 @@ public class ExtSed extends Sed {
         boolean resp = super.segmentList.remove(s);
         if (managed) {
             SegmentEvent.getInstance().fire(s, new SegmentPayload(this, SedCommand.REMOVED));
+            SedEvent.getInstance().fire(this, SedCommand.CHANGED);
             LogEvent.getInstance().fire(this, new LogEntry("Segments removed from SED: " + id, this));
         }
         return resp;
@@ -176,6 +179,7 @@ public class ExtSed extends Sed {
 
         if (managed) {
             MultipleSegmentEvent.getInstance().fire(segments, new SegmentPayload(this, SedCommand.REMOVED));
+            SedEvent.getInstance().fire(this, SedCommand.CHANGED);
             LogEvent.getInstance().fire(this, new LogEntry("Segments removed from SED: " + id, this));
         }
         return resp;

--- a/iris-common/src/main/java/cfa/vo/iris/sed/ExtSed.java
+++ b/iris-common/src/main/java/cfa/vo/iris/sed/ExtSed.java
@@ -26,7 +26,6 @@ import cfa.vo.iris.events.SedCommand;
 import cfa.vo.iris.events.SedEvent;
 import cfa.vo.iris.events.SegmentEvent;
 import cfa.vo.iris.events.SegmentEvent.SegmentPayload;
-import cfa.vo.iris.interop.SedPayload;
 import cfa.vo.iris.interop.SedServerResource;
 import cfa.vo.iris.interop.VaoMessage;
 import cfa.vo.iris.logging.LogEntry;
@@ -49,6 +48,7 @@ import org.astrogrid.samp.client.SampException;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.util.*;
 import java.util.logging.Level;
@@ -197,6 +197,20 @@ public class ExtSed extends Sed {
         Sed sed = Sed.read(filename, format);
         String[] path = filename.split(File.separator);
         String id = path[path.length - 1].split("\\.")[0];
+        return wrap(sed, id, managed);
+    }
+
+    public static ExtSed read(InputStream stream, SedFormat format) throws SedParsingException, SedInconsistentException, IOException, SedNoDataException {
+        return read(stream, format, true);
+    }
+
+    public static ExtSed read(InputStream stream, SedFormat format, boolean managed) throws SedParsingException, SedInconsistentException, IOException, SedNoDataException {
+        Sed sed = Sed.read(stream, format);
+        String id = stream.toString();
+        return wrap(sed, id, managed);
+    }
+
+    private static ExtSed wrap(Sed sed, String id, boolean managed) throws SedNoDataException, SedInconsistentException {
         ExtSed s = new ExtSed(id, managed);
         for (int i = 0; i < sed.getNumberOfSegments(); i++) {
             s.addSegment(sed.getSegment(i));

--- a/iris-common/src/test/java/cfa/vo/iris/test/unit/AbstractGUITest.java
+++ b/iris-common/src/test/java/cfa/vo/iris/test/unit/AbstractGUITest.java
@@ -41,7 +41,7 @@ public abstract class AbstractGUITest extends AbstractUISpecTest {
 
     protected Desktop desktop;
     protected Window window;
-    private ApplicationStub app;
+    protected ApplicationStub app;
     private StubAdapter adapter;
     
     @Before

--- a/iris-visualizer/pom.xml
+++ b/iris-visualizer/pom.xml
@@ -32,6 +32,12 @@
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>iris-test-data</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>iris-common</artifactId>
             <version>${project.version}</version>
             <type>test-jar</type>

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/VisualizerComponent.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/VisualizerComponent.java
@@ -27,7 +27,7 @@ public class VisualizerComponent implements IrisComponent {
     
     private IrisApplication app;
     private IWorkspace ws;
-    private List<IMenuItem> menuItems = new MenuItems();
+    private MenuItems menuItems = new MenuItems();
 
     @Override
     public void init(IrisApplication irisApplication, IWorkspace iWorkspace) {
@@ -66,6 +66,10 @@ public class VisualizerComponent implements IrisComponent {
 
     @Override
     public void shutdown() {
+    }
+
+    public PlotterView getDefaultPlotterView() {
+        return menuItems.view;
     }
 
     private class MenuItems extends ArrayList<IMenuItem> {

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
@@ -29,6 +29,8 @@ import javax.swing.JPopupMenu;
 import java.awt.Component;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.util.Collections;
+import java.util.Map;
 
 import javax.swing.JSpinner;
 import javax.swing.SpinnerListModel;
@@ -36,12 +38,16 @@ import javax.swing.plaf.basic.BasicArrowButton;
 import javax.swing.JTextField;
 import javax.swing.JCheckBox;
 import cfa.vo.iris.IrisApplication;
+import cfa.vo.iris.events.SedCommand;
+import cfa.vo.iris.events.SedEvent;
+import cfa.vo.iris.events.SedListener;
 import cfa.vo.iris.gui.GUIUtils;
 import cfa.vo.iris.gui.NarrowOptionPane;
 import cfa.vo.iris.sed.ExtSed;
 import cfa.vo.iris.sed.stil.SegmentStarTableAdapter;
 import cfa.vo.iris.sed.stil.StarTableAdapter;
 import cfa.vo.iris.visualizer.stil.StilPlotter;
+import cfa.vo.iris.visualizer.stil.preferences.SegmentLayer;
 import cfa.vo.sedlib.ISegment;
 import cfa.vo.iris.IWorkspace;
 import javax.swing.JFrame;
@@ -144,11 +150,20 @@ public class PlotterView extends JInternalFrame {
         // Action for resetting plot
         btnReset.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
-                resetPlot();
+                resetPlot(null);
             }
         });
+
+        SedEvent.getInstance().add(new PlotSedListener());
     }
 
+    public ExtSed getSed() {
+        return plotter.getSed();
+    }
+
+    public Map<ISegment, SegmentLayer> getSegmentsMap() {
+        return plotter.getSegmentsMap();
+    }
     
     private void openMetadataBrowser() throws Exception {
         if (!metadataBrowser.isVisible()) {
@@ -160,9 +175,9 @@ public class PlotterView extends JInternalFrame {
         }
     }
     
-    private void resetPlot() {
+    private void resetPlot(ExtSed sed) {
         this.metadataBrowser.reset();
-        this.plotter.reset();
+        this.plotter.reset(sed);
     }
     
     private static void addPopup(Component component, final JPopupMenu popup) {
@@ -346,5 +361,13 @@ public class PlotterView extends JInternalFrame {
         
         mntmCoplot = new JMenuItem("Coplot");
         mnView.add(mntmCoplot);
+    }
+
+    private class PlotSedListener implements SedListener {
+
+        @Override
+        public void process(ExtSed source, SedCommand payload) {
+            resetPlot(source);
+        }
     }
 }

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/VisualizerComponentTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/VisualizerComponentTest.java
@@ -73,7 +73,8 @@ public class VisualizerComponentTest extends AbstractComponentGUITest {
                 .getSubMenu(windowName)
                 .getSubMenu(windowName)
                 .click();
-        assertSame(sedManager.getSelected(), comp.getDefaultPlotterView().getSed());
+        ExtSed initialSed = sedManager.getSelected();
+        assertNull(initialSed);
 
         // Test the plotter reacts to a sed event
         final ExtSed sed = sedManager.newSed("sampleSed");
@@ -97,6 +98,27 @@ public class VisualizerComponentTest extends AbstractComponentGUITest {
                 assertTrue(comp.getDefaultPlotterView().getSegmentsMap().containsKey(segment));
             }
         });
+
+        // Just double checking this works more than once.
+        final ExtSed sed2 = sedManager.newSed("oneMoreSed");
+        // Make sure this is enqueued in the Swing EDT
+        SwingUtilities.invokeLater(new Runnable() {
+            @Override
+            public void run() {
+                assertSame(sed2, comp.getDefaultPlotterView().getSed());
+            }
+        });
+
+        // Just double checking we can go back through select
+        sedManager.select(sed);
+        // Make sure this is enqueued in the Swing EDT
+        SwingUtilities.invokeLater(new Runnable() {
+            @Override
+            public void run() {
+                assertSame(sed, comp.getDefaultPlotterView().getSed());
+            }
+        });
+
 
 //        assertEquals("sampleSed", comp.getDefaultPlotterView().getLegend().getTitle());
     }

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/VisualizerComponentTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/VisualizerComponentTest.java
@@ -15,10 +15,17 @@
  */
 package cfa.vo.iris.visualizer;
 
+import cfa.vo.iris.sed.ExtSed;
+import cfa.vo.iris.sed.SedlibSedManager;
 import cfa.vo.iris.test.unit.AbstractComponentGUITest;
 import cfa.vo.iris.IrisComponent;
+import cfa.vo.sedlib.Segment;
+import cfa.vo.sedlib.common.SedNoDataException;
 import org.junit.Before;
 import org.junit.Test;
+
+import javax.swing.*;
+
 import static org.junit.Assert.*;
 
 public class VisualizerComponentTest extends AbstractComponentGUITest {
@@ -51,5 +58,57 @@ public class VisualizerComponentTest extends AbstractComponentGUITest {
         mbButton.click();
         
         assertTrue(desktop.containsWindow("Metadata Browser").isTrue());
+    }
+
+    @Test
+    public void testEventSubscription() throws Exception {
+        SedlibSedManager sedManager = (SedlibSedManager) app.getWorkspace().getSedManager();
+
+        // No view when starting application up
+        assertNull(comp.getDefaultPlotterView());
+
+        // When the viewer button is clicked, the displayed SED should be the one selected in the SedManager
+        window.getMenuBar()
+                .getMenu("Tools")
+                .getSubMenu(windowName)
+                .getSubMenu(windowName)
+                .click();
+        assertSame(sedManager.getSelected(), comp.getDefaultPlotterView().getSed());
+
+        // Test the plotter reacts to a sed event
+        final ExtSed sed = sedManager.newSed("sampleSed");
+        // Make sure this is enqueued in the Swing EDT
+        SwingUtilities.invokeLater(new Runnable() {
+            @Override
+            public void run() {
+                assertSame(sed, comp.getDefaultPlotterView().getSed());
+            }
+        });
+
+
+        // Test the plotter reacts to a segment event (although this only requires subscribing to SedEvents)
+        final Segment segment = createSampleSegment();
+        sed.addSegment(segment);
+
+        // Make sure this is enqueued in the Swing EDT
+        SwingUtilities.invokeLater(new Runnable() {
+            @Override
+            public void run() {
+                assertTrue(comp.getDefaultPlotterView().getSegmentsMap().containsKey(segment));
+            }
+        });
+
+//        assertEquals("sampleSed", comp.getDefaultPlotterView().getLegend().getTitle());
+    }
+
+    private Segment createSampleSegment() throws SedNoDataException {
+        double[] x = new double[]{1.0, 2.0, 3.0};
+        double[] y = new double[]{1.0, 2.0, 3.0};
+        Segment segment = new Segment();
+        segment.setFluxAxisValues(y);
+        segment.setFluxAxisUnits("Jy");
+        segment.setSpectralAxisValues(x);
+        segment.setSpectralAxisUnits("Angstrom");
+        return segment;
     }
 }

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/VisualizerComponentTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/VisualizerComponentTest.java
@@ -21,10 +21,12 @@ import cfa.vo.iris.test.unit.AbstractComponentGUITest;
 import cfa.vo.iris.IrisComponent;
 import cfa.vo.sedlib.Segment;
 import cfa.vo.sedlib.common.SedNoDataException;
+import cfa.vo.sedlib.io.SedFormat;
+import cfa.vo.testdata.TestData;
 import org.junit.Before;
 import org.junit.Test;
-
 import javax.swing.*;
+import java.net.URL;
 
 import static org.junit.Assert.*;
 
@@ -121,6 +123,32 @@ public class VisualizerComponentTest extends AbstractComponentGUITest {
 
 
 //        assertEquals("sampleSed", comp.getDefaultPlotterView().getLegend().getTitle());
+    }
+
+    @Test(timeout=2500)
+    public void testReadPerformance() throws Exception {
+        URL benchmarkURL = TestData.class.getResource("test300k_VO.fits");
+        final ExtSed sed = ExtSed.read(benchmarkURL.openStream(), SedFormat.FITS);
+        SedlibSedManager manager = (SedlibSedManager) app.getWorkspace().getSedManager();
+        manager.add(sed);
+
+        SwingUtilities.invokeLater(new Runnable() {
+            @Override
+            public void run() {
+                window.getMenuBar()
+                        .getMenu("Tools")
+                        .getSubMenu(windowName)
+                        .getSubMenu(windowName)
+                        .click();
+            }
+        });
+
+        SwingUtilities.invokeLater(new Runnable() {
+            @Override
+            public void run() {
+                assertSame(sed, comp.getDefaultPlotterView().getSed());
+            }
+        });
     }
 
     private Segment createSampleSegment() throws SedNoDataException {

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
         <module>test-components</module>
         <module>sed-builder</module>
         <module>iris-visualizer</module>
+        <module>iris-test-data</module>
     </modules>
 
     <!-- 

--- a/sed-builder/src/main/java/cfa/vo/sed/gui/LoadSegmentFrame.java
+++ b/sed-builder/src/main/java/cfa/vo/sed/gui/LoadSegmentFrame.java
@@ -64,15 +64,11 @@ import javax.swing.DefaultComboBoxModel;
 import javax.swing.JFileChooser;
 import javax.swing.JInternalFrame;
 import javax.swing.JList;
-import javax.swing.JOptionPane;
 import javax.swing.plaf.basic.BasicComboBoxRenderer;
 import org.jdesktop.application.Action;
 import org.jdesktop.application.Task;
 
-/**
- *
- * @author olaurino
- */
+
 public final class LoadSegmentFrame extends JInternalFrame {
 
     private ISedManager<ExtSed> manager;
@@ -717,31 +713,6 @@ public final class LoadSegmentFrame extends JInternalFrame {
         GUIUtils.moveToFront(this);
     }
 
-    private void spectralWarningCheck(Segment seg) throws SedInconsistentException, SedNoDataException {
-	int numOfPoints = spectraWarning(seg);
-	if(numOfPoints < 2500 && numOfPoints > 1000) {
-	    sed.addSegment(seg);
-	    NarrowOptionPane.showMessageDialog(this, 
-		    "Over 1000 data points. Viewer may be slightly slower than usual", 
-		    "", 
-		    NarrowOptionPane.INFORMATION_MESSAGE);
-	}
-	else if(numOfPoints > 2500) {
-	    int answer = NarrowOptionPane.showConfirmDialog(this, 
-		    "Over 2500 data points. Viewer may be slow. Do you want to continue import?", 
-		    "", 
-		    NarrowOptionPane.YES_NO_OPTION);
-	    if (answer == JOptionPane.NO_OPTION) {
-		return;
-	    } else {
-		sed.addSegment(seg);
-	    }
-	}
-	else {
-	    sed.addSegment(seg);
-	}
-    }
-
     private class FormatRenderer extends BasicComboBoxRenderer {
 
         @Override
@@ -785,41 +756,6 @@ public final class LoadSegmentFrame extends JInternalFrame {
         List<Integer> unsuc = readCompliant();
 
         try {
-	    
-	    /* Spectra warning. If there are 1000 < points < 2500, just warn user that
-	    * visualizer may be slow.
-	    * If there are over 2500 points, give user decision to add to Iris or not.
-	    */
-	    int numOfPoints = format.getFilter(getURL()).getColumnData(0,0).length;
-	    if(numOfPoints < 2500 && numOfPoints > 1000) {
-		NarrowOptionPane.showMessageDialog(this, 
-			"There are over 1000 data points in this file.\n"+
-				"Visualization tools may be slightly slower than usual for this SED.", 
-			"Large File Detected", 
-			NarrowOptionPane.INFORMATION_MESSAGE);
-	    }
-	    else if(numOfPoints > 2500) {
-		int answer = NarrowOptionPane.showOptionDialog(this, 
-			"The number of data points exceeds the limit supported by Iris visualization tools (number of points detected: "+String.valueOf(numOfPoints)+").\n"+
-			//"There are over 2500 points in this file (number detected: "+String.valueOf(numOfPoints)+").\n"+
-				//"Iris visualization tools do not support spectra, meaning"+
-				"Visualization tools will be slow for this SED.\n\n"+
-				"Do you want to continue import?", 
-			"Large Segment Detected", 
-			NarrowOptionPane.YES_NO_OPTION, 
-			NarrowOptionPane.WARNING_MESSAGE, null, new String[]{"Yes", "No"}, "No");
-		if (answer == JOptionPane.NO_OPTION) {
-		    return;
-		}
-//			    } else if (numOfPoints > 7500) {
-//				int answer = NarrowOptionPane.showConfirmDialog(this, 
-//					"There are over 7500 data points in this file. The Viewer and Fitting Tool WILL be slow for this SED! \nDo you want to continue import?", 
-//					"Large File Detected", 
-//					NarrowOptionPane.YES_NO_OPTION);
-//				if (answer == JOptionPane.YES_OPTION) {
-//				}
-	    }
-	    
             if (unsuc != null) {
                 if (!segList.isEmpty()) {
 //                    for (Segment seg : segList) {
@@ -861,7 +797,7 @@ public final class LoadSegmentFrame extends JInternalFrame {
                 try {
                     SetupBean conf = new AsciiConf().makeConf(getURL());
                     Segment seg = SegmentImporter.getSegments(conf).get(0);
-		    
+
                     sed.addSegment(seg);
                 } catch (Exception ex) {
                     SetupBean conf = new SetupBean();
@@ -1088,35 +1024,9 @@ public final class LoadSegmentFrame extends JInternalFrame {
     public void loadCatalog() {
         segList = new ArrayList();
         List<Integer> unsuc = readCompliant();
-	
+
         try {
-	    
-	    /* Spectra warning. If there are 1000 < points < 2500, just warn user that
-	    * visualizer may be slow.
-	    * If there are over 2500 points, give user decision to add to Iris or not.
-	    */
-	    int numOfPoints = format.getFilter(getURL()).getColumnData(0,0).length;
-	    if(numOfPoints < 2500 && numOfPoints > 1000) {
-		NarrowOptionPane.showMessageDialog(this, 
-			"There are over 1000 data points in this file.\n"+
-				"Visualization tools may be slightly slower than usual for this SED.", 
-			"Large File Detected", 
-			NarrowOptionPane.INFORMATION_MESSAGE);
-	    } else if(numOfPoints > 2500) {
-		int answer = NarrowOptionPane.showOptionDialog(this, 
-			"The number of data points exceeds the limit supported by Iris visualization tools (number of points detected: "+String.valueOf(numOfPoints)+").\n"+
-			//"There are over 2500 points in this file (number detected: "+String.valueOf(numOfPoints)+").\n"+
-				//"Iris visualization tools do not support spectra, meaning"+
-				"Visualization tools will be slow for this SED.\n\n"+
-				"Do you want to continue import?",
-			"Large Segment Detected", 
-			NarrowOptionPane.YES_NO_OPTION, 
-			NarrowOptionPane.WARNING_MESSAGE, null, new String[]{"Yes", "No"}, "No");
-		if (answer == JOptionPane.NO_OPTION) {
-		    return;
-		}
-	    }
-	    
+
             if (unsuc != null) {
                 if (!segList.isEmpty()) {		    
                     for (Segment seg : segList) {
@@ -1152,7 +1062,7 @@ public final class LoadSegmentFrame extends JInternalFrame {
                         if (!(filter instanceof AbstractSingleStarTableFilter)) {
                             throw new Exception("Plugins are not supported yet for Photometry Catalogs. Only native file formats are supported");
                         }
-			
+
                         PhotometryCatalogBuilder conf = new PhotometryCatalogBuilder((AbstractSingleStarTableFilter) filter, sed, i);
                         PhotometryCatalogFrame frame = new PhotometryCatalogFrame(conf);
 
@@ -1168,7 +1078,7 @@ public final class LoadSegmentFrame extends JInternalFrame {
                 if (!(filter instanceof AbstractSingleStarTableFilter)) {
                     throw new Exception("Plugins are not supported yet for Photometry Catalogs. Only native file formats are supported");
                 }
-		
+
                 PhotometryCatalogBuilder conf = new PhotometryCatalogBuilder((AbstractSingleStarTableFilter) filter, sed, 0);
                 PhotometryCatalogFrame frame = new PhotometryCatalogFrame(conf);
 
@@ -1182,22 +1092,6 @@ public final class LoadSegmentFrame extends JInternalFrame {
             Logger.getLogger(LoadSegmentFrame.class.getName()).log(Level.SEVERE, "", ex);
             NarrowOptionPane.showMessageDialog(this, "An error occurred. Please check the file", "Error", NarrowOptionPane.ERROR_MESSAGE);
         }
-    }
-    
-    /* Given a list of Segments, returns the number of data points in all the
-     * Segments.
-     */
-    private int spectraWarning(List<Segment> segList) {
-        int numOfPoints = 0;
-        
-	for (Segment segList1 : segList) {
-	    numOfPoints += segList1.getLength();
-	}
-        
-        return numOfPoints;
-    }
-    private int spectraWarning(Segment seg) {
-            return seg.getLength();
     }
     
 }

--- a/sed-builder/src/main/java/cfa/vo/sed/gui/SampChooser.java
+++ b/sed-builder/src/main/java/cfa/vo/sed/gui/SampChooser.java
@@ -30,9 +30,7 @@ import cfa.vo.iris.IWorkspace;
 import cfa.vo.iris.gui.NarrowOptionPane;
 import cfa.vo.iris.sed.ExtSed;
 import cfa.vo.iris.sed.SedlibSedManager;
-import cfa.vo.sed.builder.SedBuilder;
 import cfa.vo.sed.filters.AbstractSingleStarTableFilter;
-import cfa.vo.sed.filters.IFileFormat;
 import cfa.vo.sed.filters.NativeFileFormat;
 import cfa.vo.sed.setup.PhotometryCatalogBuilder;
 import cfa.vo.sed.setup.SetupBean;
@@ -40,13 +38,8 @@ import java.net.URL;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.ImageIcon;
-import javax.swing.JOptionPane;
 import org.jdesktop.application.Action;
 
-/**
- *
- * @author olaurino
- */
 public class SampChooser extends javax.swing.JInternalFrame {
 
     private IWorkspace workspace;
@@ -178,34 +171,7 @@ public class SampChooser extends javax.swing.JInternalFrame {
     public void importCatalog() {
         try {
             AbstractSingleStarTableFilter filter = (AbstractSingleStarTableFilter) NativeFileFormat.valueOf(formatName).getFilter(url);
-	    
-	    /* Spectra warning. If there are 1000 < points < 2500, just warn user that
-	    * visualizer may be slow.
-	    * If there are over 2500 points, give user decision to add to Iris or not.
-	    */
-	    int numOfPoints = filter.getColumnData(0, 0).length;
-	    if(numOfPoints < 2500 && numOfPoints > 1000) {
-		NarrowOptionPane.showMessageDialog(this, 
-			"There are over 1000 data points in this file.\n"+
-				"Visualization tools may be slightly slower than usual for this SED.", 
-			"Large Segment Detected", 
-			NarrowOptionPane.INFORMATION_MESSAGE);
-	    }
-	    else if(numOfPoints > 2500) {
-		int answer = NarrowOptionPane.showOptionDialog(this, 
-			"The number of data points exceeds the limit supported by Iris visualization tools (number of points detected: "+String.valueOf(numOfPoints)+").\n"+
-			//"There are over 2500 points in this file (number detected: "+String.valueOf(numOfPoints)+").\n"+
-				//"Iris visualization tools do not support spectra, meaning"+
-				"Visualization tools will be slow for this SED.\n\n"+
-				"Do you want to continue import?", 
-			"Large Segment Detected", 
-			NarrowOptionPane.YES_NO_OPTION, 
-			NarrowOptionPane.WARNING_MESSAGE, null, new String[]{"Yes", "No"}, "No");
-		if (answer == JOptionPane.NO_OPTION) {
-		    return;
-		}
-	    }
-	    
+
             PhotometryCatalogFrame catFrame = new PhotometryCatalogFrame(new PhotometryCatalogBuilder(filter, sed, 0));
             workspace.addFrame(catFrame);
             catFrame.setVisible(true);
@@ -232,34 +198,7 @@ public class SampChooser extends javax.swing.JInternalFrame {
     @Action
     public void importSpectrum() {
         try {
-	    
-	    /* Spectra warning. If there are 1000 < points < 2500, just warn user that
-	    * visualizer may be slow.
-	    * If there are over 2500 points, give user decision to add to Iris or not.
-	    */
-	    int numOfPoints = NativeFileFormat.valueOf(formatName).getFilter(url).getColumnData(0,0).length;
-	    if(numOfPoints < 2500 && numOfPoints > 1000) {
-		NarrowOptionPane.showMessageDialog(this, 
-			"There are over 1000 data points in this file.\n"+
-				"Visualization tools may be slightly slower than usual for this SED.", 
-			"Large Segment Detected", 
-			NarrowOptionPane.INFORMATION_MESSAGE);
-	    }
-	    else if(numOfPoints > 2500) {
-		int answer = NarrowOptionPane.showOptionDialog(this,
-			"The number of data points exceeds the limit supported by Iris visualization tools (number of points detected: "+String.valueOf(numOfPoints)+").\n"+
-			//"There are over 2500 points in this file (number detected: "+String.valueOf(numOfPoints)+").\n"+
-				//"Iris visualization tools do not support spectra, meaning"+
-				"Visualization tools will be slow for this SED.\n\n"+
-				"Do you want to continue import?", 
-			"Large Segment Detected", 
-			NarrowOptionPane.YES_NO_OPTION, 
-			NarrowOptionPane.WARNING_MESSAGE, null, new String[]{"Yes", "No"}, "No");
-		if (answer == JOptionPane.NO_OPTION) {
-		    return;
-		}
-	    }
-	    
+
             SetupBean c = new SetupBean();
             c.setPositionInFile(0);
             c.setFileLocation(url.toString());


### PR DESCRIPTION
Resolve #239.

# Description
This PR introduces a simple benchmark assessing SEDs can be loaded and displayed in a reasonable amount of time.

This PR relies on a new git repository for the test data, so to reduce the footprint of the main repository.

The benchmark relies on a simple annotation from JUnit which will fail the test if it takes longer than a timeout. The timeout keeps into account the test setup time, so some heuristics were used to determine a reasonable timeout of 2500 milliseconds. Interactive testing was performed to ensure that the system is responsive.

We can use something fancier or try to roll our own benchmark logic if required.

I also had to remove some code that was added to warn the users when too large files were loaded. 

Plus, since SEDLib does not handle URLs directly, I overrode the `read` method in `ExtSed` to make the tests more portable (they were failing depending on the way they were called).

# Notes
The test is not particularly safe because there is currently no way to test whether the plot was actually displayed.

# Dependencies
This PR depends on #224 because I needed at least a naive way of checking that the plotter updated itself to plot the new sed. So, this PR should be rebased and merged after #224.