### PR TITLE
iris-dev#20 Flatten StarTable

### DIFF
--- a/iris-common/src/main/java/cfa/vo/iris/sed/stil/StilColumnManager.java
+++ b/iris-common/src/main/java/cfa/vo/iris/sed/stil/StilColumnManager.java
@@ -36,11 +36,9 @@ public class StilColumnManager {
         return new FlattenedStarTable(tables);
     }
 
-    public static int getColumnIndex(StarTable table, String utype) {
+    public static int getColumnIndex(StarTable table, ColumnInfo info) {
         for (int i=0; i<table.getColumnCount(); i++) {
-            UTYPE required = new UTYPE(utype);
-            UTYPE found = new UTYPE(table.getColumnInfo(i).getUtype());
-            if (required.equals(found)) {
+            if (ColumnInfoIndex.sameId(info, table.getColumnInfo(i))) {
                 return i;
             }
         }
@@ -191,10 +189,8 @@ public class StilColumnManager {
         private List<Object[]> readData(StarTable... tables) throws IOException {
             List<Object[]> retValue = new ArrayList<>();
 
-//            Map<ColumnInfo, List<Object>> map = new HashMap<>();
             for (ColumnInfo info : index.getValues()) {
                 List<Object> arrayList = new ArrayList<>();
-//                map.put(info, arrayList);
                 tableLoop:
                 for (StarTable t : tables) {
                     for (int i=0; i<t.getColumnCount(); i++) {

--- a/iris-common/src/main/java/cfa/vo/iris/sed/stil/StilColumnManager.java
+++ b/iris-common/src/main/java/cfa/vo/iris/sed/stil/StilColumnManager.java
@@ -1,0 +1,209 @@
+package cfa.vo.iris.sed.stil;
+
+import uk.ac.starlink.table.*;
+
+import java.io.IOException;
+import java.security.KeyException;
+import java.util.*;
+
+public class StilColumnManager {
+    private ColumnInfoIndex index = new ColumnInfoIndex();
+
+    /**
+     * Generate ColumnInfos for a series of StarTables. The resulting array can be used to create a new table
+     * that concatenates and joins different tables.
+     *
+     * ColumnInfos are guaranteed to have different IDs.
+     *
+     * ColumnInfos without ID are not included.
+     *
+     * @param tables The tables that are to be joined
+     * @return An Array of ColumnInfo objects representing the Columns of a table concatenation of the input tables.
+     */
+    public ColumnInfo[] extractColumns(StarTable... tables) {
+        for (StarTable t : tables) {
+            ColumnInfo[] infos = Tables.getColumnInfos(t);
+            for (ColumnInfo i : infos) {
+                index.put(i);
+            }
+        }
+
+        return index.getValues().toArray(new ColumnInfo[]{});
+
+    }
+
+    public ColumnStarTable flatten(StarTable... tables) throws IOException {
+        return new FlattenedStarTable(tables);
+    }
+
+    public static int getColumnIndex(StarTable table, String utype) {
+        for (int i=0; i<table.getColumnCount(); i++) {
+            if (utype.equals(table.getColumnInfo(i).getUtype())) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Class for managing indexes of ColumnInfos templates, with keys that depend on the metadata available for the info.
+     *
+     * The ID of a ColumnInfo is its utype if available, otherwise it is its name.
+     */
+    public static class ColumnInfoIndex {
+        private Map<String, ColumnInfo> infosMap = new TreeMap<>();
+
+        /**
+         * get the ColumnInfo template for a specific ID
+         * @param id the ID
+         * @return A ColumnInfo instance if available
+         * @throws KeyException when no ColumnInfos in the index have that ID.
+         */
+        public ColumnInfo get(String id) throws KeyException {
+            if(infosMap.containsKey(id)) {
+                return infosMap.get(id);
+            }
+            throw new KeyException("Key "+ id + " not in index");
+        }
+
+        /**
+         * return whether the index contains an info with the same ID as the argument.
+         * Note that not necessarily the ColumnInfo provided as argument and the one in the index are equals.
+         * This call simply checks if a ColumnInfo (template) with the same ID as the argument is in the index.
+         *
+         * @param info The ColumnInfo object to check
+         * @return true if a ColumnInfo with the same ID is in the index, false otherwise.
+         */
+        public Boolean hasInfo(ColumnInfo info) {
+            return containsId(info);
+        }
+
+        /**
+         * put info in index. The operation will be actually performed only if there is no ColumnInfo template
+         * with the same ID in the index. The return value informs the client whether the operation happened or not.
+         *
+         * If the instance does not have a valid ID (e.g. an empty string as name and no utype) then the operation
+         * is not performed either.
+         *
+         * @param info the ColumnInfo instance to add to the index
+         * @return true if the operation was performed, i.e. if no ColumnInfo with the same ID was found in the index,
+         * false, if a ColumnInfo template with the same ID was found, so the argument was not inserted.
+         */
+        public Boolean put(ColumnInfo info) {
+            if (!getId(info).isEmpty() && !containsId(info)) {
+                doPut(info);
+                return Boolean.TRUE;
+            }
+            return Boolean.FALSE;
+        }
+
+        /**
+         * return an unmodifiable Collection of the ColumnInfo instances in this index.
+         * @return an unmodifiable Collections of ColumnInfo instances.
+         */
+        public Collection<ColumnInfo> getValues() {
+            return Collections.unmodifiableCollection(infosMap.values());
+        }
+
+        private Boolean containsId(ColumnInfo info) {
+            String id = getId(info);
+            if (!id.isEmpty() && infosMap.containsKey(id)) {
+                return Boolean.TRUE;
+            }
+            return Boolean.FALSE;
+        }
+
+        private void doPut(ColumnInfo info) {
+            String id = getId(info);
+            infosMap.put(id, info);
+        }
+
+        private static String getId(ColumnInfo info) {
+            String utype = info.getUtype();
+
+            if (utype != null && !utype.isEmpty()) {
+                return utype;
+            }
+
+            String name = info.getName();
+
+            if (name != null && !name.isEmpty()) {
+                return name;
+            }
+
+            return "";
+        }
+
+        /**
+         * check that two ColumnInfo instances have the same ID.
+         * @param info1
+         * @param info2
+         * @return
+         */
+        public static boolean sameId(ColumnInfo info1, ColumnInfo info2) {
+            return getId(info1).equals(getId(info2));
+        }
+    }
+
+    private class FlattenedStarTable extends uk.ac.starlink.table.ColumnStarTable {
+        private long nRows;
+
+        public FlattenedStarTable(StarTable... tables) throws IOException {
+            ColumnInfo[] infos = extractColumns(tables);
+            int nCols = infos.length;
+
+            long nRows = 0;
+            for (StarTable t : tables) {
+                nRows += t.getRowCount();
+            }
+            this.nRows = nRows;
+
+            List<Object[]> dataMatrix = readData(tables);
+
+            for (int i=0; i<nCols; i++) {
+                ColumnInfo info = infos[i];
+                ColumnData column;
+                if (info.getContentClass().isPrimitive()) {
+                    // It does not look like this is even possible, see:
+                    // http://www.star.bristol.ac.uk/~mbt/stil/javadocs/uk/ac/starlink/table/ValueInfo.html#getContentClass%28%29
+                    column = PrimitiveArrayColumn.makePrimitiveColumn(info, dataMatrix.get(i));
+                } else {
+                    column = new ObjectArrayColumn(info, dataMatrix.get(i));
+                }
+                this.addColumn(column);
+            }
+        }
+
+        @Override
+        public long getRowCount() {
+            return nRows;
+        }
+
+        private List<Object[]> readData(StarTable... tables) throws IOException {
+            List<Object[]> retValue = new ArrayList<>();
+
+            Map<ColumnInfo, List<Object>> map = new HashMap<>();
+            for (ColumnInfo info : index.getValues()) {
+                List<Object> arrayList = new ArrayList<>();
+                map.put(info, arrayList);
+                tableLoop:
+                for (StarTable t : tables) {
+                    for (int i=0; i<t.getColumnCount(); i++) {
+                        if (ColumnInfoIndex.sameId(info, t.getColumnInfo(i))) {
+                            for (long j = 0; j < t.getRowCount(); j++) {
+                                arrayList.add(t.getCell(j, i));
+                            }
+                            continue tableLoop;
+                        }
+                    }
+                    int tableRows = Tables.checkedLongToInt(t.getRowCount());
+                    Object[] tableArray = new Object[tableRows];
+                    Arrays.fill(tableArray, null); // Not sure this is necessary, in any case this is not the final implementation.
+                    arrayList.addAll(Arrays.asList(tableArray));
+                }
+                retValue.add(arrayList.toArray());
+            }
+            return retValue;
+        }
+    }
+}

--- a/iris-common/src/main/java/cfa/vo/iris/sed/stil/StilColumnManager.java
+++ b/iris-common/src/main/java/cfa/vo/iris/sed/stil/StilColumnManager.java
@@ -1,9 +1,9 @@
 package cfa.vo.iris.sed.stil;
 
+import cfa.vo.iris.utils.UTYPE;
 import uk.ac.starlink.table.*;
 
 import java.io.IOException;
-import java.security.KeyException;
 import java.util.*;
 
 public class StilColumnManager {
@@ -38,7 +38,9 @@ public class StilColumnManager {
 
     public static int getColumnIndex(StarTable table, String utype) {
         for (int i=0; i<table.getColumnCount(); i++) {
-            if (utype.equals(table.getColumnInfo(i).getUtype())) {
+            UTYPE required = new UTYPE(utype);
+            UTYPE found = new UTYPE(table.getColumnInfo(i).getUtype());
+            if (required.equals(found)) {
                 return i;
             }
         }
@@ -57,13 +59,16 @@ public class StilColumnManager {
          * get the ColumnInfo template for a specific ID
          * @param id the ID
          * @return A ColumnInfo instance if available
-         * @throws KeyException when no ColumnInfos in the index have that ID.
+         * @throws NoSuchElementException when no ColumnInfos in the index have that ID.
          */
-        public ColumnInfo get(String id) throws KeyException {
+        public ColumnInfo get(String id) throws NoSuchElementException {
+            // this works with utypes and names, might not work with other stuff we may add in the future
+            id = buildId(id);
+
             if(infosMap.containsKey(id)) {
                 return infosMap.get(id);
             }
-            throw new KeyException("Key "+ id + " not in index");
+            throw new NoSuchElementException("Key "+ id + " not in index");
         }
 
         /**
@@ -105,6 +110,10 @@ public class StilColumnManager {
             return Collections.unmodifiableCollection(infosMap.values());
         }
 
+        private static String buildId(String id) {
+            return new UTYPE(id).getMain();
+        }
+
         private Boolean containsId(ColumnInfo info) {
             String id = getId(info);
             if (!id.isEmpty() && infosMap.containsKey(id)) {
@@ -122,7 +131,7 @@ public class StilColumnManager {
             String utype = info.getUtype();
 
             if (utype != null && !utype.isEmpty()) {
-                return utype;
+                return buildId(utype);
             }
 
             String name = info.getName();
@@ -182,10 +191,10 @@ public class StilColumnManager {
         private List<Object[]> readData(StarTable... tables) throws IOException {
             List<Object[]> retValue = new ArrayList<>();
 
-            Map<ColumnInfo, List<Object>> map = new HashMap<>();
+//            Map<ColumnInfo, List<Object>> map = new HashMap<>();
             for (ColumnInfo info : index.getValues()) {
                 List<Object> arrayList = new ArrayList<>();
-                map.put(info, arrayList);
+//                map.put(info, arrayList);
                 tableLoop:
                 for (StarTable t : tables) {
                     for (int i=0; i<t.getColumnCount(); i++) {

--- a/iris-common/src/main/java/cfa/vo/iris/utils/UTYPE.java
+++ b/iris-common/src/main/java/cfa/vo/iris/utils/UTYPE.java
@@ -1,8 +1,66 @@
 package cfa.vo.iris.utils;
 
-/**
- * Created by olaurino on 10/28/15.
- */
+
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
 public class UTYPE {
+    String prefix;
+    String main;
+
     public final static String FLUX_STAT_ERROR = "Spectrum.Data.FluxAxis.Accuracy.StatError";
+
+    public UTYPE(String utypeString) {
+        if (utypeString == null || utypeString.isEmpty()) {
+            throw new IllegalArgumentException("UTYPE needs a non null, non empty string");
+        }
+
+        if (utypeString.contains(":")) {
+            String[] tokens = utypeString.split(":");
+            prefix = tokens[0].toLowerCase();
+            main = tokens[1].toLowerCase();
+        } else {
+            main = utypeString.toLowerCase();
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+
+        if (o == null || getClass() != o.getClass()) return false;
+
+        UTYPE utype = (UTYPE) o;
+
+        return new EqualsBuilder()
+                .append(main, utype.main)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37)
+                .append(main)
+                .toHashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "UTYPE{" +
+                "prefix='" + prefix + '\'' +
+                ", main='" + main + '\'' +
+                '}';
+    }
+
+    public String getCanonicalString() {
+        String p = "";
+        if(prefix != null) {
+            p = prefix+":";
+        }
+        return p+main;
+    }
+
+    public String getMain() {
+        return main;
+    }
 }

--- a/iris-common/src/main/java/cfa/vo/iris/utils/UTYPE.java
+++ b/iris-common/src/main/java/cfa/vo/iris/utils/UTYPE.java
@@ -9,8 +9,8 @@ public class UTYPE {
     String main;
 
     public final static String FLUX_STAT_ERROR = "Spectrum.Data.FluxAxis.Accuracy.StatError";
-    public final static String SPECTRAL_VALUES = "Data.SpectralAxis.Value";
-    public final static String FLUX_VALUES = "Data.FluxAxis.Value";
+    public final static String SPECTRAL_VALUES = "Spectrum.Data.SpectralAxis.Value";
+    public final static String FLUX_VALUES = "Spectrum.Data.FluxAxis.Value";
 
     public UTYPE(String utypeString) {
         if (utypeString == null || utypeString.isEmpty()) {

--- a/iris-common/src/main/java/cfa/vo/iris/utils/UTYPE.java
+++ b/iris-common/src/main/java/cfa/vo/iris/utils/UTYPE.java
@@ -15,6 +15,8 @@ public class UTYPE {
             throw new IllegalArgumentException("UTYPE needs a non null, non empty string");
         }
 
+        utypeString = utypeString.replaceAll("(?i)spectrum.", "");
+
         if (utypeString.contains(":")) {
             String[] tokens = utypeString.split(":");
             prefix = tokens[0].toLowerCase();

--- a/iris-common/src/main/java/cfa/vo/iris/utils/UTYPE.java
+++ b/iris-common/src/main/java/cfa/vo/iris/utils/UTYPE.java
@@ -9,6 +9,8 @@ public class UTYPE {
     String main;
 
     public final static String FLUX_STAT_ERROR = "Spectrum.Data.FluxAxis.Accuracy.StatError";
+    public final static String SPECTRAL_VALUES = "Data.SpectralAxis.Value";
+    public final static String FLUX_VALUES = "Data.FluxAxis.Value";
 
     public UTYPE(String utypeString) {
         if (utypeString == null || utypeString.isEmpty()) {

--- a/iris-common/src/test/java/cfa/vo/iris/sed/stil/FlattenMultipleStarTablesTest.java
+++ b/iris-common/src/test/java/cfa/vo/iris/sed/stil/FlattenMultipleStarTablesTest.java
@@ -1,0 +1,166 @@
+package cfa.vo.iris.sed.stil;
+
+import org.junit.Before;
+import org.junit.Test;
+import uk.ac.starlink.table.*;
+import uk.ac.starlink.ttools.filter.AssertException;
+
+import java.security.KeyException;
+import java.util.Collection;
+
+import static org.junit.Assert.*;
+
+public class FlattenMultipleStarTablesTest {
+    private ColumnStarTable table1;
+    private ColumnStarTable table2;
+    private final double[] SPECTRAL = {1.0, 1.1, 1.2};
+    private final double[] FLUX = {2.0, 2.1, 2.2};
+    private final String[] STRING = {"One", "Two", "Three"};
+    private final String SPECTRAL_NAME = "spectral";
+    private final String FLUX_NAME = "flux";
+    private final String STRING_NAME = "stringField";
+    private final String SPECTRAL_UTYPE = "test:spectral";
+    private final String FLUX_UTYPE = "test:flux";
+    private final String STRING_UTYPE = "test:string";
+    private final StilColumnManager manager = new StilColumnManager();
+
+    @Before
+    public void setUp() {
+        ColumnInfo info11 = new ColumnInfo(SPECTRAL_NAME, Double.class, "");
+        info11.setUtype(SPECTRAL_UTYPE);
+        ColumnData columnSpectral1 = PrimitiveArrayColumn.makePrimitiveColumn(info11, SPECTRAL);
+        ColumnInfo info12 = new ColumnInfo(FLUX_NAME, Double.class, "");
+        info12.setUtype(FLUX_UTYPE);
+        ColumnData columnFlux1 = PrimitiveArrayColumn.makePrimitiveColumn(info12, FLUX);
+
+        ColumnInfo info21 = new ColumnInfo(SPECTRAL_NAME, Double.class, "");
+        info21.setUtype(SPECTRAL_UTYPE);
+        ColumnData columnSpectral2 = PrimitiveArrayColumn.makePrimitiveColumn(info21, SPECTRAL);
+        ColumnInfo info22 = new ColumnInfo(FLUX_NAME, Double.class, "");
+        info22.setUtype(FLUX_UTYPE);
+        ColumnData columnFlux2 = PrimitiveArrayColumn.makePrimitiveColumn(info22, FLUX);
+        ColumnInfo info23 = new ColumnInfo(STRING_NAME, String.class, "");
+        info23.setUtype(STRING_UTYPE);
+        ColumnData columnString2 = new ObjectArrayColumn(info23, STRING);
+
+        table1 = new ColumnStarTable() {
+            @Override
+            public long getRowCount() {
+                return 3;
+            }
+        };
+        table1.addColumn(columnSpectral1);
+        table1.addColumn(columnFlux1);
+
+        table2 = new ColumnStarTable() {
+            @Override
+            public long getRowCount() {
+                return 3;
+            }
+        };
+        table2.addColumn(columnFlux2);
+        table2.addColumn(columnString2);
+        table2.addColumn(columnSpectral2);
+    }
+
+    @Test
+    public void testExtractColumns() throws Exception {
+        // Tables have two columns with the same utype, plus one column with a third utype.
+        // Columns extracted from the two tables should be a set of three columnInfo with three different utypes
+        ColumnInfo[] columnInfos = manager.extractColumns(table1, table2);
+        assertEquals(3, columnInfos.length);
+
+        // We are assuming a TreeMap implementation in index, so keys are sorted alphabetically.
+        assertEquals(FLUX_UTYPE, columnInfos[0].getUtype());
+        assertEquals(SPECTRAL_UTYPE, columnInfos[1].getUtype());
+        assertEquals(STRING_UTYPE, columnInfos[2].getUtype());
+    }
+
+    @Test
+    public void testStarTableFlatten() throws Exception {
+        ColumnStarTable table = manager.flatten(table1, table2);
+
+        assertEquals(3, table.getColumnCount());
+        assertEquals(6, table.getRowCount());
+
+        // assuming specific implementation is ArrayColumn
+        int spectralIndex = StilColumnManager.getColumnIndex(table, SPECTRAL_UTYPE);
+        Object[] spectral = (Object[])((ArrayColumn)table.getColumnData(spectralIndex)).getArray();
+        assertArrayEquals(new Double[]{1.0, 1.1, 1.2, 1.0, 1.1, 1.2}, spectral);
+
+        int fluxIndex = StilColumnManager.getColumnIndex(table, FLUX_UTYPE);
+        Object[] flux = (Object[]) ((ArrayColumn)table.getColumnData(fluxIndex)).getArray();
+        assertArrayEquals(new Double[]{2.0, 2.1, 2.2, 2.0, 2.1, 2.2}, flux);
+
+        int stringIndex = StilColumnManager.getColumnIndex(table, STRING_UTYPE);
+        Object[] string = (Object[])((ArrayColumn)table.getColumnData(stringIndex)).getArray();
+        assertArrayEquals(new String[]{null, null, null, "One", "Two", "Three"}, string);
+    }
+
+    @Test
+    public void testInfoIndex() throws Exception {
+        StilColumnManager.ColumnInfoIndex index = new StilColumnManager.ColumnInfoIndex();
+        ColumnInfo info = new ColumnInfo(SPECTRAL_NAME);
+        ColumnInfo info2 = new ColumnInfo(STRING_NAME);
+        info2.setUtype(STRING_UTYPE);
+
+        assertTrue(index.put(info));
+
+        assertTrue(index.hasInfo(info));
+
+        // Should return false because info2 does not have either name or utype matching those of info
+        assertFalse(index.hasInfo(info2));
+
+        assertTrue(index.put(info2));
+
+        assertTrue(index.hasInfo(info2));
+
+        ColumnInfo info3 = new ColumnInfo(FLUX_NAME);
+        info3.setUtype(STRING_UTYPE);
+
+        // Should return true because utype is the same, even if we did not add info3 to the index;
+        assertTrue(index.hasInfo(info3));
+
+        // Should return false because a slot with this ID is already taken
+        assertFalse(index.put(info3));
+
+        assertSame(info, index.get(SPECTRAL_NAME));
+        assertSame(info2, index.get(STRING_UTYPE));
+
+        try {
+            index.get(STRING_NAME);
+            throw new AssertException("should have failed");
+        } catch (KeyException e) {
+            // should throw exception because STRING_NAME is not an ID for any of the infos in the index
+        }
+
+        ColumnInfo info4 = new ColumnInfo(STRING_NAME);
+        info4.setUtype(FLUX_UTYPE);
+        // should return false because even though it has the same name as info2, they do not have the same utype
+        assertFalse(index.hasInfo(info4));
+
+        ColumnInfo info5 = new ColumnInfo("");
+        // ColumnInfos with empty names and no utypes are not acceptable. There is no means to compare their semantic content.
+        assertFalse(index.put(info5));
+        // should return false because even though it has the same name as info2, they do not have the same utype
+        assertFalse(index.hasInfo(info5));
+
+        Collection<ColumnInfo> infos = index.getValues();
+        assertEquals(2, infos.size());
+        assertTrue(infos.contains(info));
+        assertTrue(infos.contains(info2));
+
+        assertTrue(StilColumnManager.ColumnInfoIndex.sameId(info2, info3));
+        assertFalse(StilColumnManager.ColumnInfoIndex.sameId(info, info2));
+    }
+
+    @Test
+    public void testGetColumnIndex() throws Exception {
+        assertEquals(0, StilColumnManager.getColumnIndex(table1, SPECTRAL_UTYPE));
+        assertEquals(1, StilColumnManager.getColumnIndex(table1, FLUX_UTYPE));
+        assertEquals(-1, StilColumnManager.getColumnIndex(table1, STRING_UTYPE));
+        assertEquals(0, StilColumnManager.getColumnIndex(table2, FLUX_UTYPE));
+        assertEquals(2, StilColumnManager.getColumnIndex(table2, SPECTRAL_UTYPE));
+        assertEquals(1, StilColumnManager.getColumnIndex(table2, STRING_UTYPE));
+    }
+}

--- a/iris-common/src/test/java/cfa/vo/iris/sed/stil/FlattenMultipleStarTablesTest.java
+++ b/iris-common/src/test/java/cfa/vo/iris/sed/stil/FlattenMultipleStarTablesTest.java
@@ -37,7 +37,8 @@ public class FlattenMultipleStarTablesTest {
         ColumnInfo info21 = new ColumnInfo(SPECTRAL_NAME, Double.class, "");
         info21.setUtype(SPECTRAL_UTYPE.toUpperCase());
         ColumnData columnSpectral2 = PrimitiveArrayColumn.makePrimitiveColumn(info21, SPECTRAL);
-        ColumnInfo info22 = new ColumnInfo(FLUX_NAME, Double.class, "");
+        // insert a "Spectrum String"
+        ColumnInfo info22 = new ColumnInfo(FLUX_NAME.replace("flux", "Spectrum.flux"), Double.class, "");
         info22.setUtype(FLUX_UTYPE.toUpperCase());
         ColumnData columnFlux2 = PrimitiveArrayColumn.makePrimitiveColumn(info22, FLUX);
         ColumnInfo info23 = new ColumnInfo(STRING_NAME, String.class, "");

--- a/iris-common/src/test/java/cfa/vo/iris/sed/stil/FlattenMultipleStarTablesTest.java
+++ b/iris-common/src/test/java/cfa/vo/iris/sed/stil/FlattenMultipleStarTablesTest.java
@@ -1,12 +1,12 @@
 package cfa.vo.iris.sed.stil;
 
+import cfa.vo.iris.utils.UTYPE;
 import org.junit.Before;
 import org.junit.Test;
 import uk.ac.starlink.table.*;
 import uk.ac.starlink.ttools.filter.AssertException;
-
-import java.security.KeyException;
 import java.util.Collection;
+import java.util.NoSuchElementException;
 
 import static org.junit.Assert.*;
 
@@ -27,20 +27,21 @@ public class FlattenMultipleStarTablesTest {
     @Before
     public void setUp() {
         ColumnInfo info11 = new ColumnInfo(SPECTRAL_NAME, Double.class, "");
-        info11.setUtype(SPECTRAL_UTYPE);
+        // take only the main part of the utype
+        info11.setUtype(SPECTRAL_UTYPE.split(":")[1]);
         ColumnData columnSpectral1 = PrimitiveArrayColumn.makePrimitiveColumn(info11, SPECTRAL);
         ColumnInfo info12 = new ColumnInfo(FLUX_NAME, Double.class, "");
         info12.setUtype(FLUX_UTYPE);
         ColumnData columnFlux1 = PrimitiveArrayColumn.makePrimitiveColumn(info12, FLUX);
 
         ColumnInfo info21 = new ColumnInfo(SPECTRAL_NAME, Double.class, "");
-        info21.setUtype(SPECTRAL_UTYPE);
+        info21.setUtype(SPECTRAL_UTYPE.toUpperCase());
         ColumnData columnSpectral2 = PrimitiveArrayColumn.makePrimitiveColumn(info21, SPECTRAL);
         ColumnInfo info22 = new ColumnInfo(FLUX_NAME, Double.class, "");
-        info22.setUtype(FLUX_UTYPE);
+        info22.setUtype(FLUX_UTYPE.toUpperCase());
         ColumnData columnFlux2 = PrimitiveArrayColumn.makePrimitiveColumn(info22, FLUX);
         ColumnInfo info23 = new ColumnInfo(STRING_NAME, String.class, "");
-        info23.setUtype(STRING_UTYPE);
+        info23.setUtype(STRING_UTYPE.toUpperCase());
         ColumnData columnString2 = new ObjectArrayColumn(info23, STRING);
 
         table1 = new ColumnStarTable() {
@@ -71,9 +72,9 @@ public class FlattenMultipleStarTablesTest {
         assertEquals(3, columnInfos.length);
 
         // We are assuming a TreeMap implementation in index, so keys are sorted alphabetically.
-        assertEquals(FLUX_UTYPE, columnInfos[0].getUtype());
-        assertEquals(SPECTRAL_UTYPE, columnInfos[1].getUtype());
-        assertEquals(STRING_UTYPE, columnInfos[2].getUtype());
+        assertEquals(new UTYPE(FLUX_UTYPE), new UTYPE(columnInfos[0].getUtype()));
+        assertEquals(new UTYPE(SPECTRAL_UTYPE), new UTYPE(columnInfos[1].getUtype()));
+        assertEquals(new UTYPE(STRING_UTYPE), new UTYPE(columnInfos[2].getUtype()));
     }
 
     @Test
@@ -130,7 +131,7 @@ public class FlattenMultipleStarTablesTest {
         try {
             index.get(STRING_NAME);
             throw new AssertException("should have failed");
-        } catch (KeyException e) {
+        } catch (NoSuchElementException e) {
             // should throw exception because STRING_NAME is not an ID for any of the infos in the index
         }
 

--- a/iris-common/src/test/java/cfa/vo/iris/units/DefaultUnitsManagerTest.java
+++ b/iris-common/src/test/java/cfa/vo/iris/units/DefaultUnitsManagerTest.java
@@ -323,6 +323,21 @@ public class DefaultUnitsManagerTest {
         assertArrayEquals(expected, observed, Math.abs(Math.abs(expected[0])) / PRECISION);
     }
 
+    @Test
+    public void testEquals() throws Exception {
+        XUnit unit = manager.newXUnits("A");
+        XUnit other = manager.newXUnits("Angstrom");
+        assertTrue(unit.equals(other) && other.equals(unit));
+
+        YUnit yUnit = manager.newYUnits("10*Jy");
+        YUnit yOther = manager.newYUnits("Jy");
+        assertTrue(yUnit.equals(yOther) && yOther.equals(yUnit));
+
+        unit = manager.newXUnits("Angstrom");
+        other = manager.newXUnits("Hz");
+        assertFalse(unit.equals(other) || other.equals(unit));
+    }
+
     @BeforeClass
     public static void setUpClass() throws Exception {
         manager = new DefaultUnitsManager();

--- a/iris-common/src/test/java/cfa/vo/iris/utils/UTYPETest.java
+++ b/iris-common/src/test/java/cfa/vo/iris/utils/UTYPETest.java
@@ -1,0 +1,78 @@
+package cfa.vo.iris.utils;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class UTYPETest {
+    @Test
+    public void testFull() throws Exception {
+        UTYPE u = new UTYPE("test:something");
+
+        assertEquals("test", u.prefix);
+        assertEquals("something", u.main);
+    }
+
+    @Test
+    public void testMainOnly() throws Exception {
+        UTYPE u = new UTYPE("something");
+
+        assertNull(u.prefix);
+        assertEquals("something", u.main);
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testErrorEmpty() throws Exception {
+        UTYPE u = new UTYPE("");
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testErrorNull() throws Exception {
+        UTYPE u = new UTYPE(null);
+    }
+
+    @Test
+    public void testEqualityFull() throws Exception {
+        UTYPE u = new UTYPE("test:something");
+        UTYPE u2 = new UTYPE("TEST:someTHing");
+        assertTrue(u2.equals(u) && u.equals(u2));
+        assertTrue(u2.hashCode() == u.hashCode());
+    }
+
+    @Test
+    public void testEqualityMainOnly() throws Exception {
+        UTYPE u = new UTYPE("test:something");
+        UTYPE u2 = new UTYPE("someTHing");
+        assertTrue(u2.equals(u) && u.equals(u2));
+        assertTrue(u2.hashCode() == u.hashCode());
+    }
+
+    @Test
+    public void testCanonicalString() throws Exception {
+        UTYPE u = new UTYPE("test:something");
+        UTYPE u2 = new UTYPE("TEST:someTHing");
+        assertTrue(u2.getCanonicalString().equals(u.getCanonicalString()));
+        assertEquals("test:something", u.getCanonicalString());
+
+        u = new UTYPE("somethiNG");
+        assertEquals("something", u.getCanonicalString());
+    }
+
+    @Test
+    public void testMain() throws Exception {
+        UTYPE u = new UTYPE("test:something");
+        UTYPE u2 = new UTYPE("someTHing");
+        assertTrue(u2.getMain().equals(u.getMain()));
+        assertEquals("something", u.getMain());
+    }
+
+    @Test
+    public void testToString() throws Exception {
+        UTYPE u = new UTYPE("test:something");
+        UTYPE u2 = new UTYPE("TEST:someTHing");
+        assertTrue(u2.toString().equals(u.toString()));
+        assertEquals("UTYPE{prefix='test', main='something'}", u.toString());
+    }
+
+
+}

--- a/iris-common/src/test/java/cfa/vo/iris/utils/UTYPETest.java
+++ b/iris-common/src/test/java/cfa/vo/iris/utils/UTYPETest.java
@@ -48,6 +48,14 @@ public class UTYPETest {
     }
 
     @Test
+    public void testEqualitySpectrum() throws Exception {
+        UTYPE u = new UTYPE("test:SpEctruM.something");
+        UTYPE u2 = new UTYPE("someTHing");
+        assertTrue(u2.equals(u) && u.equals(u2));
+        assertTrue(u2.hashCode() == u.hashCode());
+    }
+
+    @Test
     public void testCanonicalString() throws Exception {
         UTYPE u = new UTYPE("test:something");
         UTYPE u2 = new UTYPE("TEST:someTHing");


### PR DESCRIPTION
Resolve ChandraCXC/iris-dev#20
Resolve ChandraCXC/iris-dev#6

This PR introduces methods to _flatten_ a number of StarTables into a single StarTable, i.e. to provide a unified view of a number of tables. This is both a concatenation (values in common columns are concatenated) and a join (columns unique to one or more tables are null-padded and attached to the output table).

Columns are "common" in a semantic sense: they may have different names and units, for instance, but if the utype is the same, then they are considered the same and concatenated. Also, if the units differ, the values are converted to the same unit in the output table.

The current implementation is incomplete and focuses on columns. It is also rather inefficient, because it copies all the values over, but I want to make sure I have all the tests in place and a simple working implementation before I optimize it. Eventually, I would like to just store original tables in the flattened "view" and implement the StarTable interface with some form of smart delegation. I still don't know how to avoid potential memory leaks, but maybe that must be dealt with by the calling code once we integrate this. It is also hard to make sure the implementation is robust against changes in the shape of the tables, or in the column metadata. Again, this is possibly something to be taken into account in the client code, i.e. if disruptive changes are made, the old view should be discarded and a new one created. This is one more reason to make the view creation as efficient as possible.

If two tables have columns with the same ID, the output table will have a column with the same ID. Values will be concatenated, maintaining the order in which the tables are passed as arguments.

If a table has a column with a unique ID among the set of tables being concatenated, then a new column is created in the output table with all nulls except the values of the table containing that column.

IDs for columns are determined by taking the utype if one exists. Otherwise, ColumnInfo names will be used. More complicated rules can be applied if necessary.

Note that this PR also addresses ChandraCXC/iris-dev#6, as I needed such a method in my implementation.

Still to be done:
  * homogenize units
  * what about columns with same IDs but different UCDs?
  * copy parameters over (but what if two tables have parameters with same ID and different value?)
  * ~~compare utypes by matching rather than by equality (e.g. `ssa:Target.name` and `spec:spectrum.target.name` are the same)~~
  * optimize implementation
  * are nulls OK? Probably STIL provides utility methods to determine the best null value for each content class
  * error handling:
    * incompatible columns with same ID
    * unsupported unit strings
  * refactoring
  * integration in metadata browser and plotter