### PR TITLE
Simple StarTableAdapter Using VOSerialization

### DIFF
--- a/iris-common/src/main/java/cfa/vo/iris/sed/stil/SegmentStarTable.java
+++ b/iris-common/src/main/java/cfa/vo/iris/sed/stil/SegmentStarTable.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2016 Smithsonian Astrophysical Observatory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package cfa.vo.iris.sed.stil;
 
 import java.io.IOException;

--- a/iris-common/src/main/java/cfa/vo/iris/sed/stil/SegmentStarTableAdapter.java
+++ b/iris-common/src/main/java/cfa/vo/iris/sed/stil/SegmentStarTableAdapter.java
@@ -3,15 +3,15 @@ package cfa.vo.iris.sed.stil;
 import java.util.Map;
 import java.util.WeakHashMap;
 
-import cfa.vo.sedlib.ISegment;
+import cfa.vo.sedlib.Segment;
 import uk.ac.starlink.table.StarTable;
 
-public class SegmentStarTableAdapter implements StarTableAdapter<ISegment> {
+public class SegmentStarTableAdapter implements StarTableAdapter<Segment> {
     
-    private Map<ISegment, StarTable> cache = new WeakHashMap<>();
+    private Map<Segment, StarTable> cache = new WeakHashMap<>();
 
     @Override
-    public StarTable convertStarTable(ISegment data) {
+    public StarTable convertStarTable(Segment data) {
         if (cache.containsKey(data)) {
             return cache.get(data);
         }

--- a/iris-common/src/main/java/cfa/vo/iris/sed/stil/SegmentStarTableAdapter.java
+++ b/iris-common/src/main/java/cfa/vo/iris/sed/stil/SegmentStarTableAdapter.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2016 Smithsonian Astrophysical Observatory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package cfa.vo.iris.sed.stil;
 
 import java.util.Map;

--- a/iris-common/src/main/java/cfa/vo/iris/sed/stil/SerializingStarTableAdapater.java
+++ b/iris-common/src/main/java/cfa/vo/iris/sed/stil/SerializingStarTableAdapater.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2016 Smithsonian Astrophysical Observatory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package cfa.vo.iris.sed.stil;
 
 import java.io.ByteArrayOutputStream;

--- a/iris-common/src/main/java/cfa/vo/iris/sed/stil/SerializingStarTableAdapater.java
+++ b/iris-common/src/main/java/cfa/vo/iris/sed/stil/SerializingStarTableAdapater.java
@@ -1,0 +1,46 @@
+package cfa.vo.iris.sed.stil;
+
+import java.io.ByteArrayOutputStream;
+
+import cfa.vo.sedlib.Sed;
+import cfa.vo.sedlib.Segment;
+import cfa.vo.sedlib.io.VOTableSerializer;
+import uk.ac.starlink.table.StarTable;
+import uk.ac.starlink.table.StoragePolicy;
+import uk.ac.starlink.table.TableSequence;
+import uk.ac.starlink.util.ByteArrayDataSource;
+import uk.ac.starlink.votable.VOTableBuilder;
+
+
+public class SerializingStarTableAdapater implements StarTableAdapter<Segment> {
+
+    @Override
+    public StarTable convertStarTable(Segment data) {
+        try {
+            Sed tmp = new Sed();
+            tmp.addSegment(data);
+            ByteArrayOutputStream os = toVOTable(tmp);
+            StarTable table = convertOSStream(os);
+            return table;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
+    private ByteArrayOutputStream toVOTable(Sed sed) throws Exception {
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        
+        VOTableSerializer serializer = new VOTableSerializer();
+        serializer.serialize(os, sed);
+        
+        return os;
+    }
+
+    private StarTable convertOSStream(ByteArrayOutputStream os) throws Exception {
+        ByteArrayDataSource ds = new ByteArrayDataSource("Iris DS", os.toByteArray());
+        VOTableBuilder votBuilder = new VOTableBuilder();
+        TableSequence seq = votBuilder.makeStarTables(ds, StoragePolicy.getDefaultPolicy());
+        return seq.nextTable();
+    }
+}
+

--- a/iris-common/src/main/java/cfa/vo/iris/sed/stil/StarTableAdapter.java
+++ b/iris-common/src/main/java/cfa/vo/iris/sed/stil/StarTableAdapter.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2016 Smithsonian Astrophysical Observatory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package cfa.vo.iris.sed.stil;
 
 import uk.ac.starlink.table.StarTable;

--- a/iris-common/src/test/java/cfa/vo/iris/sed/stil/SegmentStarTableTest.java
+++ b/iris-common/src/test/java/cfa/vo/iris/sed/stil/SegmentStarTableTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2016 Smithsonian Astrophysical Observatory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package cfa.vo.iris.sed.stil;
 
 import org.junit.Before;

--- a/iris-common/src/test/java/cfa/vo/iris/sed/stil/SerializingStarTableTest.java
+++ b/iris-common/src/test/java/cfa/vo/iris/sed/stil/SerializingStarTableTest.java
@@ -1,0 +1,49 @@
+package cfa.vo.iris.sed.stil;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.commons.lang.StringUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+import cfa.vo.sedlib.Sed;
+import cfa.vo.sedlib.Segment;
+import cfa.vo.sedlib.io.SedFormat;
+import uk.ac.starlink.table.StarTable;
+import uk.ac.starlink.ttools.jel.ColumnIdentifier;
+
+public class SerializingStarTableTest {
+    
+    private Sed sed;
+    
+    private String utype = "utype$";
+    private final String seg_flux_utype = "spec:Spectrum.Data.FluxAxis.Value";
+    private final String seg_spec_utype = "spec:Spectrum.Data.SpectralAxis.Value";
+    
+    @Before
+    public void setUp() throws Exception {
+        sed = Sed.read(getClass().getResource("/test_data/test.vot").getPath(), SedFormat.VOT);
+        assertEquals(1, sed.getNumberOfSegments());
+    }
+
+    @Test
+    public void testStarTable() throws Exception {
+        StarTableAdapter<Segment> adapter = new SerializingStarTableAdapater();
+        Segment seg = sed.getSegment(0);
+        
+        StarTable table = adapter.convertStarTable(seg);
+        
+        assertTrue(!StringUtils.isEmpty(table.getName()));
+        assertEquals(455, table.getRowCount());
+        assertTrue(table.isRandom());
+        
+        int cc = table.getColumnCount();
+        assertEquals(cc, 16);
+        
+        ColumnIdentifier id = new ColumnIdentifier(table);
+
+        assertTrue(id.getColumnIndex(utype + seg_flux_utype) >= 0);
+        assertTrue(id.getColumnIndex(utype + seg_spec_utype) >= 0);
+    }
+}

--- a/iris-common/src/test/java/cfa/vo/iris/sed/stil/SerializingStarTableTest.java
+++ b/iris-common/src/test/java/cfa/vo/iris/sed/stil/SerializingStarTableTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2016 Smithsonian Astrophysical Observatory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package cfa.vo.iris.sed.stil;
 
 import static org.junit.Assert.assertEquals;

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserView.java
@@ -46,6 +46,7 @@ import cfa.vo.iris.IWorkspace;
 import cfa.vo.iris.sed.ExtSed;
 import cfa.vo.iris.sed.stil.StarTableAdapter;
 import cfa.vo.sedlib.ISegment;
+import cfa.vo.sedlib.Segment;
 import uk.ac.starlink.table.EmptyStarTable;
 import uk.ac.starlink.table.StarTable;
 import uk.ac.starlink.table.gui.StarJTable;
@@ -67,7 +68,7 @@ public class MetadataBrowserView extends JInternalFrame {
     private static final StarTable EMPTY_STARTABLE = new EmptyStarTable();
     
     protected IWorkspace ws;
-    protected StarTableAdapter<ISegment> starTableAdapter;
+    protected StarTableAdapter<Segment> starTableAdapter;
     
     protected JList<StarTable> selectedTables;
     protected StarTable selectedStarTable;
@@ -105,7 +106,7 @@ public class MetadataBrowserView extends JInternalFrame {
      * 
      * @throws Exception
      */
-    public MetadataBrowserView(IWorkspace ws, StarTableAdapter<ISegment> adapter) throws Exception {
+    public MetadataBrowserView(IWorkspace ws, StarTableAdapter<Segment> adapter) throws Exception {
         this.ws = ws;
         this.starTableAdapter = adapter;
         

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
@@ -29,7 +29,6 @@ import javax.swing.JPopupMenu;
 import java.awt.Component;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.util.Collections;
 import java.util.Map;
 
 import javax.swing.JSpinner;
@@ -42,14 +41,13 @@ import cfa.vo.iris.events.SedCommand;
 import cfa.vo.iris.events.SedEvent;
 import cfa.vo.iris.events.SedListener;
 import cfa.vo.iris.gui.GUIUtils;
-import cfa.vo.iris.gui.NarrowOptionPane;
 import cfa.vo.iris.sed.ExtSed;
 import cfa.vo.iris.sed.stil.SegmentStarTableAdapter;
 import cfa.vo.iris.sed.stil.StarTableAdapter;
 import cfa.vo.iris.visualizer.metadata.MetadataBrowserView;
 import cfa.vo.iris.visualizer.stil.StilPlotter;
 import cfa.vo.iris.visualizer.stil.preferences.SegmentLayer;
-import cfa.vo.sedlib.ISegment;
+import cfa.vo.sedlib.Segment;
 import cfa.vo.iris.IWorkspace;
 import javax.swing.JFrame;
 
@@ -63,7 +61,7 @@ public class PlotterView extends JInternalFrame {
     // Plotting Components
     private StilPlotter plotter;
     private JInternalFrame residuals;
-    private StarTableAdapter<ISegment> starTableAdapter;
+    private StarTableAdapter<Segment> starTableAdapter;
     private MetadataBrowserView metadataBrowser;
     
     // Buttons, etc.
@@ -162,7 +160,7 @@ public class PlotterView extends JInternalFrame {
         return plotter.getSed();
     }
 
-    public Map<ISegment, SegmentLayer> getSegmentsMap() {
+    public Map<Segment, SegmentLayer> getSegmentsMap() {
         return plotter.getSegmentsMap();
     }
     

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/StilPlotter.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/StilPlotter.java
@@ -25,6 +25,7 @@ import cfa.vo.iris.sed.stil.StarTableAdapter;
 import cfa.vo.iris.visualizer.stil.preferences.PlotPreferences;
 import cfa.vo.iris.visualizer.stil.preferences.SegmentLayer;
 import cfa.vo.sedlib.ISegment;
+import cfa.vo.sedlib.Segment;
 import uk.ac.starlink.ttools.plot2.task.PlanePlot2Task;
 import uk.ac.starlink.ttools.plot2.task.PlotDisplay;
 import uk.ac.starlink.ttools.task.MapEnvironment;
@@ -56,13 +57,13 @@ public class StilPlotter extends JPanel {
     private IWorkspace ws;
     private SedlibSedManager sedManager;
     private ExtSed currentSed;
-    private StarTableAdapter<ISegment> adapter;
+    private StarTableAdapter<Segment> adapter;
     
     // TODO: How can we keep this in sync with the iris application?
-    private Map<ISegment, SegmentLayer> segments;
+    private Map<Segment, SegmentLayer> segments;
     private PlotPreferences plotPreferences;
     
-    public StilPlotter(IrisApplication app, IWorkspace ws, StarTableAdapter<ISegment> adapter) {
+    public StilPlotter(IrisApplication app, IWorkspace ws, StarTableAdapter<Segment> adapter) {
         this.adapter = adapter;
         this.ws = ws;
         this.app = app;
@@ -101,7 +102,7 @@ public class StilPlotter extends JPanel {
         return currentSed;
     }
 
-    public Map<ISegment, SegmentLayer> getSegmentsMap() {
+    public Map<Segment, SegmentLayer> getSegmentsMap() {
         return Collections.unmodifiableMap(segments);
     }
     
@@ -146,7 +147,7 @@ public class StilPlotter extends JPanel {
         logger.info(String.format("Plotting SED with %s segments...", sed.getNamespace()));
         
         for (int i=0; i<sed.getNumberOfSegments(); ++i) {
-            ISegment segment = sed.getSegment(i);
+            Segment segment = sed.getSegment(i);
             
             if (!segments.containsKey(segment)) {
                 segments.put(segment, new SegmentLayer(adapter.convertStarTable(segment)));

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/preferences/SegmentLayer.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/preferences/SegmentLayer.java
@@ -5,6 +5,7 @@ import static cfa.vo.iris.visualizer.stil.preferences.PlotPreferences.*;
 import java.util.HashMap;
 import java.util.Map;
 
+import cfa.vo.iris.sed.stil.SegmentStarTable.ColumnName;
 import uk.ac.starlink.table.StarTable;
 
 public class SegmentLayer {
@@ -23,6 +24,14 @@ public class SegmentLayer {
         this.suffix = '_' + table.getName();
         
         this.setInSource(table)
+        
+            // TODO: Rework when we have more intelligent column implementation
+            .setXCol(ColumnName.X_COL.name())
+            .setYCol(ColumnName.Y_COL.name())
+            .setXerrhi(ColumnName.X_ERR_HI.name())
+            .setXerrlo(ColumnName.X_ERR_LO.name())
+            .setYerrhi(ColumnName.Y_ERR_HI.name())
+            .setYerrlo(ColumnName.Y_ERR_LO.name())
             
             // TODO: put options into enums
             // Setting default values here

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/preferences/SegmentLayer.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/preferences/SegmentLayer.java
@@ -5,7 +5,6 @@ import static cfa.vo.iris.visualizer.stil.preferences.PlotPreferences.*;
 import java.util.HashMap;
 import java.util.Map;
 
-import cfa.vo.iris.sed.stil.SegmentStarTable.ColumnName;
 import uk.ac.starlink.table.StarTable;
 
 public class SegmentLayer {
@@ -24,14 +23,6 @@ public class SegmentLayer {
         this.suffix = '_' + table.getName();
         
         this.setInSource(table)
-        
-            // TODO: Rework when we have more intelligent column implementation
-            .setXCol(ColumnName.X_COL.name())
-            .setYCol(ColumnName.Y_COL.name())
-            .setXerrhi(ColumnName.X_ERR_HI.name())
-            .setXerrlo(ColumnName.X_ERR_LO.name())
-            .setYerrhi(ColumnName.Y_ERR_HI.name())
-            .setYerrlo(ColumnName.Y_ERR_LO.name())
             
             // TODO: put options into enums
             // Setting default values here

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/PlottingPerformanceIT.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/PlottingPerformanceIT.java
@@ -14,6 +14,7 @@ import cfa.vo.iris.sed.SedlibSedManager;
 import cfa.vo.iris.test.unit.AbstractComponentGUITest;
 import cfa.vo.iris.visualizer.stil.preferences.SegmentLayer;
 import cfa.vo.sedlib.ISegment;
+import cfa.vo.sedlib.Segment;
 import cfa.vo.sedlib.io.SedFormat;
 import cfa.vo.testdata.TestData;
 import uk.ac.starlink.table.StarTable;
@@ -65,7 +66,7 @@ public class PlottingPerformanceIT extends AbstractComponentGUITest {
                 assertSame(sed, comp.getDefaultPlotterView().getSed());
                 
                 // Verify the startable has loaded correctly
-                Map<ISegment, SegmentLayer> segmentMap = 
+                Map<Segment, SegmentLayer> segmentMap = 
                         comp.getDefaultPlotterView().getSegmentsMap();
                 
                 assertEquals(1, segmentMap.size());

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/PlottingPerformanceIT.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/PlottingPerformanceIT.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2016 Smithsonian Astrophysical Observatory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package cfa.vo.iris.visualizer;
 
 import java.net.URL;


### PR DESCRIPTION
This implementation uses SEDLib's VOT mapper functionality to create a ByteStream that is piped directly into Stil's VOT reader.

I had to leave pretty much everything in the plotter as is to avoid breaking anything in the visualizer, but I did have to change relying on the interface to the pojo directly, as for some reason that's what the SED interface does anyway.

We will need to have column selection for plotting in place before we can switch to using this adapter in the plotter/MB, as stil requires arguments for x and y and as of now we cannot detect them.