### PR TITLE
Iris dev 14 implement automatic color selection

### DIFF
--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/ColorPalette.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/ColorPalette.java
@@ -23,17 +23,31 @@ import java.util.List;
  * create or return a list of colors.
  * 
  */
-public interface ColorPalette {
+public abstract class ColorPalette {
     /**
      * Get the next available color in the palette
      * @return a color
      */
-    public Color getNextColor();
+    public abstract Color getNextColor();
     
     /**
      * Returns a list of N colors 
      * @param n
      * @return a list of colors
      */
-    public List<Color> createPalette(int n);
+    public abstract List<Color> createPalette(int n);
+    
+    /**
+     * Returns the hexadecimal color code of the supplied color.
+     * @param color
+     * @return a hexadecimal color code
+     * @throws NullPointerException 
+     */
+    public final static String colorToHex(Color color) throws NullPointerException {
+        String hexColor = Integer.toHexString(color.getRGB() & 0xffffff);
+        if (hexColor.length() < 6) {
+            hexColor = "000000".substring(0, 6 - hexColor.length()) + hexColor;
+        }
+        return hexColor;
+    }
 }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/ColorPalette.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/ColorPalette.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 Chandra X-Ray Observatory.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cfa.vo.iris.visualizer.plotter;
+
+import java.awt.Color;
+import java.util.List;
+
+/**
+ * Interface for a plotter color palette. A color pallete should be able to
+ * create or return a list of colors.
+ * 
+ */
+public interface ColorPalette {
+    /**
+     * Get the next available color in the palette
+     * @return a color
+     */
+    public Color getNextColor();
+    
+    /**
+     * Returns a list of N colors 
+     * @param n
+     * @return a list of colors
+     */
+    public List<Color> createPalette(int n);
+}

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/HSVColorPalette.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/HSVColorPalette.java
@@ -56,17 +56,6 @@ public class HSVColorPalette implements ColorPalette {
         return colors;
     }
     
-//    public Color getNextColor() {
-//        
-//        // make sure no color is too close to white, yellow, or black
-//        final float hue = random.nextFloat();
-//        // Saturation between 0.1 and 0.3
-//        final float saturation = (random.nextInt(2000) + 1000) / 10000f;
-//        final float luminance = 0.9f;
-//        
-//        return Color.getHSBColor(hue, saturation, luminance);
-//    }
-    
     /**
      * Returns a new distinct color using the golden rule ratio.
      * 
@@ -83,33 +72,34 @@ public class HSVColorPalette implements ColorPalette {
         hue += INVERSE_GOLDEN_RATION;
         hue %= 1;
         
-        // TODO: come up with a better algorithm for distinct colors of 
-        // different saturations and brightnesses. This one gives too
-        // many yellow colors.
+        // TODO: come up with an algorithm for distinct colors of 
+        // different saturations and brightnesses.
         
-        // reset the saturation and brightness
-        // if they get too low
-        if (brightness < BRIGHTNESS_THRESHOLD) {
-            brightness = 1.0;
-        }
-        if (saturation < SATURATION_THRESHOLD) {
-            saturation = 1.0;
-        }
+        brightness = 1.0;
         
-        // Close hues repeat themselves every 6 colors.
-        // when this happens, change the brightness and/or saturation
-        // so that we get colors that are more different from the first set
-        if (index !=0 && index % 12 == 0) {
-            brightness -= 0.25;
-        }
-        
-        // change saturation every 4 brightness decreases
-        if (index != 0 && index % 6 == 0) {
-            saturation -= -0.25;
-        }
-        
-        // counter for hues.
-        index++;
+//        // reset the saturation and brightness
+//        // if they get too low
+//        if (brightness < BRIGHTNESS_THRESHOLD) {
+//            brightness = 1.0;
+//        }
+//        if (saturation < SATURATION_THRESHOLD) {
+//            saturation = 1.0;
+//        }
+//        
+//        // Close hues repeat themselves every 6 colors.
+//        // when this happens, change the brightness and/or saturation
+//        // so that we get colors that are more different from the first set
+//        if (index !=0 && index % 12 == 0) {
+//            brightness -= 0.25;
+//        }
+//        
+//        // change saturation every 4 brightness decreases
+//        if (index != 0 && index % 6 == 0) {
+//            saturation -= -0.25;
+//        }
+//        
+//        // counter for hues.
+//        index++;
         
         return color;
     }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/HSVColorPalette.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/HSVColorPalette.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2016 Chandra X-Ray Observatory.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cfa.vo.iris.visualizer.plotter;
+
+import java.awt.Color;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+/**
+ *
+ * Generate N distinct colors
+ */
+public class HSVColorPalette implements ColorPalette {
+    
+    private Random random = new Random();
+    private Color color = new Color(Color.black.getRGB());
+    private double hue = 0;
+    private double saturation = 1.0;
+    private double brightness = 0;
+    private long index;
+    private final double INVERSE_GOLDEN_RATION = 1/1.61803398875;
+    
+    // saturation and brightness thresholds
+    private final double SATURATION_THRESHOLD = 0.3;
+    private final double BRIGHTNESS_THRESHOLD = 0.25;
+    
+    /**
+     * Generate n distinct colors
+     * @param n
+     * @return a list of distinct colors
+     * 
+     */
+    @Override
+    public final List<Color> createPalette(int n) {
+        
+        List<Color> colors = new ArrayList<>();
+                
+        for (int i=0; i < n; i++) {
+            colors.add(getNextColor());
+        }
+        
+        return colors;
+    }
+    
+//    public Color getNextColor() {
+//        
+//        // make sure no color is too close to white, yellow, or black
+//        final float hue = random.nextFloat();
+//        // Saturation between 0.1 and 0.3
+//        final float saturation = (random.nextInt(2000) + 1000) / 10000f;
+//        final float luminance = 0.9f;
+//        
+//        return Color.getHSBColor(hue, saturation, luminance);
+//    }
+    
+    /**
+     * Returns a new distinct color using the golden rule ratio.
+     * 
+     * @return color
+     */
+    @Override
+    public final Color getNextColor() {
+        
+        // first, set the current color in the palette. 
+        // This is the return value
+        color = Color.getHSBColor((float) hue, (float) saturation, (float) brightness);
+        
+        // calculate the next hue using the golden ratio
+        hue += INVERSE_GOLDEN_RATION;
+        hue %= 1;
+        
+        // TODO: come up with a better algorithm for distinct colors of 
+        // different saturations and brightnesses. This one gives too
+        // many yellow colors.
+        
+        // reset the saturation and brightness
+        // if they get too low
+        if (brightness < BRIGHTNESS_THRESHOLD) {
+            brightness = 1.0;
+        }
+        if (saturation < SATURATION_THRESHOLD) {
+            saturation = 1.0;
+        }
+        
+        // Close hues repeat themselves every 6 colors.
+        // when this happens, change the brightness and/or saturation
+        // so that we get colors that are more different from the first set
+        if (index !=0 && index % 12 == 0) {
+            brightness -= 0.25;
+        }
+        
+        // change saturation every 4 brightness decreases
+        if (index != 0 && index % 6 == 0) {
+            saturation -= -0.25;
+        }
+        
+        // counter for hues.
+        index++;
+        
+        return color;
+    }
+    
+    public final static String toHexString(Color color) throws NullPointerException {
+        String hexColor = Integer.toHexString(color.getRGB() & 0xffffff);
+        if (hexColor.length() < 6) {
+            hexColor = "000000".substring(0, 6 - hexColor.length()) + hexColor;
+        }
+        return hexColor;
+    }
+
+}

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/HSVColorPalette.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/HSVColorPalette.java
@@ -24,7 +24,7 @@ import java.util.Random;
  *
  * Generate N distinct colors
  */
-public class HSVColorPalette implements ColorPalette {
+public class HSVColorPalette extends ColorPalette {
     
     private Random random = new Random();
     private Color color = new Color(Color.black.getRGB());
@@ -58,6 +58,8 @@ public class HSVColorPalette implements ColorPalette {
     
     /**
      * Returns a new distinct color using the golden rule ratio.
+     * Algorithm adopted from
+     * http://martin.ankerl.com/2009/12/09/how-to-create-random-colors-programmatically/
      * 
      * @return color
      */
@@ -103,13 +105,4 @@ public class HSVColorPalette implements ColorPalette {
         
         return color;
     }
-    
-    public final static String toHexString(Color color) throws NullPointerException {
-        String hexColor = Integer.toHexString(color.getRGB() & 0xffffff);
-        if (hexColor.length() < 6) {
-            hexColor = "000000".substring(0, 6 - hexColor.length()) + hexColor;
-        }
-        return hexColor;
-    }
-
 }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedPreferences.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedPreferences.java
@@ -106,7 +106,7 @@ public class SedPreferences {
         }
         
         // add colors to segment layer
-        String hexColor = HSVColorPalette.toHexString(colors.getNextColor());
+        String hexColor = HSVColorPalette.colorToHex(colors.getNextColor());
         layer.setMarkColor(hexColor);
         
         segmentPreferences.put(me, layer);

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedPreferences.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedPreferences.java
@@ -27,6 +27,8 @@ import org.apache.commons.lang.StringUtils;
 
 import cfa.vo.iris.sed.ExtSed;
 import cfa.vo.iris.sed.stil.StarTableAdapter;
+import cfa.vo.iris.visualizer.plotter.ColorPalette;
+import cfa.vo.iris.visualizer.plotter.HSVColorPalette;
 import cfa.vo.iris.visualizer.plotter.SegmentLayer;
 import cfa.vo.sedlib.Segment;
 
@@ -40,11 +42,13 @@ public class SedPreferences {
     StarTableAdapter<Segment> adapter;
     final Map<MapKey, SegmentLayer> segmentPreferences;
     final ExtSed sed;
+    final ColorPalette colors;
     
     public SedPreferences(ExtSed sed, StarTableAdapter<Segment> adapter) {
         this.sed = sed;
         this.segmentPreferences = Collections.synchronizedMap(new LinkedHashMap<MapKey, SegmentLayer>());
         this.adapter = adapter;
+        this.colors = new HSVColorPalette();
         
         refresh();
     }
@@ -100,6 +104,10 @@ public class SedPreferences {
             count++;
             layer.setSuffix(layer.getSuffix() + " " + count);
         }
+        
+        // add colors to segment layer
+        String hexColor = HSVColorPalette.toHexString(colors.getNextColor());
+        layer.setMarkColor(hexColor);
         
         segmentPreferences.put(me, layer);
     }

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/preferences/SedPreferencesTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/preferences/SedPreferencesTest.java
@@ -65,6 +65,12 @@ public class SedPreferencesTest {
         SegmentLayer layer2 = prefs.getSegmentPreferences(seg2);
         assertFalse(layer1.getSuffix().equals(layer2.getSuffix()));
         
+        // Check that the colors for each segment are different
+        String color2 = prefs.getSegmentPreferences(seg2).getMarkColor();
+        assertNotEquals(
+                prefs.getSegmentPreferences(seg1).getMarkColor(),
+                prefs.getSegmentPreferences(seg2).getMarkColor());
+        
         // Ensure we get the right startables back
         assertEquals(3, layer1.getInSource().getRowCount());
         assertEquals(3, layer2.getInSource().getRowCount());
@@ -73,6 +79,10 @@ public class SedPreferencesTest {
         sed.remove(seg1);
         prefs.refresh();
         assertEquals(1, prefs.getAllSegmentPreferences().size());
+        
+        // The color for seg2 should still be the same as it was before 
+        // seg1 was removed
+        assertEquals(color2, prefs.getSegmentPreferences(seg2).getMarkColor());
         
         assertNotNull(prefs.getSegmentPreferences(seg2));
         assertNotNull(prefs.getSegmentPreferences(seg2).getInSource());


### PR DESCRIPTION
Addresses ChandraCXC/iris-dev#14

This PR introduces a very simple automatic coloring for added Segments. Using an HSV cylinder as the color space, the golden ratio is used to create a set of fairly distinct colors. I say "fairly" because only the hue changes, not the brightness or saturation. The colors have full brightness and saturation. In commit e2c6522, I tried to change the brightness and saturation every six colors or so to try to get more variety. However, this algorithm produced a lot of pale yellow colors, which is not wanted.

I created a ColorPalette interface to use for other color palettes we may create later.

Issue ChandraCXC/iris#258 causes problems for Segment coloration. If two or more segments have the same Target Name, the SegmentLayer colors are replaced with the latest ones, even if you remove the newly added segments from the plot.