### PR TITLE
Split Reset Method #7

### DIFF
--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserView.java
@@ -267,7 +267,6 @@ public class MetadataBrowserView extends JInternalFrame {
     }
 
     public void reset() {
-        
         // Multiple threads resetting this simultaneously can do weird things
         // to JList and JTable objects.
         synchronized(this) {
@@ -358,12 +357,10 @@ public class MetadataBrowserView extends JInternalFrame {
         @Override
         public void process(ExtSed source, VisualizerCommand payload) {
             if (VisualizerCommand.RESET.equals(payload) ||
-                VisualizerCommand.SELECTED.equals(payload))
+                VisualizerCommand.SELECTED.equals(payload) ||
+                VisualizerCommand.REDRAW.equals(payload))
             {
                 reset();
-            }
-            else if (VisualizerCommand.REDRAW.equals(payload)) {
-                setSedId();
             }
         }
     }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserView.java
@@ -21,7 +21,6 @@ import javax.swing.JList;
 
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
-import java.util.Map;
 import java.awt.Color;
 import java.awt.Component;
 
@@ -45,15 +44,12 @@ import javax.swing.event.ListSelectionListener;
 
 import cfa.vo.iris.IWorkspace;
 import cfa.vo.iris.sed.ExtSed;
-import cfa.vo.iris.sed.stil.StarTableAdapter;
 import cfa.vo.iris.visualizer.plotter.SegmentLayer;
 import cfa.vo.iris.visualizer.preferences.SedPreferences;
 import cfa.vo.iris.visualizer.preferences.VisualizerChangeEvent;
 import cfa.vo.iris.visualizer.preferences.VisualizerCommand;
 import cfa.vo.iris.visualizer.preferences.VisualizerComponentPreferences;
 import cfa.vo.iris.visualizer.preferences.VisualizerListener;
-import cfa.vo.sedlib.ISegment;
-import cfa.vo.sedlib.Segment;
 import uk.ac.starlink.table.EmptyStarTable;
 import uk.ac.starlink.table.StarTable;
 import uk.ac.starlink.table.gui.StarJTable;
@@ -291,6 +287,10 @@ public class MetadataBrowserView extends JInternalFrame {
     }
     
     private void setSedId() {
+        if (selected == null) {
+            return;
+        }
+        
         TitledBorder border = (TitledBorder) segmentListScrollPane.getBorder();
         border.setTitle(selected.getId());
     }
@@ -357,7 +357,9 @@ public class MetadataBrowserView extends JInternalFrame {
 
         @Override
         public void process(ExtSed source, VisualizerCommand payload) {
-            if (VisualizerCommand.RESET.equals(payload)) {
+            if (VisualizerCommand.RESET.equals(payload) ||
+                VisualizerCommand.SELECTED.equals(payload))
+            {
                 reset();
             }
             else if (VisualizerCommand.REDRAW.equals(payload)) {

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserView.java
@@ -357,7 +357,12 @@ public class MetadataBrowserView extends JInternalFrame {
 
         @Override
         public void process(ExtSed source, VisualizerCommand payload) {
-            reset();
+            if (VisualizerCommand.RESET.equals(payload)) {
+                reset();
+            }
+            else if (VisualizerCommand.REDRAW.equals(payload)) {
+                setSedId();
+            }
         }
     }
 }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
@@ -375,7 +375,12 @@ public class PlotterView extends JInternalFrame {
 
         @Override
         public void process(ExtSed source, VisualizerCommand payload) {
-            resetPlot(source);
+            if (VisualizerCommand.RESET.equals(payload)) {
+                resetPlot(source);
+            }
+            else if (VisualizerCommand.REDRAW.equals(payload)) {
+                
+            }
         }
     }
 }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
@@ -147,13 +147,18 @@ public class PlotterView extends JInternalFrame {
             }
         });
         
-        // Action for resetting plot
+        // Action for resetting the visualizer component from the UI using the reset button
         btnReset.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
                 resetPlot(null);
+                metadataBrowser.reset();
             }
         });
         
+        addPlotChangeListener();
+    }
+    
+    protected void addPlotChangeListener() {
         VisualizerChangeEvent.getInstance().add(new PlotChangeListener());
     }
 
@@ -180,12 +185,11 @@ public class PlotterView extends JInternalFrame {
     }
     
     private void resetPlot(ExtSed sed) {
-        this.metadataBrowser.reset();
         // TODO: setting second argument to "false" forces the plot display
         // to be cached. Do we want this behavior in the future?
         // Note (jb): tried opening 300k sed with "fals" and "true." Both
         // produce a .5 second lag in panning the viewer.
-        this.plotter.reset(sed, true);
+        this.plotter.reset(sed, false);
     }
     
     private static void addPopup(Component component, final JPopupMenu popup) {
@@ -375,7 +379,9 @@ public class PlotterView extends JInternalFrame {
 
         @Override
         public void process(ExtSed source, VisualizerCommand payload) {
-            if (VisualizerCommand.RESET.equals(payload)) {
+            if (VisualizerCommand.RESET.equals(payload) ||
+                VisualizerCommand.SELECTED.equals(payload)) 
+            {
                 resetPlot(source);
             }
             else if (VisualizerCommand.REDRAW.equals(payload)) {

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
@@ -189,7 +189,7 @@ public class PlotterView extends JInternalFrame {
         this.plotter.reset(sed, true);
     }
 
-    private void redrawPlow() {
+    private void redrawPlot() {
         this.plotter.redraw(true);
     }
     
@@ -386,7 +386,7 @@ public class PlotterView extends JInternalFrame {
                 resetPlot(source);
             }
             else if (VisualizerCommand.REDRAW.equals(payload)) {
-                redrawPlow();
+                redrawPlot();
             }
         }
     }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
@@ -191,6 +191,10 @@ public class PlotterView extends JInternalFrame {
         // produce a .5 second lag in panning the viewer.
         this.plotter.reset(sed, false);
     }
+
+    private void redrawPlow() {
+        this.plotter.redraw();
+    }
     
     private static void addPopup(Component component, final JPopupMenu popup) {
     }
@@ -385,7 +389,7 @@ public class PlotterView extends JInternalFrame {
                 resetPlot(source);
             }
             else if (VisualizerCommand.REDRAW.equals(payload)) {
-                
+                redrawPlow();
             }
         }
     }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
@@ -185,15 +185,12 @@ public class PlotterView extends JInternalFrame {
     }
     
     private void resetPlot(ExtSed sed) {
-        // TODO: setting second argument to "false" forces the plot display
-        // to be cached. Do we want this behavior in the future?
-        // Note (jb): tried opening 300k sed with "fals" and "true." Both
-        // produce a .5 second lag in panning the viewer.
-        this.plotter.reset(sed, false);
+        // TODO: At somepoint we may want this to be a feature if we ever have static SEDs.
+        this.plotter.reset(sed, true);
     }
 
     private void redrawPlow() {
-        this.plotter.redraw();
+        this.plotter.redraw(true);
     }
     
     private static void addPopup(Component component, final JPopupMenu popup) {

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/SegmentLayer.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/SegmentLayer.java
@@ -71,7 +71,7 @@ public class SegmentLayer {
         }
         
         this.setInSource(table);
-        this.suffix = '_' + table.getName();
+        this.suffix = table.getName();
         
         // Setting default values here
         this.setErrorBarType(ErrorBarType.capped_lines)

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedPreferences.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedPreferences.java
@@ -163,7 +163,7 @@ public class SedPreferences {
     }
     
     // Removes any segments that are no longer in the SED
-    void clean() {
+    private void clean() {
         
         // Use iterator for concurrent modification
         Iterator<Entry<MapKey, SegmentLayer>> it = segmentPreferences.entrySet().iterator();

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedPreferences.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedPreferences.java
@@ -80,6 +80,9 @@ public class SedPreferences {
         return segmentPreferences.get(new MapKey(seg));
     }
     
+    /**
+     * Reserializes all segments within the sed.
+     */
     void refresh() {
         for (int i=0; i < sed.getNumberOfSegments(); i++) {
             addSegment(sed.getSegment(i));
@@ -92,6 +95,10 @@ public class SedPreferences {
         segmentPreferences.clear();
     }
     
+    /**
+     * Add a segment to the sed preferences map.
+     * @param seg
+     */
     void addSegment(Segment seg) {
         
         MapKey me = new MapKey(seg);
@@ -105,18 +112,13 @@ public class SedPreferences {
         // Ensure that the layer has a unique identifier in the list of segments
         SegmentLayer layer = new SegmentLayer(adapter.convertStarTable(seg));
         int count = 0;
-        while (!isUniqueLayerSuffix(layer.getSuffix())) {
+        String id = layer.getSuffix();
+        while (!isUniqueLayerSuffix(id)) {
             count++;
-            String suffix = layer.getSuffix();
-            
-            // increment the suffix count
-            if (Character.isDigit(suffix.charAt(suffix.length()-1))){
-                layer.setSuffix(suffix.substring(0, suffix.lastIndexOf(" ")));
-            }
-            String id = layer.getSuffix() + " " + count;
-            layer.setSuffix(id);
-            layer.getInSource().setName(id);
+            id = layer.getSuffix() + " " + count;
         }
+        layer.setSuffix(id);
+        layer.getInSource().setName(id);
         
         // add colors to segment layer
         String hexColor = ColorPalette.colorToHex(colors.getNextColor());
@@ -125,6 +127,15 @@ public class SedPreferences {
         setUnits(seg, layer);
         
         segmentPreferences.put(me, layer);
+    }
+    
+    /**
+     * Removes a segment from the sed preferences map.
+     * @param segment
+     */
+    void removeSegment(Segment segment) {
+        MapKey me = new MapKey(segment);
+        segmentPreferences.remove(me);
     }
     
     /**

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerCommand.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerCommand.java
@@ -18,5 +18,6 @@ package cfa.vo.iris.visualizer.preferences;
 
 public enum VisualizerCommand {
     RESET,
-    REDRAW;
+    REDRAW, 
+    SELECTED;
 }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerComponentPreferences.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerComponentPreferences.java
@@ -138,13 +138,15 @@ public class VisualizerComponentPreferences {
     
     /**
      * Adds or updates the segment within the specified SED.
-     * @param sed
+     * @param sed - the sed to which the segment is attached
      * @param segment
      */
     public void update(ExtSed sed, Segment segment) {
         if (sedPreferences.containsKey(sed)) {
             sedPreferences.get(sed).addSegment(segment);
         } else {
+            // The segment will automatically be serialized and attached the the 
+            // SedPrefrences since it's assumed to be attached to the SED.
             sedPreferences.put(sed, new SedPreferences(sed, adapter));
         }
         fire(sed, VisualizerCommand.RESET);
@@ -155,8 +157,8 @@ public class VisualizerComponentPreferences {
      * @param sed
      */
     public void remove(ExtSed sed) {
-        if (sedPreferences.containsKey(sed)) {
-            
+        if (!sedPreferences.containsKey(sed)) {
+            return;
         }
         sedPreferences.get(sed).removeAll();
         sedPreferences.remove(sed);

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/StilPlotter.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/StilPlotter.java
@@ -24,6 +24,8 @@ import cfa.vo.iris.visualizer.plotter.SegmentLayer;
 import cfa.vo.iris.visualizer.preferences.SedPreferences;
 import cfa.vo.iris.visualizer.preferences.VisualizerComponentPreferences;
 import cfa.vo.sedlib.Segment;
+import uk.ac.starlink.ttools.plot2.geom.PlaneAspect;
+import uk.ac.starlink.ttools.plot2.geom.PlaneSurfaceFactory;
 import uk.ac.starlink.ttools.plot2.task.PlanePlot2Task;
 import uk.ac.starlink.ttools.plot2.task.PlotDisplay;
 import uk.ac.starlink.ttools.task.MapEnvironment;
@@ -43,56 +45,81 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class StilPlotter extends JPanel {
-    
-    private static final Logger logger = Logger.getLogger(StilPlotter.class.getName());
-    
+
+    private static final Logger logger = Logger
+            .getLogger(StilPlotter.class.getName());
+
     private static final long serialVersionUID = 1L;
-    
-    private PlotDisplay display;
-    
+
+    private PlotDisplay<PlaneSurfaceFactory.Profile, PlaneAspect> display;
+
     private IWorkspace ws;
     private SedlibSedManager sedManager;
     private ExtSed currentSed;
     private final VisualizerComponentPreferences preferences;
-    
+
     private MapEnvironment env;
-    
-    public StilPlotter(IWorkspace ws, VisualizerComponentPreferences preferences) {
+
+    public StilPlotter(IWorkspace ws,
+            VisualizerComponentPreferences preferences) {
         this.ws = ws;
         this.sedManager = (SedlibSedManager) ws.getSedManager();
         this.preferences = preferences;
-        
+
         setBorder(new BevelBorder(BevelBorder.LOWERED, null, null, null, null));
         setBackground(Color.WHITE);
         setLayout(new GridLayout(1, 0, 0, 0));
-        
+
         reset(null, true);
     }
-    
+
     /**
      * 
-     * @param sed Sed to reset plot to
-     * @param dataMayChange indicates if the data on the plot may change while
-     * while the current display is active.
+     * @param sed
+     *            Sed to reset plot to
+     * @param dataMayChange
+     *            indicates if the data on the plot may change while while the
+     *            current display is active.
      */
     public void reset(ExtSed sed, boolean dataMayChange) {
-        if (display != null) {
-            display.removeAll();
-            remove(display);
-            display = null; // just to be safe
+        removeDisplay();
+        
+        // https://github.com/Starlink/starjava/blob/master/ttools/src/main/
+        // uk/ac/starlink/ttools/example/EnvPlanePlotter.java
+        boolean cached = !dataMayChange;
+        display = createPlotComponent(sed, cached);
+        
+        addDisplay();
+    }
+
+    /**
+     * Redraws the current plot in place. Useful for changes to the plot
+     * preferences.
+     *
+     */
+    public void redraw() {
+        removeDisplay();
+        if (display == null) {
+            return;
         }
         
-        try {
-            // https://github.com/Starlink/starjava/blob/master/ttools/src/main/
-            // uk/ac/starlink/ttools/example/EnvPlanePlotter.java
-            boolean cached =! dataMayChange;
-            display = createPlotComponent(sed, cached);
-        } catch (RuntimeException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        // Use the aspect to maintain existing positioning
+        final PlaneAspect aspect = display.getAspect();
+        display = createPlotComponent(currentSed, false);
+        display.setAspect(aspect);
         
+        addDisplay();
+    }
+    
+    private void removeDisplay() {
+        if (display == null) {
+            return;
+        }
+        display.removeAll();
+        remove(display);
+    }
+    
+    private void addDisplay() {
         add(display, BorderLayout.CENTER);
         display.revalidate();
         display.repaint();
@@ -103,10 +130,11 @@ public class StilPlotter extends JPanel {
     }
 
     public Map<Segment, SegmentLayer> getSegmentsMap() {
-        return Collections.unmodifiableMap(preferences.getSelectedSedPreferences().getAllSegmentPreferences());
+        return Collections.unmodifiableMap(preferences
+                .getSelectedSedPreferences().getAllSegmentPreferences());
     }
-    
-    public PlotDisplay getPlotDisplay() {
+
+    public PlotDisplay<PlaneSurfaceFactory.Profile, PlaneAspect> getPlotDisplay() {
         return display;
     }
 
@@ -121,71 +149,88 @@ public class StilPlotter extends JPanel {
 
     /**
      * 
-     * @param env Plot display environment to use 
-     * @param cached If true, cache the environment. Should be false if the data
-     * might change.
-     * @return PlotDisplay
-     * @throws Exception 
-     */
-    protected PlotDisplay createPlotComponent(MapEnvironment env, boolean cached) throws Exception {
-        
-        logger.log(Level.FINE, "plot environment:");
-        logger.log(Level.FINE, ReflectionToStringBuilder.toString(env));
-        
-        return new PlanePlot2Task().createPlotComponent(env, cached);
-    }
-    
-    /**
-     * 
-     * @param sed the SED to plot
-     * @param cached If true, cache the environment. Should be false if the data
-     * might change.
+     * @param sed
+     *            the SED to plot
+     * @param cached
+     *            If true, cache the environment. Should be false if the data
+     *            might change.
      * @return
-     * @throws Exception 
      */
-    protected PlotDisplay createPlotComponent(ExtSed sed, boolean cached) throws Exception {
+    protected PlotDisplay<PlaneSurfaceFactory.Profile, PlaneAspect> createPlotComponent(
+            ExtSed sed, boolean cached) {
         logger.info("Creating new plot from selected SED");
 
         if (sed == null) {
             sed = sedManager.getSelected();
         }
         this.currentSed = sed;
-        
+
+        try {
+            setupMapEnvironment(currentSed);
+            return createPlotComponent(env, cached);
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * 
+     * @param env
+     *            Plot display environment to use
+     * @param cached
+     *            If true, cache the environment. Should be false if the data
+     *            might change.
+     * @return PlotDisplay
+     * @throws Exception
+     */
+    protected PlotDisplay<PlaneSurfaceFactory.Profile, PlaneAspect> createPlotComponent(
+            MapEnvironment env, boolean cached) throws Exception {
+
+        logger.log(Level.FINE, "plot environment:");
+        logger.log(Level.FINE, ReflectionToStringBuilder.toString(env));
+
+        return new PlanePlot2Task().createPlotComponent(env, cached);
+    }
+
+    protected void setupMapEnvironment(ExtSed sed) throws IOException {
+
         env = new MapEnvironment();
         env.setValue("type", "plot2plane");
-        env.setValue("insets", new Insets(50, 80, 50, 50)); 
+        env.setValue("insets", new Insets(50, 80, 50, 50));
         // TODO: force numbers on Y axis to only be 3-5 digits long. Keeps
         // Y-label from falling off the jpanel. Conversely, don't set "insets"
         // and let the plotter dynamically change size to keep axes labels
         // on the plot.
-        
+
         // Add high level plot preferences
         PlotPreferences pp = preferences.getPlotPreferences();
         for (String key : pp.getPreferences().keySet()) {
             env.setValue(key, pp.getPreferences().get(key));
         }
-        
+
         if (sed != null) {
             // set title of plot if available
             env.setValue("title", sed.getId());
-            
+
             // Add segments and segment preferences
             addSegmentLayers(sed, env);
         }
-        
-        return createPlotComponent(env, cached);
     }
-    
-    private void addSegmentLayers(ExtSed sed, MapEnvironment env) throws IOException {
+
+    private void addSegmentLayers(ExtSed sed, MapEnvironment env)
+            throws IOException {
         if (sed == null) {
             logger.info("No SED selected, returning empty plot");
             return;
         }
-        
-        logger.info(String.format("Plotting SED with %s segments...", sed.getNamespace()));
-        
+
+        logger.info(String.format("Plotting SED with %s segments...",
+                sed.getNamespace()));
+
         SedPreferences prefs = preferences.getSedPreferences(sed);
-        for (int i=0; i<sed.getNumberOfSegments(); i++) {
+        for (int i = 0; i < sed.getNumberOfSegments(); i++) {
             SegmentLayer layer = prefs.getSegmentPreferences(sed.getSegment(i));
             for (String key : layer.getPreferences().keySet()) {
                 env.setValue(key, layer.getPreferences().get(key));

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/StilPlotter.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/StilPlotter.java
@@ -57,7 +57,7 @@ public class StilPlotter extends JPanel {
     private SedlibSedManager sedManager;
     private ExtSed currentSed;
     private final VisualizerComponentPreferences preferences;
-
+    
     private MapEnvironment env;
 
     public StilPlotter(IWorkspace ws,
@@ -82,7 +82,7 @@ public class StilPlotter extends JPanel {
      *            current display is active.
      */
     public void reset(ExtSed sed, boolean dataMayChange) {
-        resetPlot(sed, null, dataMayChange);
+        resetPlot(sed, false, dataMayChange);
     }
 
     /**
@@ -91,23 +91,36 @@ public class StilPlotter extends JPanel {
      *
      */
     public void redraw(boolean dataMayChange) {
+        // If there's no display then don't change anything
         if (display == null) {
             return;
         }
         
-        // Use the aspect to maintain existing positioning
-        PlaneAspect aspect = display.getAspect();
-        resetPlot(currentSed, aspect, dataMayChange);
+        resetPlot(currentSed, true, dataMayChange);
     }
     
+    /**
+     * Resets the plot.
+     * 
+     * TODO: Allow users to fix a plot in place either from plot preferences or from the
+     *  PlotterView.
+     *  
+     * @param sed - the sed to plot
+     * @param fixed - if set to true, the plot bounds will not change
+     * @param dataMayChange - if the data in the sed will change (usually true)
+     */
     private void resetPlot(ExtSed sed,
-                           PlaneAspect plane, 
+                           boolean fixed, 
                            boolean dataMayChange) 
     {
+        // Get initial bounds if available
+        PlaneAspect existingAspect = null;
+        
         // Clear the display if it's available
         if (display != null) {
             display.removeAll();
             remove(display);
+            existingAspect = display.getAspect();
         }
         
         // Update the current SED
@@ -120,9 +133,9 @@ public class StilPlotter extends JPanel {
         boolean cached = !dataMayChange;
         display = createPlotComponent(currentSed, cached);
         
-        // Set the bounds using the aspect if provided one
-        if (plane != null) {
-            display.setAspect(plane);
+        // Set the bounds using the aspect if provided one and if the plot is fixed
+        if (existingAspect != null && fixed) {
+            display.setAspect(existingAspect);
         }
         
         // Add the display to the plot view

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserViewTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserViewTest.java
@@ -201,6 +201,21 @@ public class MetadataBrowserViewTest extends AbstractComponentGUITest {
             }
         });
         
+        // Add another segment
+        final Segment seg2 = createSampleSegment(new double[] {100}, new double[] {200});
+        sed.addSegment(seg2);
+        
+        // 1 segment should have been added to table
+        invokeWithRetry(10, 100, new Runnable() {
+            @Override
+            public void run() {
+                // Verify values in table are correct
+                assertEquals(2, mbView.selectedTables.getModel().getSize());
+                assertEquals(3, metadataTable.getRowCount());
+                assertEquals(1, Double.parseDouble((String) metadataTable.getContentAt(0, 1)), .1);
+            }
+        });
+        
         // Remove the segment
         sed.remove(seg1);
         
@@ -209,8 +224,8 @@ public class MetadataBrowserViewTest extends AbstractComponentGUITest {
             @Override
             public void run() {
                 // Verify values in table are correct
-                assertEquals(0, mbView.selectedTables.getModel().getSize());
-                assertEquals(0, metadataTable.getRowCount());
+                assertEquals(1, mbView.selectedTables.getModel().getSize());
+                assertEquals(1, metadataTable.getRowCount());
             }
         });
     }

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/preferences/SedPreferencesTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/preferences/SedPreferencesTest.java
@@ -109,8 +109,8 @@ public class SedPreferencesTest {
         sed.addSegment(seg2);
         
         prefs.refresh();
-        assertEquals("_my segment", prefs.getSegmentPreferences(seg1).getSuffix());
-        assertEquals("_my segment 1", prefs.getSegmentPreferences(seg2).getSuffix());
+        assertEquals("my segment", prefs.getSegmentPreferences(seg1).getSuffix());
+        assertEquals("my segment 1", prefs.getSegmentPreferences(seg2).getSuffix());
         
         // add another segment of the same target name
         // suffix number should go up 1
@@ -119,6 +119,6 @@ public class SedPreferencesTest {
         sed.addSegment(seg3);
         
         prefs.refresh();
-        assertEquals("_my segment 2", prefs.getSegmentPreferences(seg3).getSuffix());
+        assertEquals("my segment 2", prefs.getSegmentPreferences(seg3).getSuffix());
     }
 }

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/preferences/VisualizerComponentPreferencesTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/preferences/VisualizerComponentPreferencesTest.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2016 Smithsonian Astrophysical Observatory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package cfa.vo.iris.visualizer.preferences;
 
 import static cfa.vo.iris.test.unit.TestUtils.createSampleSegment;

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/preferences/VisualizerComponentPreferencesTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/preferences/VisualizerComponentPreferencesTest.java
@@ -1,0 +1,59 @@
+package cfa.vo.iris.visualizer.preferences;
+
+import static cfa.vo.iris.test.unit.TestUtils.createSampleSegment;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import cfa.vo.iris.IWorkspace;
+import cfa.vo.iris.sed.ExtSed;
+import cfa.vo.iris.test.unit.StubWorkspace;
+import cfa.vo.sedlib.Segment;
+
+public class VisualizerComponentPreferencesTest {
+
+    @Test
+    public void testPreferences() throws Exception {
+        ExtSed sed = new ExtSed("test");
+        IWorkspace ws = new StubWorkspace();
+        
+        VisualizerComponentPreferences prefs = new VisualizerComponentPreferences(ws) {
+            @Override
+            protected void addSedListeners() {}
+        };
+        assertEquals(0, prefs.getSelectedLayers().size());
+        assertEquals(0, prefs.getSedPreferences().size());
+        assertEquals(0, prefs.getSelectedLayers().size());
+        assertNull(prefs.getSelectedSedPreferences());
+        
+        // Add SED
+        prefs.update(sed);
+        assertEquals(1, prefs.getSedPreferences().size());
+        assertEquals(0, prefs.getSedPreferences(sed).getAllSegmentPreferences().size());
+        
+        // Add segment to SED
+        Segment seg1 = createSampleSegment();
+        sed.addSegment(seg1);
+        prefs.update(sed, seg1);
+        assertEquals(1, prefs.getSedPreferences().size());
+        assertEquals(1, prefs.getSedPreferences(sed).getAllSegmentPreferences().size());
+        
+        // Add another segment
+        Segment seg2 = createSampleSegment(new double[] {1}, new double[] {2});
+        sed.addSegment(seg2);
+        prefs.update(sed, seg2);
+        assertEquals(1, prefs.getSedPreferences().size());
+        assertEquals(2, prefs.getSedPreferences(sed).getAllSegmentPreferences().size());
+        
+        // Remove the first segment
+        prefs.remove(sed, seg1);
+        assertEquals(1, prefs.getSedPreferences().size());
+        assertEquals(1, prefs.getSedPreferences(sed).getAllSegmentPreferences().size());
+        
+        // Remove the SED
+        prefs.remove(sed);
+        assertEquals(0, prefs.getSelectedLayers().size());
+        assertEquals(0, prefs.getSedPreferences().size());
+        assertEquals(0, prefs.getSelectedLayers().size());
+    }
+}

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/StilPlotterTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/StilPlotterTest.java
@@ -150,7 +150,7 @@ public class StilPlotterTest {
         
         sed.removeSegment(0);
         preferences.remove(sed, seg);
-        plot.redraw();
+        plot.redraw(true);
         display = plot.getPlotDisplay();
 
         // Verify no layers

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/StilPlotterTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/StilPlotterTest.java
@@ -63,7 +63,7 @@ public class StilPlotterTest {
         MapEnvironment env = plot.getEnv();
 
         // check shape
-        StringParameter par = new StringParameter("shape_3C 273");
+        StringParameter par = new StringParameter("shape3C 273");
         env.acquireValue(par);
         assertEquals(par.objectValue(env), "open_circle");
         
@@ -76,7 +76,7 @@ public class StilPlotterTest {
         assertEquals(log.objectValue(env), true);
         
         // check errorbars shape
-        par.setName("errorbar_3C 273_ERROR");
+        par.setName("errorbar3C 273_ERROR");
         env.acquireValue(par);
         assertEquals(par.objectValue(env), "capped_lines");
         

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/StilPlotterTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/StilPlotterTest.java
@@ -44,7 +44,7 @@ public class StilPlotterTest {
     public StilPlotterTest() {
         preferences = new VisualizerComponentPreferences(ws) {
             @Override
-            protected void addSedListener() {}
+            protected void addSedListeners() {}
         };
         
     }


### PR DESCRIPTION
Closes https://github.com/ChandraCXC/iris-dev/issues/7

Adds a segment event listener to the VisualizerComponentPrefereces settings to give the plotter/metadata browser more detailed information into sedmanager changes, allowing more efficient updates of the model and GUI. This change drastically improves performance in the plotter - at least while testing on my box and on my laptop.

This overlaps slightly with https://github.com/ChandraCXC/iris/pull/262, and this should probably be incorporated in some manner so that changing plot preferences doesn't reset the existing plot bounds.

Important note - we have access to the plotter bounds though the plane aspect object in the PlotDisplay.

