### PR TITLE
iris-dev#19 Viewing Multiple Segments in the Metadata Browser

### DIFF
--- a/iris-common/src/main/java/cfa/vo/iris/sed/stil/SegmentStarTable.java
+++ b/iris-common/src/main/java/cfa/vo/iris/sed/stil/SegmentStarTable.java
@@ -54,6 +54,7 @@ public class SegmentStarTable extends ColumnStarTable {
 
     private double[] specValues;
     private double[] fluxValues;
+    private double[] originalFluxValues;
 
     private double[] specErrValues;
     private double[] specErrValuesLo;
@@ -84,6 +85,7 @@ public class SegmentStarTable extends ColumnStarTable {
         
         setSpecValues(segment.getSpectralAxisValues());
         setFluxValues(segment.getFluxAxisValues());
+        setOriginalFluxValues(segment.getFluxAxisValues());
         
         // Try to add flux error values
         this.fluxErrValues = (double[]) getDataFromSegment(Utypes.SEG_DATA_FLUXAXIS_ACC_STATERR);
@@ -138,6 +140,9 @@ public class SegmentStarTable extends ColumnStarTable {
         if (fluxValues != null) {
             setFluxValues(units.convertY(fluxValues, specValues, fluxUnits, specUnits, newUnit));
         }
+        if (originalFluxValues != null) {
+            setOriginalFluxValues(units.convertY(originalFluxValues, specValues, fluxUnits, specUnits, newUnit));
+        }
         if (fluxErrValues != null) {
             setFluxErrValues(units.convertY(fluxErrValues, specValues, fluxUnits, specUnits, newUnit));
         }
@@ -166,19 +171,22 @@ public class SegmentStarTable extends ColumnStarTable {
     void setSpecValues(double[] specValues) {
         removeColumn(Column.SPECTRAL_COL);
         this.specValues = specValues;
-        
-        if (!isEmpty(specValues))
-            addColumn(PrimitiveArrayColumn.makePrimitiveColumn(
-                Column.SPECTRAL_COL.getColumnInfo(), (Object) specValues));
+        addColumn(PrimitiveArrayColumn.makePrimitiveColumn(
+            Column.SPECTRAL_COL.getColumnInfo(), (Object) specValues));
     }
 
     void setFluxValues(double[] fluxValues) {
         removeColumn(Column.FLUX_COL);
         this.fluxValues = fluxValues;
-        
-        if (!isEmpty(fluxValues))
-            addColumn(PrimitiveArrayColumn.makePrimitiveColumn(
-                Column.FLUX_COL.getColumnInfo(), (Object) fluxValues));
+        addColumn(PrimitiveArrayColumn.makePrimitiveColumn(
+            Column.FLUX_COL.getColumnInfo(), (Object) fluxValues));
+    }
+    
+    void setOriginalFluxValues(double[] originalFluxValues) {
+        removeColumn(Column.ORIGINAL_FLUX_COL);
+        this.originalFluxValues = originalFluxValues;
+        addColumn(PrimitiveArrayColumn.makePrimitiveColumn(
+            Column.ORIGINAL_FLUX_COL.getColumnInfo(), (Object) originalFluxValues));
     }
 
     void setSpecErrValues(double[] specErrValues) {
@@ -217,12 +225,14 @@ public class SegmentStarTable extends ColumnStarTable {
                 Column.FLUX_ERR_LO.getColumnInfo(), (Object) fluxErrValuesLo));
     }
     
-    private void removeColumn(Column column) {
+    private int removeColumn(Column column) {
         for (int i=0; i<columns.size(); i++) {
             if (column.name().equals(getColumnData(i).getColumnInfo().getName())) {
                 columns.remove(i);
+                return i;
             }
         }
+        return -1;
     }
 
     /*
@@ -282,7 +292,8 @@ public class SegmentStarTable extends ColumnStarTable {
         SPECTRAL_ERR_LO("X axis low error values", "iris.spec.value"),
         FLUX_COL("Y axis values", "iris.flux.value"),
         FLUX_ERR_HI("Y axis error values", "iris.flux.value"),
-        FLUX_ERR_LO("Y axis low error values", "iris.flux.value");
+        FLUX_ERR_LO("Y axis low error values", "iris.flux.value"),
+        ORIGINAL_FLUX_COL("Original flux values", "iris.flux.value.original");
         
         public String description;
         public String utype;

--- a/iris-common/src/main/java/cfa/vo/iris/sed/stil/SegmentStarTable.java
+++ b/iris-common/src/main/java/cfa/vo/iris/sed/stil/SegmentStarTable.java
@@ -16,14 +16,16 @@
 
 package cfa.vo.iris.sed.stil;
 
+import java.io.IOException;
 import java.util.UUID;
 import java.util.logging.Logger;
 
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
+
+import uk.ac.starlink.table.ColumnData;
 import uk.ac.starlink.table.ColumnInfo;
 import uk.ac.starlink.table.ColumnStarTable;
-import uk.ac.starlink.table.ConstantColumn;
 import uk.ac.starlink.table.PrimitiveArrayColumn;
 import cfa.vo.iris.units.UnitsException;
 import cfa.vo.iris.units.UnitsManager;
@@ -50,6 +52,7 @@ public class SegmentStarTable extends ColumnStarTable {
     private static final UnitsManager units = Default.getInstance().getUnitsManager();
     
     private Segment segment;
+    private NameColumn nameColumn;
     private XUnit specUnits;
     private YUnit fluxUnits;
 
@@ -73,6 +76,8 @@ public class SegmentStarTable extends ColumnStarTable {
         this.segment = segment;
         this.specUnits = units.newXUnits(segment.getSpectralAxisUnits());
         this.fluxUnits = units.newYUnits(segment.getFluxAxisUnits());
+        
+        this.nameColumn = new NameColumn(null);
         this.setName(id);
         
         // Look for a name in the segment if we are not given one
@@ -85,7 +90,7 @@ public class SegmentStarTable extends ColumnStarTable {
         }
         
         // Add a constant column for name
-        this.addColumn(new ConstantColumn(Column.Segment_Id.getColumnInfo(), getName()));
+        this.addColumn(nameColumn);
         
         // Add spectral, flux, and original flux values
         setSpecValues(segment.getSpectralAxisValues());
@@ -124,6 +129,12 @@ public class SegmentStarTable extends ColumnStarTable {
     @Override
     public long getRowCount() {
         return segment.getData().getLength();
+    }
+    
+    @Override
+    public void setName(String name) {
+        super.setName(name);
+        nameColumn.setName(name);
     }
 
     // TODO: Make sure this logic makes sense W.R.T. what's in the Units package.
@@ -328,6 +339,29 @@ public class SegmentStarTable extends ColumnStarTable {
         
         public ColumnInfo getColumnInfo() {
             return new ColumnInfo(columnInfo);
+        }
+    }
+    
+    /**
+     * Similar to a ConstantColumn, but with an adjustable name value.
+     *
+     */
+    private static class NameColumn extends ColumnData {
+        
+        private String name;
+        
+        public NameColumn(String name) {
+            super(Column.Segment_Id.getColumnInfo());
+            this.name = name;
+        }
+        
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public Object readValue(long arg0) throws IOException {
+            return name;
         }
     }
 }

--- a/iris-common/src/main/java/cfa/vo/iris/sed/stil/SegmentStarTable.java
+++ b/iris-common/src/main/java/cfa/vo/iris/sed/stil/SegmentStarTable.java
@@ -17,6 +17,8 @@
 package cfa.vo.iris.sed.stil;
 
 import java.io.IOException;
+import java.util.Iterator;
+import java.util.TreeSet;
 import java.util.UUID;
 import java.util.logging.Logger;
 
@@ -25,8 +27,7 @@ import org.apache.commons.lang.StringUtils;
 
 import uk.ac.starlink.table.ColumnData;
 import uk.ac.starlink.table.ColumnInfo;
-import uk.ac.starlink.table.ColumnStarTable;
-import uk.ac.starlink.table.PrimitiveArrayColumn;
+import uk.ac.starlink.table.RandomStarTable;
 import cfa.vo.iris.units.UnitsException;
 import cfa.vo.iris.units.UnitsManager;
 import cfa.vo.iris.units.XUnit;
@@ -40,30 +41,35 @@ import cfa.vo.utils.Default;
 /**
  * StarTable implementation based on the data contained in an SED segment - designed 
  * specifically for use in plotting applications. The Star table will have at least 2 and 
- * no more than 6 columns representing spectral and flux values and error ranges.
- * 
- * TODO: This should ultimately accept any primitive array data and units and manage its data
- *   accordingly.
+ * no more than 8 columns representing spectral and flux values and error ranges.
  *
  */
-public class SegmentStarTable extends ColumnStarTable {
+public class SegmentStarTable extends RandomStarTable {
     
     private static final Logger logger = Logger.getLogger(SegmentStarTable.class.getName());
     private static final UnitsManager units = Default.getInstance().getUnitsManager();
     
     private Segment segment;
-    private NameColumn nameColumn;
     private XUnit specUnits;
     private YUnit fluxUnits;
+    private final long rows;
 
+    // nameColumn will always be the first column in this star table
+    private NameColumn nameColumn;
+    
+    // Maintain a sorted set of data columns
+    private TreeSet<SegmentDataColumn> columns;
+    
+    // Data holders
     private double[] specValues;
     private double[] fluxValues;
     private double[] originalFluxValues;
-
     private double[] specErrValues;
     private double[] specErrValuesLo;
+    private double[] specErrValuesHi;
     private double[] fluxErrValues;
     private double[] fluxErrValuesLo;
+    private double[] fluxErrValuesHi;
     
     public SegmentStarTable(Segment segment) 
             throws SedNoDataException, UnitsException, SedInconsistentException {
@@ -76,54 +82,60 @@ public class SegmentStarTable extends ColumnStarTable {
         this.segment = segment;
         this.specUnits = units.newXUnits(segment.getSpectralAxisUnits());
         this.fluxUnits = units.newYUnits(segment.getFluxAxisUnits());
+        this.columns = new TreeSet<SegmentDataColumn>();
         
         this.nameColumn = new NameColumn(null);
-        this.setName(id);
         
         // Look for a name in the segment if we are not given one
         if (StringUtils.isBlank(id)) {
             if (segment.isSetTarget() && segment.getTarget().isSetName()) {
-                setName(segment.getTarget().getName().getValue());
+                id = segment.getTarget().getName().getValue();
             } else {
-                setName(UUID.randomUUID().toString());
+                id = UUID.randomUUID().toString();
             }
         }
         
-        // Add a constant column for name
-        this.addColumn(nameColumn);
+        // Set star tabel name
+        setName(id);
+        
+        // Set number of rows for this table
+        rows = segment.getLength();
         
         // Add spectral, flux, and original flux values
         setSpecValues(segment.getSpectralAxisValues());
         setFluxValues(segment.getFluxAxisValues());
-        setOriginalFluxValues(segment.getFluxAxisValues());
+        setOriginalFluxValues(segment.getFluxAxisValues()); // Copies data so these aren't the same
         
         // Try to add flux error values
-        this.fluxErrValues = (double[]) getDataFromSegment(Utypes.SEG_DATA_FLUXAXIS_ACC_STATERR);
-        if (isEmpty(fluxErrValues)) {
-            fluxErrValues = (double[]) getDataFromSegment(Utypes.SEG_DATA_FLUXAXIS_ACC_STATERRHIGH);
-            fluxErrValuesLo = (double[]) getDataFromSegment(Utypes.SEG_DATA_FLUXAXIS_ACC_STATERRLOW);
-        }
-        setFluxErrValues(fluxErrValues);
-        setFluxErrValuesLo(fluxErrValuesLo);
+        setFluxErrValues((double[]) getDataFromSegment(Utypes.SEG_DATA_FLUXAXIS_ACC_STATERR));
+        setFluxErrValuesHi((double[]) getDataFromSegment(Utypes.SEG_DATA_FLUXAXIS_ACC_STATERRHIGH));
+        setFluxErrValuesLo((double[]) getDataFromSegment(Utypes.SEG_DATA_FLUXAXIS_ACC_STATERRLOW));
         
         // Try to add spectral error columns
-        specErrValues = (double[]) getDataFromSegment(Utypes.SEG_DATA_SPECTRALAXIS_ACC_STATERR);
-        if (isEmpty(specErrValues)) {
-            specErrValues = (double[]) getDataFromSegment(Utypes.SEG_DATA_SPECTRALAXIS_ACC_STATERRHIGH);
-            specErrValuesLo = (double[]) getDataFromSegment(Utypes.SEG_DATA_SPECTRALAXIS_ACC_STATERRLOW);
-        }
-        setSpecErrValues(specErrValues);
-        setSpecErrValuesLo(specErrValuesLo);
+        setSpecErrValues((double[]) getDataFromSegment(Utypes.SEG_DATA_SPECTRALAXIS_ACC_STATERR));
+        setSpecErrValuesHi((double[]) getDataFromSegment(Utypes.SEG_DATA_SPECTRALAXIS_ACC_STATERRHIGH));
+        setSpecErrValuesLo((double[]) getDataFromSegment(Utypes.SEG_DATA_SPECTRALAXIS_ACC_STATERRLOW));
     }
 
-    private double[] getDataFromSegment(int utype) {
-        double[] ret = null;
-        try {
-            ret = (double[]) segment.getData().getDataValues(utype);
-        } catch (SedNoDataException | SedInconsistentException e) {
-            logger.fine("Cannot read data for segment for utype: " + e.getLocalizedMessage());
+    @Override
+    public int getColumnCount() {
+        return 1 + columns.size();
+    }
+    
+    public ColumnData getColumnData(int index) {
+        if (index == 0) {
+            return nameColumn;
         }
-        return ret;
+        
+        Iterator<SegmentDataColumn> it = columns.iterator();
+        for (int i=0; i<index-1; i++) it.next();
+        return it.next();
+    }
+    
+
+    @Override
+    public ColumnInfo getColumnInfo(int index) {
+        return getColumnData(index).getColumnInfo();
     }
 
     @Override
@@ -132,28 +144,50 @@ public class SegmentStarTable extends ColumnStarTable {
     }
     
     @Override
+    public Object getCell( long lrow, int icol ) throws IOException {
+        return getColumnData(icol).readValue( lrow );
+    }
+    
+    @Override
     public void setName(String name) {
         super.setName(name);
         nameColumn.setName(name);
     }
-
-    // TODO: Make sure this logic makes sense W.R.T. what's in the Units package.
+    
+    /**
+     * Sets the spectral axis units for this star table, which updates all spectral
+     * valued columns in the table. As this may also alter the flux axis units,
+     * this method calls to update flux values as well.
+     * 
+     * @param newUnit
+     * @throws UnitsException
+     */
     public void setSpecUnits(XUnit newUnit) throws UnitsException {
         if (newUnit.equals(this.specUnits)) return;
         
         setSpecValues(units.convertX(specValues, specUnits, newUnit));
         setSpecErrValues(units.convertX(specErrValues, specUnits, newUnit));
         setSpecErrValuesLo(units.convertX(specErrValuesLo, specUnits, newUnit));
+        setSpecErrValuesHi(units.convertX(specErrValuesHi, specUnits, newUnit));
         specUnits = newUnit;
         
         // This may change Y values, so update them accordingly.
         setFluxUnits(fluxUnits);
+        
+        // Update column unit values
         for (int i=0; i<this.getColumnCount(); i++) {
             if (StringUtils.contains(getColumnInfo(i).getUtype(), "spec"))
                 getColumnInfo(i).setUnitString(newUnit.toString());
         }
     }
     
+    /**
+     * Sets the flux axis units for this star table, which updates all relevat flux
+     * valued columns in the table.
+     * 
+     * @param newUnit
+     * @throws UnitsException
+     */
     public void setFluxUnits(YUnit newUnit) throws UnitsException {
         if (specValues == null) return;
         
@@ -170,6 +204,9 @@ public class SegmentStarTable extends ColumnStarTable {
         if (fluxErrValuesLo != null) {
             setFluxErrValuesLo(units.convertY(fluxErrValuesLo, specValues, fluxUnits, specUnits, newUnit));
         }
+        if (fluxErrValuesHi != null) {
+            setFluxErrValuesHi(units.convertY(fluxErrValuesLo, specValues, fluxUnits, specUnits, newUnit));
+        }
         
         // Update values
         fluxUnits = newUnit;
@@ -179,122 +216,141 @@ public class SegmentStarTable extends ColumnStarTable {
         }
     }
 
+    /**
+     * @return XUnit for this star table
+     */
     public XUnit getSpecUnits() {
         return specUnits;
     }
 
+    /**
+     * @return YUnit for this star table
+     */
     public YUnit getFluxUnits() {
         return fluxUnits;
     }
 
     /*
-     * Setters overwrite existing column data, package protected at the moment,
-     * but in the future we may want to be able to manually specify array data to
-     * plot.
      * 
-     */
-    
-    void setSpecValues(double[] specValues) {
-        removeColumn(Column.Spectral_Value);
-        this.specValues = specValues;
-        addColumn(PrimitiveArrayColumn.makePrimitiveColumn(
-            Column.Spectral_Value.getColumnInfo(), (Object) specValues));
-    }
-
-    void setFluxValues(double[] fluxValues) {
-        removeColumn(Column.Flux_Value);
-        this.fluxValues = fluxValues;
-        addColumn(PrimitiveArrayColumn.makePrimitiveColumn(
-            Column.Flux_Value.getColumnInfo(), (Object) fluxValues));
-    }
-    
-    void setOriginalFluxValues(double[] originalFluxValues) {
-        removeColumn(Column.Original_Flux_Value);
-        this.originalFluxValues = originalFluxValues;
-        addColumn(PrimitiveArrayColumn.makePrimitiveColumn(
-            Column.Original_Flux_Value.getColumnInfo(), (Object) originalFluxValues));
-    }
-
-    void setSpecErrValues(double[] specErrValues) {
-        removeColumn(Column.Spectral_Error);
-        this.specErrValues = specErrValues;
-        
-        if (!isEmpty(specErrValues))
-            addColumn(PrimitiveArrayColumn.makePrimitiveColumn(
-                Column.Spectral_Error.getColumnInfo(), (Object) specErrValues));
-    }
-
-    void setSpecErrValuesLo(double[] specErrValuesLo) {
-        removeColumn(Column.Spectral_Error_Low);
-        this.specErrValuesLo = specErrValuesLo;
-        
-        if (!isEmpty(specErrValuesLo))
-            addColumn(PrimitiveArrayColumn.makePrimitiveColumn(
-                Column.Spectral_Error_Low.getColumnInfo(), (Object) specErrValuesLo));
-    }
-
-    void setFluxErrValues(double[] fluxErrValues) {
-        removeColumn(Column.Flux_Error);
-        this.fluxErrValues = fluxErrValues;
-        
-        if (!isEmpty(fluxErrValues))
-            addColumn(PrimitiveArrayColumn.makePrimitiveColumn(
-                Column.Flux_Error.getColumnInfo(), (Object) fluxErrValues));
-    }
-
-    void setFluxErrValuesLo(double[] fluxErrValuesLo) {
-        removeColumn(Column.FLux_Error_Low);
-        this.fluxErrValuesLo = fluxErrValuesLo;
-        
-        if (!isEmpty(fluxErrValuesLo))
-            addColumn(PrimitiveArrayColumn.makePrimitiveColumn(
-                Column.FLux_Error_Low.getColumnInfo(), (Object) fluxErrValuesLo));
-    }
-    
-    private int removeColumn(Column column) {
-        for (int i=0; i<columns.size(); i++) {
-            if (column.name().equals(getColumnData(i).getColumnInfo().getName())) {
-                columns.remove(i);
-                return i;
-            }
-        }
-        return -1;
-    }
-
-    /*
-     * Getters for specific column values, as of now they are only used by the 
-     * unit tests, but we may want to expose this for efficiency at some point.
+     * Getters and setters for data columns. As of now protected, but we may want
+     * to make them public at some point for updating data directly.
      * 
      */
     
     protected double[] getSpecValues() {
         return specValues;
     }
+    
+    protected void setSpecValues(double[] specValues) {
+        this.specValues = specValues;
+        updateColumnValues(specValues, Column.Spectral_Value);
+    }
 
-    protected double[] getFluxValues() {
+    public double[] getFluxValues() {
         return fluxValues;
     }
-    
-    protected double[] getOriginalFluxValues() {
+
+    public void setFluxValues(double[] fluxValues) {
+        this.fluxValues = fluxValues;
+        updateColumnValues(fluxValues, Column.Flux_Value);
+    }
+
+    public double[] getOriginalFluxValues() {
         return originalFluxValues;
     }
 
-    protected double[] getSpecErrValues() {
+    public void setOriginalFluxValues(double[] originalFluxValues) {
+        this.originalFluxValues = originalFluxValues;
+        updateColumnValues(fluxValues, Column.Original_Flux_Value);
+    }
+
+    public double[] getSpecErrValues() {
         return specErrValues;
     }
 
-    protected double[] getSpecErrValuesLo() {
+    public void setSpecErrValues(double[] specErrValues) {
+        this.specErrValues = specErrValues;
+        updateColumnValues(specErrValues, Column.Spectral_Error);
+    }
+
+    public double[] getSpecErrValuesLo() {
         return specErrValuesLo;
     }
 
-    protected double[] getFluxErrValues() {
+    public void setSpecErrValuesLo(double[] specErrValuesLo) {
+        this.specErrValuesLo = specErrValuesLo;
+        updateColumnValues(specErrValuesLo, Column.Spectral_Error_Low);
+    }
+
+    public double[] getSpecErrValuesHi() {
+        return specErrValuesHi;
+    }
+
+    public void setSpecErrValuesHi(double[] specErrValuesHi) {
+        this.specErrValuesHi = specErrValuesHi;
+        updateColumnValues(specErrValuesHi, Column.Spectral_Error_High);
+    }
+
+    public double[] getFluxErrValues() {
         return fluxErrValues;
     }
 
-    protected double[] getFluxErrValuesLo() {
+    public void setFluxErrValues(double[] fluxErrValues) {
+        this.fluxErrValues = fluxErrValues;
+        updateColumnValues(fluxErrValues, Column.Flux_Error);
+    }
+
+    public double[] getFluxErrValuesLo() {
         return fluxErrValuesLo;
     }
+
+    public void setFluxErrValuesLo(double[] fluxErrValuesLo) {
+        this.fluxErrValuesLo = fluxErrValuesLo;
+        updateColumnValues(fluxErrValuesLo, Column.FLux_Error_Low);
+    }
+
+    public double[] getFluxErrValuesHi() {
+        return fluxErrValuesHi;
+    }
+
+    public void setFluxErrValuesHi(double[] fluxErrValuesHi) {
+        this.fluxErrValuesHi = fluxErrValuesHi;
+        updateColumnValues(fluxErrValuesHi, Column.Flux_Error_High);
+    }
+
+    /**
+     * Attempts to extract data with the specified Utype from the segment.
+     * 
+     */
+    private double[] getDataFromSegment(int utype) {
+        double[] ret = null;
+        try {
+            ret = (double[]) segment.getData().getDataValues(utype);
+        } catch (SedNoDataException | SedInconsistentException e) {
+            logger.fine("Cannot read data for segment for utype: " + e.getLocalizedMessage());
+        }
+        return ret;
+    }
     
+    /**
+     * Sets, adds, or removes the relevant data from this star table.
+     * 
+     */
+    private void updateColumnValues(double[] data, Column column) {
+        SegmentDataColumn newColumn = new SegmentDataColumn(column, data);
+        columns.remove(newColumn);
+        
+        // If there is nothing in the dataset then remove this column
+        if (isEmpty(data)) {
+            return;
+        }
+        
+        if (data.length != this.rows) {
+            throw new IllegalArgumentException("Data must have equal length to existing segments");
+        }
+        columns.add(newColumn);
+    }
+
     /**
      * Returns whether or not a double array is empty or contains all NaNs.
      * 
@@ -310,21 +366,24 @@ public class SegmentStarTable extends ColumnStarTable {
         
         return true;
     }
-
+    
     /**
      * Column info, descriptions, name, and identifiers for flux and spectral
      * values in an SED.
      *
      */
     public enum Column {
+        // Columns will always appear in this order!
         Segment_Id("Segment ID", "iris.segment.id", String.class),
         Spectral_Value("X axis values", "iris.spec.value", Double.class),
-        Spectral_Error("X axis error values", "iris.spec.value.error", Double.class),
-        Spectral_Error_Low("X axis low error values", "iris.spec.value.error.low", Double.class),
         Flux_Value("Y axis values", "iris.flux.value", Double.class),
+        Original_Flux_Value("Original flux values", "iris.flux.value.original", Double.class),
+        Spectral_Error("X axis error values", "iris.spec.value.error", Double.class),
+        Spectral_Error_High("X axis error values", "iris.spec.value.error.high", Double.class),
+        Spectral_Error_Low("X axis low error values", "iris.spec.value.error.low", Double.class),
         Flux_Error("Y axis error values", "iris.flux.value.error", Double.class),
-        FLux_Error_Low("Y axis low error values", "iris.flux.value.error.low", Double.class),
-        Original_Flux_Value("Original flux values", "iris.flux.value.original", Double.class);
+        Flux_Error_High("Y axis error values", "iris.flux.value.error.high", Double.class),
+        FLux_Error_Low("Y axis low error values", "iris.flux.value.error.low", Double.class);
         
         public String description;
         public String utype;
@@ -339,6 +398,69 @@ public class SegmentStarTable extends ColumnStarTable {
         
         public ColumnInfo getColumnInfo() {
             return new ColumnInfo(columnInfo);
+        }
+        
+        public static Column getColumn(String columnName) {
+            for (Column c : Column.values()) {
+                if (c.name().equals(columnName)) {
+                    return c;
+                }
+            }
+            throw new IllegalArgumentException("No such columnName: " + columnName);
+        }
+    }
+    /**
+     * ColumnData class which stores relevant double array data for spectral/flux values.
+     * Note that comperable and compare are all over the Column enum. This is so that the 
+     * set of columns in the star table will remain in line and in order with what data is
+     * available to consumers of this class.
+     *
+     */
+    private static class SegmentDataColumn extends ColumnData implements Comparable<SegmentDataColumn> {
+        
+        public final Column column;
+        public double[] data;
+        
+        public SegmentDataColumn(Column column, double[] data) {
+            this.column = column;
+            this.data = data;
+            this.setColumnInfo(column.getColumnInfo());
+        }
+
+        @Override
+        public Object readValue(long i) throws IOException {
+            if (i > Integer.MAX_VALUE) {
+                throw new IOException("Segment data columns backed by integer indexed arrays");
+            }
+            return data[(int) i];
+        }
+        
+        @Override
+        public void storeValue( long i, Object val ) throws IOException {
+            if (!(val instanceof Double)) {
+                throw new IOException("Segment data columns only store doubles");
+            }
+            if (i > Integer.MAX_VALUE) {
+                throw new IOException("Segment data columns backed by integer indexed arrays");
+            }
+            data[(int) i] = (Double) val;
+        }
+
+        @Override
+        public int compareTo(SegmentDataColumn arg0) {
+            SegmentDataColumn o = (SegmentDataColumn) arg0;
+            return column.compareTo(o.column);
+        }
+        
+        @Override
+        public boolean equals(Object arg0) {
+            SegmentDataColumn o = (SegmentDataColumn) arg0;
+            return column.equals(o.column);
+        }
+        
+        @Override
+        public int hashCode() {
+            return column.hashCode();
         }
     }
     

--- a/iris-common/src/main/java/cfa/vo/iris/sed/stil/SegmentStarTable.java
+++ b/iris-common/src/main/java/cfa/vo/iris/sed/stil/SegmentStarTable.java
@@ -192,21 +192,11 @@ public class SegmentStarTable extends RandomStarTable {
         if (specValues == null) return;
         
         // Convert units
-        if (fluxValues != null) {
-            setFluxValues(units.convertY(fluxValues, specValues, fluxUnits, specUnits, newUnit));
-        }
-        if (originalFluxValues != null) {
-            setOriginalFluxValues(units.convertY(originalFluxValues, specValues, fluxUnits, specUnits, newUnit));
-        }
-        if (fluxErrValues != null) {
-            setFluxErrValues(units.convertY(fluxErrValues, specValues, fluxUnits, specUnits, newUnit));
-        }
-        if (fluxErrValuesLo != null) {
-            setFluxErrValuesLo(units.convertY(fluxErrValuesLo, specValues, fluxUnits, specUnits, newUnit));
-        }
-        if (fluxErrValuesHi != null) {
-            setFluxErrValuesHi(units.convertY(fluxErrValuesLo, specValues, fluxUnits, specUnits, newUnit));
-        }
+        setFluxValues(units.convertY(fluxValues, specValues, fluxUnits, specUnits, newUnit));
+        setOriginalFluxValues(units.convertY(originalFluxValues, specValues, fluxUnits, specUnits, newUnit));
+        setFluxErrValues(units.convertY(fluxErrValues, specValues, fluxUnits, specUnits, newUnit));
+        setFluxErrValuesLo(units.convertY(fluxErrValuesLo, specValues, fluxUnits, specUnits, newUnit));
+        setFluxErrValuesHi(units.convertY(fluxErrValuesLo, specValues, fluxUnits, specUnits, newUnit));
         
         // Update values
         fluxUnits = newUnit;
@@ -232,16 +222,15 @@ public class SegmentStarTable extends RandomStarTable {
 
     /*
      * 
-     * Getters and setters for data columns. As of now protected, but we may want
-     * to make them public at some point for updating data directly.
+     * Getters and setters for data columns.
      * 
      */
     
-    protected double[] getSpecValues() {
+    public double[] getSpecValues() {
         return specValues;
     }
     
-    protected void setSpecValues(double[] specValues) {
+    public void setSpecValues(double[] specValues) {
         this.specValues = specValues;
         updateColumnValues(specValues, Column.Spectral_Value);
     }

--- a/iris-common/src/main/java/cfa/vo/iris/sed/stil/SegmentStarTable.java
+++ b/iris-common/src/main/java/cfa/vo/iris/sed/stil/SegmentStarTable.java
@@ -308,11 +308,11 @@ public class SegmentStarTable extends ColumnStarTable {
     public enum Column {
         Segment_Id("Segment ID", "iris.segment.id", String.class),
         Spectral_Value("X axis values", "iris.spec.value", Double.class),
-        Spectral_Error("X axis error values", "iris.spec.value", Double.class),
-        Spectral_Error_Low("X axis low error values", "iris.spec.value", Double.class),
+        Spectral_Error("X axis error values", "iris.spec.value.error", Double.class),
+        Spectral_Error_Low("X axis low error values", "iris.spec.value.error.low", Double.class),
         Flux_Value("Y axis values", "iris.flux.value", Double.class),
-        Flux_Error("Y axis error values", "iris.flux.value", Double.class),
-        FLux_Error_Low("Y axis low error values", "iris.flux.value", Double.class),
+        Flux_Error("Y axis error values", "iris.flux.value.error", Double.class),
+        FLux_Error_Low("Y axis low error values", "iris.flux.value.error.low", Double.class),
         Original_Flux_Value("Original flux values", "iris.flux.value.original", Double.class);
         
         public String description;

--- a/iris-common/src/main/java/cfa/vo/iris/sed/stil/SerializingStarTableAdapter.java
+++ b/iris-common/src/main/java/cfa/vo/iris/sed/stil/SerializingStarTableAdapter.java
@@ -17,10 +17,12 @@
 package cfa.vo.iris.sed.stil;
 
 import java.io.ByteArrayOutputStream;
+import java.util.Iterator;
 
 import cfa.vo.sedlib.Sed;
 import cfa.vo.sedlib.Segment;
 import cfa.vo.sedlib.io.VOTableSerializer;
+import uk.ac.starlink.table.DescribedValue;
 import uk.ac.starlink.table.StarTable;
 import uk.ac.starlink.table.StoragePolicy;
 import uk.ac.starlink.table.TableSequence;
@@ -32,15 +34,19 @@ public class SerializingStarTableAdapter implements StarTableAdapter<Segment> {
 
     @Override
     public StarTable convertStarTable(Segment data) {
+        Sed tmp = new Sed();
+        StarTable table;
+        
         try {
-            Sed tmp = new Sed();
             tmp.addSegment(data);
             ByteArrayOutputStream os = toVOTable(tmp);
-            StarTable table = convertOSStream(os);
-            return table;
+            table = convertOSStream(os);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+        
+        cleanParameters(table);
+        return table;
     }
     
     private ByteArrayOutputStream toVOTable(Sed sed) throws Exception {
@@ -57,6 +63,16 @@ public class SerializingStarTableAdapter implements StarTableAdapter<Segment> {
         VOTableBuilder votBuilder = new VOTableBuilder();
         TableSequence seq = votBuilder.makeStarTables(ds, StoragePolicy.getDefaultPolicy());
         return seq.nextTable();
+    }
+    
+    private void cleanParameters(StarTable table) {
+        Iterator<?> it = table.getParameters().iterator();
+        while (it.hasNext()) {
+            DescribedValue v = (DescribedValue) it.next();
+            if (v.getValue() == null) {
+                it.remove();
+            }
+        }
     }
 }
 

--- a/iris-common/src/main/java/cfa/vo/iris/utils/UTYPE.java
+++ b/iris-common/src/main/java/cfa/vo/iris/utils/UTYPE.java
@@ -1,8 +1,50 @@
 package cfa.vo.iris.utils;
 
-/**
- * Created by olaurino on 10/28/15.
- */
+import org.apache.commons.lang.StringUtils;
+
+import cfa.vo.sedlib.common.Utypes;
+
 public class UTYPE {
     public final static String FLUX_STAT_ERROR = "Spectrum.Data.FluxAxis.Accuracy.StatError";
+
+    
+    public static String trimPrefix(String utype) {
+        
+        // Remove prefixes if present
+        if (StringUtils.contains(utype, ":")) {
+            utype = utype.split(":")[1];
+        }
+        
+        return utype;
+    }
+    
+    public static boolean compareUtypes(String utype1, String utype2) {
+        
+        // If either of them are empty they are not equal
+        if (StringUtils.isEmpty(utype1) || StringUtils.isEmpty(utype2)) {
+            return false;
+        }
+        
+        // if the strings are equal then they are equals
+        if (StringUtils.equalsIgnoreCase(utype1, utype2)) {
+            return true;
+        }
+        
+        utype1 = trimPrefix(utype1);
+        utype2 = trimPrefix(utype2);
+        
+        // Use Utype comparisons
+        int u1 = Utypes.getUtypeFromString(utype1);
+        int u2 = Utypes.getUtypeFromString(utype2);
+        
+        if (Utypes.INVALID_UTYPE == u1 || Utypes.INVALID_UTYPE == u2) {
+            return false;
+        }
+        
+        if (u1 == u2) {
+            return true;
+        }
+        
+        return false;
+    }
 }

--- a/iris-common/src/test/java/cfa/vo/iris/sed/stil/SegmentStarTableTest.java
+++ b/iris-common/src/test/java/cfa/vo/iris/sed/stil/SegmentStarTableTest.java
@@ -32,34 +32,37 @@ public class SegmentStarTableTest {
         ColumnIdentifier id = new ColumnIdentifier(table);
         
         assertTrue(!StringUtils.isEmpty(table.getName()));
+        assertEquals("3C 273", table.getName());
         assertEquals(455, table.getRowCount());
         assertTrue(table.isRandom());
         
-        assertEquals(new Double("6.17E23"), (Double) table.getCell(0, 0), 100);
-        assertEquals(new Double("6.17E23"), (Double) table.getRow(0)[0], 100);
+        assertEquals(new Double("6.17E23"), (Double) table.getCell(0, 1), 100);
+        assertEquals(new Double("6.17E23"), (Double) table.getRow(0)[1], 100);
 
-        assertEquals(3, table.getColumnCount());
-        assertEquals(Column.SPECTRAL_COL.name(), table.getColumnInfo(0).getName());
-        assertEquals(Column.FLUX_COL.name(), table.getColumnInfo(1).getName());
-        assertEquals(Column.FLUX_ERR_HI.name(), table.getColumnInfo(2).getName());
+        assertEquals(5, table.getColumnCount());
+        assertEquals(Column.Segment_Id.name(), table.getColumnInfo(0).getName());
+        assertEquals(Column.Spectral_Value.name(), table.getColumnInfo(1).getName());
+        assertEquals(Column.Flux_Value.name(), table.getColumnInfo(2).getName());
+        assertEquals(Column.Original_Flux_Value.name(), table.getColumnInfo(3).getName());
+        assertEquals(Column.Flux_Error.name(), table.getColumnInfo(4).getName());
         assertEquals(new XUnits("Hz"), table.getSpecUnits());
         assertEquals(new YUnits("Jy"), table.getFluxUnits());
         
-        int col = id.getColumnIndex(Column.FLUX_ERR_HI.name());
+        int col = id.getColumnIndex(Column.Flux_Error.name());
         assertTrue(col >= 0);
         assertEquals(new Double("4.42E-12"), (Double) table.getCell(0, col));
         
         RowSequence seq = table.getRowSequence();
         assertTrue(seq.next());
-        assertEquals(new Double("6.17E23"), (Double) seq.getRow()[0]);
+        assertEquals(new Double("6.17E23"), (Double) seq.getRow()[1]);
         
         // Basic unit conversion test
         table.setSpecUnits(new XUnits('\u03BC' + "m")); // microns
         table.setFluxUnits(new YUnits("ergs/cm**2/s/a"));
         assertEquals(new Double("4.85E-10"), (Double) table.getSpecValues()[0], 1E-12);
-        assertEquals(new Double("4.85E-10"), (Double) table.getCell(0, 0), 1E-12);
+        assertEquals(new Double("4.85E-10"), (Double) table.getCell(0, 1), 1E-12);
         
-        col = id.getColumnIndex(Column.FLUX_ERR_HI.name());
+        col = id.getColumnIndex(Column.Flux_Error.name());
         assertTrue(col >= 0);
         assertEquals(new Double("5.61E-6"), (Double) table.getCell(0, col), 1E-8);
     }

--- a/iris-common/src/test/java/cfa/vo/iris/sed/stil/SerializingStarTableTest.java
+++ b/iris-common/src/test/java/cfa/vo/iris/sed/stil/SerializingStarTableTest.java
@@ -1,9 +1,9 @@
 package cfa.vo.iris.sed.stil;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.builder.ReflectionToStringBuilder;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -11,6 +11,7 @@ import cfa.vo.sedlib.Sed;
 import cfa.vo.sedlib.Segment;
 import cfa.vo.sedlib.io.SedFormat;
 import cfa.vo.testdata.TestData;
+import uk.ac.starlink.table.DescribedValue;
 import uk.ac.starlink.table.StarTable;
 import uk.ac.starlink.ttools.jel.ColumnIdentifier;
 
@@ -46,5 +47,11 @@ public class SerializingStarTableTest {
 
         assertTrue(id.getColumnIndex(utype + seg_flux_utype) >= 0);
         assertTrue(id.getColumnIndex(utype + seg_spec_utype) >= 0);
+        
+        // Verify no non-null parameters
+        for (Object o : table.getParameters()) {
+            DescribedValue v = (DescribedValue) o;
+            assertNotNull(v.getValue());
+        }
     }
 }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/IrisMetadataTableModel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/IrisMetadataTableModel.java
@@ -24,6 +24,7 @@ import javax.swing.table.AbstractTableModel;
 
 import org.apache.commons.lang.StringUtils;
 
+import cfa.vo.iris.utils.UTYPE;
 import uk.ac.starlink.table.DescribedValue;
 import uk.ac.starlink.table.StarTable;
 import uk.ac.starlink.table.ValueInfo;
@@ -83,7 +84,7 @@ public class IrisMetadataTableModel extends AbstractTableModel {
         columnNames = new String[columnHeaders.length + 1];
         columnNames[0] = "name";
         for (int i=1; i<columnNames.length; i++) {
-            columnNames[i] = columnHeaders[i-1].name;
+            columnNames[i] = columnHeaders[i-1].columnName;
         }
     }
     
@@ -132,11 +133,22 @@ public class IrisMetadataTableModel extends AbstractTableModel {
     private static class ColumnHeader {
         
         public String name;
+        public String columnName;
         public ValueInfo inf;
         
         public ColumnHeader(DescribedValue val) {
             this.inf = val.getInfo();
             this.name = inf.getName();
+            
+            if (val.getInfo() != null && 
+                StringUtils.isNotBlank(val.getInfo().getUtype()))
+            {
+                String utype = UTYPE.trimPrefix(val.getInfo().getUtype());
+                this.columnName = utype;
+            }
+            else {
+                this.columnName = name;
+            }
         }
         
         @Override
@@ -146,20 +158,22 @@ public class IrisMetadataTableModel extends AbstractTableModel {
             
             ColumnHeader o = (ColumnHeader) other;
             
-            if (!StringUtils.equalsIgnoreCase(name, o.name)) {
+            // Different classes cannot be equal
+            if (!inf.getContentClass().equals(o.inf.getContentClass())) {
                 return false;
             }
-            // TODO: Should these be based on more than just name?
-//            if (!inf.getContentClass().equals(o.inf.getContentClass())) {
-//                return false;
-//            }
-//            if (StringUtils.equalsIgnoreCase(inf.getUCD(), o.inf.getUCD())) {
-//                return false;
-//            }
-//            if (StringUtils.equalsIgnoreCase(inf.getUtype(), o.inf.getUtype())) {
-//                return false;
-//            }
-            return true;
+            
+            // If utypes are equal they are equal
+            if (UTYPE.compareUtypes(inf.getUtype(), o.inf.getUtype())) {
+                return true;
+            }
+            
+            // If names are equal, they are equal
+            if (StringUtils.equalsIgnoreCase(name, o.name)) {
+                return true;
+            }
+            
+            return false;
         }
         
         @Override

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.form
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.form
@@ -362,7 +362,6 @@
           <SubComponents>
             <Component class="javax.swing.JList" name="starTableList">
               <Properties>
-                <Property name="selectionMode" type="int" value="0"/>
                 <Property name="cellRenderer" type="javax.swing.ListCellRenderer" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
                   <Connection code="new StarTableCellRenderer()" type="code"/>
                 </Property>

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.form
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.form
@@ -252,7 +252,7 @@
                 </DimensionLayout>
                 <DimensionLayout dim="1">
                   <Group type="103" groupAlignment="0" attributes="0">
-                      <Component id="plotterMetadataScrollPane" alignment="0" pref="462" max="32767" attributes="0"/>
+                      <Component id="plotterMetadataScrollPane" alignment="0" pref="468" max="32767" attributes="0"/>
                   </Group>
                 </DimensionLayout>
               </Layout>
@@ -287,7 +287,7 @@
                 </DimensionLayout>
                 <DimensionLayout dim="1">
                   <Group type="103" groupAlignment="0" attributes="0">
-                      <Component id="pointMetadataScrollPane" alignment="0" pref="462" max="32767" attributes="0"/>
+                      <Component id="pointMetadataScrollPane" alignment="0" pref="468" max="32767" attributes="0"/>
                   </Group>
                 </DimensionLayout>
               </Layout>
@@ -322,7 +322,7 @@
                 </DimensionLayout>
                 <DimensionLayout dim="1">
                   <Group type="103" groupAlignment="0" attributes="0">
-                      <Component id="segmentMetadataScrollPane" alignment="0" pref="462" max="32767" attributes="0"/>
+                      <Component id="segmentMetadataScrollPane" alignment="0" pref="468" max="32767" attributes="0"/>
                   </Group>
                 </DimensionLayout>
               </Layout>

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.form
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.form
@@ -195,9 +195,6 @@
         <Property name="toolTipText" type="java.lang.String" value=""/>
         <Property name="name" type="java.lang.String" value="dataPanel" noResource="true"/>
       </Properties>
-      <BindingProperties>
-        <BindingProperty name="border" source="Form" sourcePath="${selectedSed.id}" target="dataPane" targetPath="border" updateStrategy="0" immediately="false"/>
-      </BindingProperties>
 
       <Layout>
         <DimensionLayout dim="0">

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.java
@@ -217,6 +217,7 @@ public class MetadataBrowserMainView extends javax.swing.JInternalFrame {
         this.segmentDataTable = newTable;
 
         // TODO: Bindings?
+        pointStarJTable.setUtypeAsNames(true);
         pointStarJTable.setStarTable(segmentDataTable);
         pointStarJTable.configureColumnWidths(200, 20);
         

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.java
@@ -25,8 +25,6 @@ import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.ListCellRenderer;
 
-import org.apache.commons.lang.builder.ReflectionToStringBuilder;
-
 import cfa.vo.iris.IWorkspace;
 import cfa.vo.iris.sed.ExtSed;
 import cfa.vo.iris.visualizer.plotter.SegmentLayer;
@@ -35,16 +33,15 @@ import cfa.vo.iris.visualizer.preferences.VisualizerChangeEvent;
 import cfa.vo.iris.visualizer.preferences.VisualizerCommand;
 import cfa.vo.iris.visualizer.preferences.VisualizerComponentPreferences;
 import cfa.vo.iris.visualizer.preferences.VisualizerListener;
-import cfa.vo.iris.visualizer.stil.tables.ColumnMatcher;
+import cfa.vo.iris.visualizer.stil.tables.ColumnInfoMatcher;
 import cfa.vo.iris.visualizer.stil.tables.IrisStarTable;
 import cfa.vo.iris.visualizer.stil.tables.StackedStarTable;
-import cfa.vo.iris.visualizer.stil.tables.UtypeColumnMatcher;
+import cfa.vo.iris.visualizer.stil.tables.UtypeColumnInfoMatcher;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
-import uk.ac.starlink.table.EmptyStarTable;
 import uk.ac.starlink.table.StarTable;
 import uk.ac.starlink.table.gui.StarJTable;
 
@@ -68,7 +65,7 @@ public class MetadataBrowserMainView extends javax.swing.JInternalFrame {
     
     protected StackedStarTable selectedPlotterTable;
     protected StackedStarTable selectedDataTable;
-    protected ColumnMatcher columnMatcher;
+    protected ColumnInfoMatcher columnMatcher;
     
     /**
      * Creates new form MetadataBrowser
@@ -80,7 +77,7 @@ public class MetadataBrowserMainView extends javax.swing.JInternalFrame {
         this.ws = ws;
         
         // TODO: Where should this live?
-        this.columnMatcher = new UtypeColumnMatcher();
+        this.columnMatcher = new UtypeColumnInfoMatcher();
 
         initComponents();
         setChangeListener();

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.java
@@ -143,7 +143,7 @@ public class MetadataBrowserMainView extends javax.swing.JInternalFrame {
         
         for (IrisStarTable table : selectedStarTables) {
             plotterDataTables.add(table.getPlotterTable());
-            segmentDataTables.add(table.getDataTable());
+            segmentDataTables.add(table.getSegmentDataTable());
         }
         
         plotterDataTable = new StackedStarTable(plotterDataTables, columnInfoMatcher);

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.java
@@ -32,7 +32,8 @@ import cfa.vo.iris.visualizer.preferences.VisualizerChangeEvent;
 import cfa.vo.iris.visualizer.preferences.VisualizerCommand;
 import cfa.vo.iris.visualizer.preferences.VisualizerComponentPreferences;
 import cfa.vo.iris.visualizer.preferences.VisualizerListener;
-import cfa.vo.iris.visualizer.stil.IrisStarTable;
+import cfa.vo.iris.visualizer.stil.tables.IrisStarTable;
+
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/SegmentLayer.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/SegmentLayer.java
@@ -109,17 +109,17 @@ public class SegmentLayer {
         // If error columns are available in the underlying star table, the we
         // add them here.
         ColumnIdentifier id = new ColumnIdentifier(inSource);
-        if (shouldAddErrorColumn(Column.SPECTRAL_ERR_HI, id)) {
-            prefs.put(X_ERR_HI + suffix, Column.SPECTRAL_ERR_HI.name());
+        if (shouldAddErrorColumn(Column.Spectral_Error, id)) {
+            prefs.put(X_ERR_HI + suffix, Column.Spectral_Error.name());
         }
-        if (shouldAddErrorColumn(Column.SPECTRAL_ERR_LO, id)) {
-            prefs.put(X_ERR_LO + suffix, Column.SPECTRAL_ERR_LO.name());
+        if (shouldAddErrorColumn(Column.Spectral_Error_Low, id)) {
+            prefs.put(X_ERR_LO + suffix, Column.Spectral_Error_Low.name());
         }
-        if (shouldAddErrorColumn(Column.FLUX_ERR_HI, id)) {
-            prefs.put(Y_ERR_HI + suffix, Column.FLUX_ERR_HI.name());
+        if (shouldAddErrorColumn(Column.Flux_Error, id)) {
+            prefs.put(Y_ERR_HI + suffix, Column.Flux_Error.name());
         }
-        if (shouldAddErrorColumn(Column.FLUX_ERR_LO, id)) {
-            prefs.put(Y_ERR_LO + suffix, Column.FLUX_ERR_LO.name());
+        if (shouldAddErrorColumn(Column.FLux_Error_Low, id)) {
+            prefs.put(Y_ERR_LO + suffix, Column.FLux_Error_Low.name());
         }
         
         prefs.put(TYPE + suffix, LayerType.xyerror.name());
@@ -151,8 +151,8 @@ public class SegmentLayer {
     
     private void addCommonFields(String suffix, Map<String, Object> prefs) {
         prefs.put(IN + suffix, inSource);
-        prefs.put(X_COL + suffix, Column.SPECTRAL_COL.name());
-        prefs.put(Y_COL + suffix, Column.FLUX_COL.name());
+        prefs.put(X_COL + suffix, Column.Spectral_Value.name());
+        prefs.put(Y_COL + suffix, Column.Spectral_Value.name());
         
         if (size != null)
             prefs.put(SIZE + suffix, size);

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/SegmentLayer.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/SegmentLayer.java
@@ -24,7 +24,7 @@ import java.util.logging.Logger;
 
 import cfa.vo.iris.sed.stil.SegmentStarTable.Column;
 import cfa.vo.iris.units.UnitsException;
-import cfa.vo.iris.visualizer.stil.IrisStarTable;
+import cfa.vo.iris.visualizer.stil.tables.IrisStarTable;
 import uk.ac.starlink.ttools.jel.ColumnIdentifier;
 
 public class SegmentLayer {

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/SegmentLayer.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/SegmentLayer.java
@@ -112,13 +112,18 @@ public class SegmentLayer {
         if (shouldAddErrorColumn(Column.Spectral_Error, id)) {
             prefs.put(X_ERR_HI + suffix, Column.Spectral_Error.name());
         }
-        if (shouldAddErrorColumn(Column.Spectral_Error_Low, id)) {
-            prefs.put(X_ERR_LO + suffix, Column.Spectral_Error_Low.name());
-        }
         if (shouldAddErrorColumn(Column.Flux_Error, id)) {
             prefs.put(Y_ERR_HI + suffix, Column.Flux_Error.name());
         }
+        
+        // If lower and upper ranges are specified then we override existing
+        // single bounds.
+        if (shouldAddErrorColumn(Column.Spectral_Error_Low, id)) {
+            prefs.put(X_ERR_HI + suffix, Column.Spectral_Error_High.name());
+            prefs.put(X_ERR_LO + suffix, Column.Spectral_Error_Low.name());
+        }
         if (shouldAddErrorColumn(Column.FLux_Error_Low, id)) {
+            prefs.put(Y_ERR_HI + suffix, Column.Flux_Error_High.name());
             prefs.put(Y_ERR_LO + suffix, Column.FLux_Error_Low.name());
         }
         
@@ -152,7 +157,7 @@ public class SegmentLayer {
     private void addCommonFields(String suffix, Map<String, Object> prefs) {
         prefs.put(IN + suffix, inSource);
         prefs.put(X_COL + suffix, Column.Spectral_Value.name());
-        prefs.put(Y_COL + suffix, Column.Spectral_Value.name());
+        prefs.put(Y_COL + suffix, Column.Flux_Value.name());
         
         if (size != null)
             prefs.put(SIZE + suffix, size);

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedPreferences.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedPreferences.java
@@ -30,7 +30,7 @@ import cfa.vo.iris.visualizer.plotter.ColorPalette;
 import cfa.vo.iris.visualizer.plotter.HSVColorPalette;
 import cfa.vo.iris.units.UnitsException;
 import cfa.vo.iris.visualizer.plotter.SegmentLayer;
-import cfa.vo.iris.visualizer.stil.IrisStarTableAdapter;
+import cfa.vo.iris.visualizer.stil.tables.IrisStarTableAdapter;
 import cfa.vo.sedlib.Segment;
 import cfa.vo.sedlib.common.SedNoDataException;
 

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedPreferences.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedPreferences.java
@@ -30,6 +30,7 @@ import cfa.vo.iris.visualizer.plotter.ColorPalette;
 import cfa.vo.iris.visualizer.plotter.HSVColorPalette;
 import cfa.vo.iris.units.UnitsException;
 import cfa.vo.iris.visualizer.plotter.SegmentLayer;
+import cfa.vo.iris.visualizer.stil.tables.IrisStarTable;
 import cfa.vo.iris.visualizer.stil.tables.IrisStarTableAdapter;
 import cfa.vo.sedlib.Segment;
 import cfa.vo.sedlib.common.SedNoDataException;
@@ -105,12 +106,12 @@ public class SedPreferences {
         
         // If the segment is already in the map remake the star table
         if (segmentPreferences.containsKey(me)) {
-            segmentPreferences.get(me).setInSource(adapter.convertStarTable(seg));
+            segmentPreferences.get(me).setInSource(convertSegment(seg));
             return;
         }
         
         // Ensure that the layer has a unique identifier in the list of segments
-        SegmentLayer layer = new SegmentLayer(adapter.convertStarTable(seg));
+        SegmentLayer layer = new SegmentLayer(convertSegment(seg));
         int count = 0;
         String id = layer.getSuffix();
         while (!isUniqueLayerSuffix(id)) {
@@ -127,6 +128,14 @@ public class SedPreferences {
         setUnits(seg, layer);
         
         segmentPreferences.put(me, layer);
+    }
+    
+    private IrisStarTable convertSegment(Segment seg) {
+        // Convert segments with more than 3000 points asynchronously.
+        if (seg.getLength() > 3000) {
+            return adapter.convertSegmentAsync(seg);
+        }
+        return adapter.convertSegment(seg);
     }
     
     /**

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedPreferences.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedPreferences.java
@@ -102,6 +102,9 @@ public class SedPreferences {
      */
     void addSegment(Segment seg) {
         
+        // Do not keep track of empty segments
+        if (seg == null) return;
+        
         MapKey me = new MapKey(seg);
         
         // If the segment is already in the map remake the star table
@@ -142,8 +145,11 @@ public class SedPreferences {
      * Removes a segment from the sed preferences map.
      * @param segment
      */
-    void removeSegment(Segment segment) {
-        MapKey me = new MapKey(segment);
+    void removeSegment(Segment seg) {
+        // Do not keep track of empty segments
+        if (seg == null) return;
+        
+        MapKey me = new MapKey(seg);
         segmentPreferences.remove(me);
     }
     

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerComponentPreferences.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerComponentPreferences.java
@@ -21,6 +21,9 @@ import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.apache.commons.lang.builder.ReflectionToStringBuilder;
+
 import cfa.vo.iris.IWorkspace;
 import cfa.vo.iris.events.MultipleSegmentEvent;
 import cfa.vo.iris.events.MultipleSegmentListener;
@@ -249,6 +252,7 @@ public class VisualizerComponentPreferences {
 
         @Override
         public void process(Segment segment, SegmentPayload payload) {
+            System.out.println(ReflectionToStringBuilder.toString(segment));
             ExtSed sed = payload.getSed();
             SedCommand command = payload.getSedCommand();
             

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerComponentPreferences.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerComponentPreferences.java
@@ -164,6 +164,9 @@ public class VisualizerComponentPreferences {
      * @param segment
      */
     public void update(ExtSed sed, Segment segment) {
+        // Do nothing for null segments
+        if (segment == null) return;
+        
         if (sedPreferences.containsKey(sed)) {
             sedPreferences.get(sed).addSegment(segment);
         } else {
@@ -181,8 +184,11 @@ public class VisualizerComponentPreferences {
      */
     public void update(ExtSed sed, List<Segment> segments) {
         if (sedPreferences.containsKey(sed)) {
-            for (Segment segment : segments)
+            for (Segment segment : segments) {
+                // Do nothing for null segments
+                if (segment == null) continue;
                 sedPreferences.get(sed).addSegment(segment);
+            }
         } else {
             // The segment will automatically be serialized and attached the the 
             // SedPrefrences since it's assumed to be attached to the SED.
@@ -210,6 +216,9 @@ public class VisualizerComponentPreferences {
      * @param segment
      */
     public void remove(ExtSed sed, Segment segment) {
+        // Do nothing for null segments
+        if (segment == null) return;
+        
         if (sedPreferences.containsKey(sed)) {
             sedPreferences.get(sed).removeSegment(segment);
         }
@@ -224,8 +233,11 @@ public class VisualizerComponentPreferences {
      */
     public void remove(ExtSed sed, List<Segment> segments) {
         if (sedPreferences.containsKey(sed)) {
-            for (Segment segment : segments)
+            for (Segment segment : segments) {
+                // Do nothing for null segments
+                if (segment == null) continue;
                 sedPreferences.get(sed).removeSegment(segment);
+            }
         }
         
         fire(sed, VisualizerCommand.RESET);
@@ -285,6 +297,7 @@ public class VisualizerComponentPreferences {
         }
         
         private void processNotification(Segment segment, SegmentPayload payload) {
+            
             ExtSed sed = payload.getSed();
             SedCommand command = payload.getSedCommand();
             

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerComponentPreferences.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerComponentPreferences.java
@@ -303,9 +303,19 @@ public class VisualizerComponentPreferences {
     }
     
     private class VisualizerMultipleSegmentListener implements MultipleSegmentListener {
-
+        
         @Override
         public void process(java.util.List<Segment> segments, SegmentPayload payload) {
+            try {
+                processNotification(segments, payload);
+            } catch (Exception e) {
+                // TODO: This happens asynchronously, what should we do with
+                // exceptions?
+                e.printStackTrace();
+            }
+        }
+        
+        private void processNotification(java.util.List<Segment> segments, SegmentPayload payload) {
             ExtSed sed = payload.getSed();
             SedCommand command = payload.getSedCommand();
             

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerComponentPreferences.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerComponentPreferences.java
@@ -33,7 +33,7 @@ import cfa.vo.iris.events.SegmentListener;
 import cfa.vo.iris.sed.ExtSed;
 import cfa.vo.iris.visualizer.plotter.PlotPreferences;
 import cfa.vo.iris.visualizer.plotter.SegmentLayer;
-import cfa.vo.iris.visualizer.stil.IrisStarTableAdapter;
+import cfa.vo.iris.visualizer.stil.tables.IrisStarTableAdapter;
 import cfa.vo.sedlib.Segment;
 
 /**

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerComponentPreferences.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerComponentPreferences.java
@@ -22,8 +22,6 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang.builder.ReflectionToStringBuilder;
-
 import cfa.vo.iris.IWorkspace;
 import cfa.vo.iris.events.MultipleSegmentEvent;
 import cfa.vo.iris.events.MultipleSegmentListener;
@@ -36,7 +34,9 @@ import cfa.vo.iris.events.SegmentListener;
 import cfa.vo.iris.sed.ExtSed;
 import cfa.vo.iris.visualizer.plotter.PlotPreferences;
 import cfa.vo.iris.visualizer.plotter.SegmentLayer;
+import cfa.vo.iris.visualizer.stil.tables.ColumnInfoMatcher;
 import cfa.vo.iris.visualizer.stil.tables.IrisStarTableAdapter;
+import cfa.vo.iris.visualizer.stil.tables.UtypeColumnInfoMatcher;
 import cfa.vo.sedlib.Segment;
 
 /**
@@ -48,6 +48,7 @@ public class VisualizerComponentPreferences {
     
     PlotPreferences plotPreferences;
     IrisStarTableAdapter adapter;
+    ColumnInfoMatcher columnInfoMatcher;
     final IWorkspace ws;
     final Map<ExtSed, SedPreferences> sedPreferences;
     
@@ -62,6 +63,9 @@ public class VisualizerComponentPreferences {
         for (ExtSed sed : (List<ExtSed>) ws.getSedManager().getSeds()) {
             update(sed);
         }
+        
+        // TODO: Should this be in preferences?
+        this.columnInfoMatcher = new UtypeColumnInfoMatcher();
         
         // Plotter global preferences
         this.plotPreferences = PlotPreferences.getDefaultPlotPreferences();
@@ -82,6 +86,14 @@ public class VisualizerComponentPreferences {
      */
     public PlotPreferences getPlotPreferences() {
         return plotPreferences;
+    }
+    
+    /**
+     * @return
+     *  ColumnInfoMatcher used in stacking star tables.
+     */
+    public ColumnInfoMatcher getColumnInfoMatcher() {
+        return columnInfoMatcher;
     }
 
     /**
@@ -252,7 +264,6 @@ public class VisualizerComponentPreferences {
 
         @Override
         public void process(Segment segment, SegmentPayload payload) {
-            System.out.println(ReflectionToStringBuilder.toString(segment));
             ExtSed sed = payload.getSed();
             SedCommand command = payload.getSedCommand();
             

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/IrisStarJTable.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/IrisStarJTable.java
@@ -16,6 +16,7 @@
 
 package cfa.vo.iris.visualizer.stil;
 
+import uk.ac.starlink.table.StarTable;
 import uk.ac.starlink.table.gui.StarJTable;
 
 /**
@@ -27,5 +28,10 @@ public class IrisStarJTable extends StarJTable {
     public IrisStarJTable() {
         super(false);
     }
-
+    
+    public void setStarTable(StarTable table) {
+        // Include the index column for non-null/non-empty star tables.
+        boolean showIndex = (table != null && table.getRowCount() > 0);
+        super.setStarTable(table, showIndex);
+    }
 }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/IrisStarJTable.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/IrisStarJTable.java
@@ -16,22 +16,58 @@
 
 package cfa.vo.iris.visualizer.stil;
 
+import org.apache.commons.lang.StringUtils;
+
+import cfa.vo.iris.utils.UTYPE;
 import uk.ac.starlink.table.StarTable;
 import uk.ac.starlink.table.gui.StarJTable;
+import uk.ac.starlink.table.gui.StarTableColumn;
 
 /**
  * Simple bean wrapper for the StarJTable class.
  *
  */
 public class IrisStarJTable extends StarJTable {
-
+    
+    // Use ColumnNames or Utypes in the column header fields
+    private boolean utypeAsNames = false;
+    
     public IrisStarJTable() {
         super(false);
     }
-    
+
     public void setStarTable(StarTable table) {
         // Include the index column for non-null/non-empty star tables.
         boolean showIndex = (table != null && table.getRowCount() > 0);
+        setStarTable(table, showIndex);
+    }
+    
+    public boolean isUtypeAsNames() {
+        return utypeAsNames;
+    }
+
+    public void setUtypeAsNames(boolean utypeAsNames) {
+        this.utypeAsNames = utypeAsNames;
+    }
+    
+    @Override
+    public void setStarTable(StarTable table, boolean showIndex) {
         super.setStarTable(table, showIndex);
+        
+        if (!utypeAsNames) {
+            return;
+        }
+        
+        // If we're using utypes as column names, override existing settings here.
+        for (int i=0;i < columnModel.getColumnCount(); i++) {
+            StarTableColumn c = (StarTableColumn) columnModel.getColumn(i);
+            
+            if (c.getColumnInfo() != null &&
+                StringUtils.isNotBlank(c.getColumnInfo().getUtype()))
+            {
+                String utype = UTYPE.trimPrefix(c.getColumnInfo().getUtype());
+                c.setHeaderValue(utype);
+            }
+        }
     }
 }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/ColumnInfoMatcher.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/ColumnInfoMatcher.java
@@ -6,6 +6,6 @@ import uk.ac.starlink.table.ColumnInfo;
  * Interface for compatibility checks between columns of a StarTable.
  *
  */
-public interface ColumnMatcher {
+public interface ColumnInfoMatcher {
     public boolean isCompatible(ColumnInfo c1, ColumnInfo c2);
 }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/ColumnInfoMatcher.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/ColumnInfoMatcher.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2016 Smithsonian Astrophysical Observatory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package cfa.vo.iris.visualizer.stil.tables;
 
 import uk.ac.starlink.table.ColumnInfo;

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/ColumnMappingStarTable.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/ColumnMappingStarTable.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2016 Smithsonian Astrophysical Observatory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package cfa.vo.iris.visualizer.stil.tables;
 
 import java.util.ArrayList;

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/ColumnMappingStarTable.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/ColumnMappingStarTable.java
@@ -33,7 +33,9 @@ public class ColumnMappingStarTable extends ColumnPermutedStarTable {
         
         // Verify input
         if (baseTable.getColumnCount() > metadataTable.getColumnCount()) {
-            throw new IllegalArgumentException("baseTable must have fewer columns than metadataTable");
+            throw new IllegalArgumentException("baseTable (" + 
+                       baseTable.getColumnCount() + " columns) must have fewer columns than metadataTable (" +
+                       metadataTable.getColumnCount() + ")");
         }
         
         // Init map to all -1

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/ColumnMappingStarTable.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/ColumnMappingStarTable.java
@@ -23,11 +23,11 @@ public class ColumnMappingStarTable extends ColumnPermutedStarTable {
     
     private final StarTable metadataTable;
     private final StarTable originalStarTable;
-    private final ColumnMatcher matcher;
+    private final ColumnInfoMatcher matcher;
 
     public ColumnMappingStarTable(final StarTable baseTable,
                                   StarTable metadataTable,
-                                  ColumnMatcher matcher) 
+                                  ColumnInfoMatcher matcher) 
     {
         super(baseTable, new int[metadataTable.getColumnCount()]);
         

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/ColumnMappingStarTable.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/ColumnMappingStarTable.java
@@ -1,0 +1,102 @@
+package cfa.vo.iris.visualizer.stil.tables;
+
+import java.util.ArrayList;
+
+import cfa.vo.iris.units.UnitsManager;
+import cfa.vo.utils.Default;
+import uk.ac.starlink.table.ColumnInfo;
+import uk.ac.starlink.table.ColumnPermutedStarTable;
+import uk.ac.starlink.table.ConstantStarTable;
+import uk.ac.starlink.table.JoinStarTable;
+import uk.ac.starlink.table.StarTable;
+
+/**
+ * Variation of a column permuted StarTable which maps the columns of a given
+ * StarTable to match up with a provided metadata table. It is required that
+ * the metadata table has more rows than the baseTable. Any excess rows will be
+ * filled in using constant empty columns.
+ *
+ */
+public class ColumnMappingStarTable extends ColumnPermutedStarTable {
+    
+    private static final UnitsManager um = Default.getInstance().getUnitsManager();
+    
+    private final StarTable metadataTable;
+    private final StarTable originalStarTable;
+    private final ColumnMatcher matcher;
+
+    public ColumnMappingStarTable(final StarTable baseTable,
+                                  StarTable metadataTable,
+                                  ColumnMatcher matcher) 
+    {
+        super(baseTable, new int[metadataTable.getColumnCount()]);
+        
+        // Verify input
+        if (baseTable.getColumnCount() > metadataTable.getColumnCount()) {
+            throw new IllegalArgumentException("baseTable must have fewer columns than metadataTable");
+        }
+        
+        // Init map to all -1
+        int[] map = getColumnMap();
+        for (int i=0; i<map.length; i++) {
+            map[i] = -1;
+        }
+        
+        this.metadataTable = metadataTable;
+        this.matcher = matcher;
+        this.originalStarTable = baseTable;
+        
+        computeColumnMap();
+        addNullColumns();
+    }
+    
+    private void computeColumnMap() {
+        
+        for (int i=0; i<metadataTable.getColumnCount(); i++) {
+            ColumnInfo meta = metadataTable.getColumnInfo(i);
+
+            for (int j=0; j<baseTable.getColumnCount(); j++) {
+                ColumnInfo base = baseTable.getColumnInfo(j);
+                
+                // If they're compatible, match this column of the base table to the
+                // metadataTable
+                if (matcher.isCompatible(meta, base)) {
+                    // TODO: Units Conversion
+                    this.getColumnMap()[i] = j;
+                    break;
+                }
+            }
+        }
+    }
+    
+    /**
+     * Need to fill in base table with empty columns to match the metadataTable.
+     */
+    private void addNullColumns() {
+        ArrayList<ColumnInfo> infos = new ArrayList<>(
+                metadataTable.getColumnCount() - baseTable.getColumnCount());
+        
+        // Used to map
+        int counter = baseTable.getColumnCount();
+        int[] map = getColumnMap();
+        
+        for (int i=0; i<map.length; i++) {
+            // If there is no mapping from the base table, then we need to add a new column.
+            if (map[i] == -1) {
+                ColumnInfo inf = metadataTable.getColumnInfo(i);
+                inf.setNullable(true);
+                infos.add(inf);
+                map[i] = counter;
+                counter++;
+            }
+        }
+        
+        StarTable table = new ConstantStarTable(infos.toArray(new ColumnInfo[0]),
+                new Object[infos.size()], baseTable.getRowCount());
+        this.baseTable = new JoinStarTable(new StarTable[] {baseTable, table});
+    }
+    
+    public StarTable getOriginalTable() {
+        return originalStarTable;
+    }
+}

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/ColumnMatcher.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/ColumnMatcher.java
@@ -1,0 +1,11 @@
+package cfa.vo.iris.visualizer.stil.tables;
+
+import uk.ac.starlink.table.ColumnInfo;
+
+/**
+ * Interface for compatibility checks between columns of a StarTable.
+ *
+ */
+public interface ColumnMatcher {
+    public boolean isCompatible(ColumnInfo c1, ColumnInfo c2);
+}

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/ColumnMetadataStarTable.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/ColumnMetadataStarTable.java
@@ -1,0 +1,59 @@
+package cfa.vo.iris.visualizer.stil.tables;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+
+import uk.ac.starlink.table.ColumnData;
+import uk.ac.starlink.table.ColumnInfo;
+import uk.ac.starlink.table.ColumnStarTable;
+import uk.ac.starlink.table.ConstantColumn;
+import uk.ac.starlink.table.StarTable;
+
+/**
+ * StarTable for producing a minimal metadata table for a list of StarTables.
+ *
+ */
+public class ColumnMetadataStarTable extends ColumnStarTable {
+    
+    private List<ColumnInfo> columnInfoList;
+    private List<StarTable> starTables;
+    private ColumnMatcher matcher;
+
+    public ColumnMetadataStarTable(List<? extends StarTable> tables, ColumnMatcher matcher) {
+        super();
+        this.columnInfoList = new LinkedList<>();
+        this.starTables = new ArrayList<>(tables.size());
+        this.matcher = matcher;
+
+        // Iterate over all ColumnInfos and add all unique columns.
+        for (StarTable table : tables) {
+            starTables.add(table);
+            for (int i=0; i<table.getColumnCount(); i++) {
+                if (!hasMatch(table.getColumnInfo(i))) {
+                    columnInfoList.add(table.getColumnInfo(i));
+                }
+            }
+        }
+        
+        // Setup star table with relevant column data.
+        for (ColumnInfo c : columnInfoList) {
+            ColumnData data = new ConstantColumn(c, null);
+            addColumn(data);
+        }
+    }
+    
+    private boolean hasMatch(ColumnInfo data) {
+        for (ColumnInfo info : columnInfoList) {
+            if (matcher.isCompatible(data, info)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public long getRowCount() {
+        return 0;
+    }
+}

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/ColumnMetadataStarTable.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/ColumnMetadataStarTable.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2016 Smithsonian Astrophysical Observatory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package cfa.vo.iris.visualizer.stil.tables;
 
 import java.util.ArrayList;

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/ColumnMetadataStarTable.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/ColumnMetadataStarTable.java
@@ -18,9 +18,9 @@ public class ColumnMetadataStarTable extends ColumnStarTable {
     
     private List<ColumnInfo> columnInfoList;
     private List<StarTable> starTables;
-    private ColumnMatcher matcher;
+    private ColumnInfoMatcher matcher;
 
-    public ColumnMetadataStarTable(List<? extends StarTable> tables, ColumnMatcher matcher) {
+    public ColumnMetadataStarTable(List<? extends StarTable> tables, ColumnInfoMatcher matcher) {
         super();
         this.columnInfoList = new LinkedList<>();
         this.starTables = new ArrayList<>(tables.size());

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/IrisStarTable.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/IrisStarTable.java
@@ -58,6 +58,13 @@ public class IrisStarTable extends WrapperStarTable {
         dataTable.setParameter(value);
     }
     
+    @Override
+    public void setName(String name) {
+        super.setName(name);
+        plotterTable.setName(name);
+        dataTable.setName(name);
+    }
+    
     public StarTable getDataTable() {
         return dataTable;
     }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/IrisStarTable.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/IrisStarTable.java
@@ -32,7 +32,7 @@ public class IrisStarTable extends WrapperStarTable {
     private static final StarTable EMPTY_STARTABLE = new EmptyStarTable();
     
     private Future<StarTable> dataTableHolder;
-    private StarTable dataTable;
+    private StarTable segmentDataTable;
     private SegmentStarTable plotterTable;
     
     IrisStarTable(SegmentStarTable plotterTable, Future<StarTable> dataTableHolder) {
@@ -44,7 +44,7 @@ public class IrisStarTable extends WrapperStarTable {
     {
         super(plotterTable);
         
-        this.dataTable = dataTable;
+        this.segmentDataTable = dataTable;
         this.plotterTable = plotterTable;
         
         setName(plotterTable.getName());
@@ -53,31 +53,31 @@ public class IrisStarTable extends WrapperStarTable {
     @SuppressWarnings("rawtypes")
     @Override 
     public List getParameters() {
-        return dataTable.getParameters();
+        return segmentDataTable.getParameters();
     }
     
     @Override
     public DescribedValue getParameterByName(String parameter) {
-        return dataTable.getParameterByName(parameter);
+        return segmentDataTable.getParameterByName(parameter);
     }
     
     @Override
     public void setParameter(DescribedValue value) {
-        dataTable.setParameter(value);
+        segmentDataTable.setParameter(value);
     }
     
     @Override
     public void setName(String name) {
         super.setName(name);
         plotterTable.setName(name);
-        dataTable.setName(name);
+        segmentDataTable.setName(name);
     }
     
-    public StarTable getDataTable() {
-        if (EMPTY_STARTABLE == dataTable) {
+    public StarTable getSegmentDataTable() {
+        if (EMPTY_STARTABLE == segmentDataTable) {
             checkDataTable();
         }
-        return dataTable;
+        return segmentDataTable;
     }
     
     private void checkDataTable() {
@@ -86,7 +86,7 @@ public class IrisStarTable extends WrapperStarTable {
         }
         
         try {
-            dataTable = dataTableHolder.get();
+            segmentDataTable = dataTableHolder.get();
         } catch (Exception e) {
             // TODO: Maybe show a warning message to users?
             throw new RuntimeException("Could not serialize segment", e);

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/IrisStarTable.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/IrisStarTable.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package cfa.vo.iris.visualizer.stil;
+package cfa.vo.iris.visualizer.stil.tables;
 
 import java.util.List;
 

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/IrisStarTableAdapter.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/IrisStarTableAdapter.java
@@ -18,7 +18,6 @@ package cfa.vo.iris.visualizer.stil.tables;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import cfa.vo.iris.sed.stil.SegmentStarTable;
 import cfa.vo.iris.sed.stil.SerializingStarTableAdapter;
@@ -33,16 +32,27 @@ import uk.ac.starlink.table.StarTable;
 
 public class IrisStarTableAdapter {
     
-    private static final ExecutorService executor = Executors.newFixedThreadPool(2);
+    private final ExecutorService executor;
+    
+    public IrisStarTableAdapter(ExecutorService executor) {
+        this.executor = executor;
+    }
 
-    public IrisStarTable convertStarTable(Segment data) {
+    public IrisStarTable convertSegment(Segment data) {
+        return convert(data, false);
+    }
+    
+    public IrisStarTable convertSegmentAsync(Segment data) {
+        return convert(data, true);
+    }
+    
+    private IrisStarTable convert(Segment data, boolean async) {
         try {
             SegmentStarTable segTable = new SegmentStarTable(data);
             IrisStarTable ret = new IrisStarTable(segTable);
             
-            // Only serialized asynchronously for segments of length >= 3000.
             SerializingStarTableAdapter adapter = new SerializingStarTableAdapter();
-            if (data.getLength() > 3000) {
+            if (async) {
                 executor.submit(new AsyncSerializer(data, ret, adapter));
             } else {
                 ret.setDataTable(adapter.convertStarTable(data));
@@ -53,7 +63,6 @@ public class IrisStarTableAdapter {
             throw new RuntimeException(e);
         }
     }
-    
     
     private static class AsyncSerializer implements Callable<StarTable> {
         
@@ -69,8 +78,11 @@ public class IrisStarTableAdapter {
         
         @Override
         public StarTable call() throws Exception {
+            // Convert and update the datatable
             StarTable converted = adapter.convertStarTable(data);
             table.setDataTable(converted);
+            
+            // Notify components of a change
             notifyVisualizerComponents();
             return converted;
         }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/IrisStarTableAdapter.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/IrisStarTableAdapter.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package cfa.vo.iris.visualizer.stil;
+package cfa.vo.iris.visualizer.stil.tables;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/StackedStarTable.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/StackedStarTable.java
@@ -17,7 +17,7 @@ public class StackedStarTable extends WrapperStarTable {
     private ColumnMetadataStarTable metadataTable;
     private ColumnMappingStarTable[] dataTables;
 
-    public StackedStarTable(List<? extends StarTable> tables, ColumnMatcher matcher)
+    public StackedStarTable(List<? extends StarTable> tables, ColumnInfoMatcher matcher)
     {
         super(null);
         

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/StackedStarTable.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/StackedStarTable.java
@@ -1,0 +1,34 @@
+package cfa.vo.iris.visualizer.stil.tables;
+
+import java.io.IOException;
+import java.util.List;
+
+import uk.ac.starlink.table.ConcatStarTable;
+import uk.ac.starlink.table.StarTable;
+import uk.ac.starlink.table.WrapperStarTable;
+
+/**
+ * Extension of a ConcatStarTable that supports stacking of any StarTable, regardless
+ * of ColumnInfo compatibility.
+ *
+ */
+public class StackedStarTable extends WrapperStarTable {
+    
+    private ColumnMetadataStarTable metadataTable;
+    private ColumnMappingStarTable[] dataTables;
+
+    public StackedStarTable(List<? extends StarTable> tables, ColumnMatcher matcher) 
+            throws IOException 
+    {
+        super(null);
+        
+        this.metadataTable = new ColumnMetadataStarTable(tables, matcher);
+        this.dataTables = new ColumnMappingStarTable[tables.size()];
+        
+        for (int i=0; i<tables.size(); i++) {
+            dataTables[i] = new ColumnMappingStarTable(tables.get(i), metadataTable, matcher);
+        }
+        
+        this.baseTable = new ConcatStarTable(metadataTable, dataTables);
+    }
+}

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/StackedStarTable.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/StackedStarTable.java
@@ -17,8 +17,7 @@ public class StackedStarTable extends WrapperStarTable {
     private ColumnMetadataStarTable metadataTable;
     private ColumnMappingStarTable[] dataTables;
 
-    public StackedStarTable(List<? extends StarTable> tables, ColumnMatcher matcher) 
-            throws IOException 
+    public StackedStarTable(List<? extends StarTable> tables, ColumnMatcher matcher)
     {
         super(null);
         
@@ -29,6 +28,10 @@ public class StackedStarTable extends WrapperStarTable {
             dataTables[i] = new ColumnMappingStarTable(tables.get(i), metadataTable, matcher);
         }
         
-        this.baseTable = new ConcatStarTable(metadataTable, dataTables);
+        try {
+            this.baseTable = new ConcatStarTable(metadataTable, dataTables);
+        } catch (IOException e) {
+            throw new IllegalArgumentException(e);
+        }
     }
 }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/StackedStarTable.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/StackedStarTable.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2016 Smithsonian Astrophysical Observatory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package cfa.vo.iris.visualizer.stil.tables;
 
 import java.io.IOException;

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/UtypeColumnInfoMatcher.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/UtypeColumnInfoMatcher.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2016 Smithsonian Astrophysical Observatory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package cfa.vo.iris.visualizer.stil.tables;
 
 import org.apache.commons.lang.StringUtils;
@@ -8,13 +24,23 @@ public class UtypeColumnInfoMatcher implements ColumnInfoMatcher {
 
     @Override
     public boolean isCompatible(ColumnInfo c1, ColumnInfo c2) {
-        if (StringUtils.isEmpty(c1.getUtype()) || StringUtils.isEmpty(c2.getUtype())) {
-            return false;
+        
+        // TODO: UTYPE identification
+        if (!StringUtils.isEmpty(c1.getUtype()) && !StringUtils.isEmpty(c2.getUtype())) {
+            if(StringUtils.equalsIgnoreCase(c1.getUtype(), c2.getUtype()))
+            {
+                return true;
+            }
         }
-        if (StringUtils.equalsIgnoreCase(c1.getUtype(), c2.getUtype()))
-        {
-            return true;
+        
+        // Fall back to name equality if the utypes are not equal or not available.
+        if (!StringUtils.isEmpty(c1.getName()) && !StringUtils.isEmpty(c2.getName())) {
+            if(StringUtils.equalsIgnoreCase(c1.getName(), c2.getName()))
+            {
+                return true;
+            }
         }
+        
         return false;
     }
 

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/UtypeColumnInfoMatcher.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/UtypeColumnInfoMatcher.java
@@ -18,7 +18,7 @@ package cfa.vo.iris.visualizer.stil.tables;
 
 import org.apache.commons.lang.StringUtils;
 
-import cfa.vo.sedlib.common.Utypes;
+import cfa.vo.iris.utils.UTYPE;
 import uk.ac.starlink.table.ColumnInfo;
 
 public class UtypeColumnInfoMatcher implements ColumnInfoMatcher {
@@ -26,7 +26,7 @@ public class UtypeColumnInfoMatcher implements ColumnInfoMatcher {
     @Override
     public boolean isCompatible(ColumnInfo c1, ColumnInfo c2) {
         
-        boolean utypesMatch = compareUtypes(c1.getUtype(), c2.getUtype());
+        boolean utypesMatch = UTYPE.compareUtypes(c1.getUtype(), c2.getUtype());
         if (utypesMatch) {
             return true;
         }
@@ -42,40 +42,4 @@ public class UtypeColumnInfoMatcher implements ColumnInfoMatcher {
         // If both utype and names are not equal
         return false;
     }
-    
-    private boolean compareUtypes(String utype1, String utype2) {
-        
-        // If either of them are empty they are not equal
-        if (StringUtils.isEmpty(utype1) || StringUtils.isEmpty(utype2)) {
-            return false;
-        }
-        
-        // if the strings are equal then they are equals
-        if (StringUtils.equalsIgnoreCase(utype1, utype2)) {
-            return true;
-        }
-        
-        // Remove prefixes if present
-        if (StringUtils.contains(utype1, ":")) {
-            utype1 = utype1.split(":")[1];
-        }
-        if (StringUtils.contains(utype2, ":")) {
-            utype2 = utype2.split(":")[1];
-        }
-        
-        // Use Utype comparisons
-        int u1 = Utypes.getUtypeFromString(utype1);
-        int u2 = Utypes.getUtypeFromString(utype2);
-        
-        if (Utypes.INVALID_UTYPE == u1 || Utypes.INVALID_UTYPE == u2) {
-            return false;
-        }
-        
-        if (u1 == u2) {
-            return true;
-        }
-        
-        return false;
-    }
-
 }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/UtypeColumnInfoMatcher.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/UtypeColumnInfoMatcher.java
@@ -55,6 +55,14 @@ public class UtypeColumnInfoMatcher implements ColumnInfoMatcher {
             return true;
         }
         
+        // Remove prefixes if present
+        if (StringUtils.contains(utype1, ":")) {
+            utype1 = utype1.split(":")[1];
+        }
+        if (StringUtils.contains(utype2, ":")) {
+            utype2 = utype2.split(":")[1];
+        }
+        
         // Use Utype comparisons
         int u1 = Utypes.getUtypeFromString(utype1);
         int u2 = Utypes.getUtypeFromString(utype2);

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/UtypeColumnInfoMatcher.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/UtypeColumnInfoMatcher.java
@@ -18,6 +18,7 @@ package cfa.vo.iris.visualizer.stil.tables;
 
 import org.apache.commons.lang.StringUtils;
 
+import cfa.vo.sedlib.common.Utypes;
 import uk.ac.starlink.table.ColumnInfo;
 
 public class UtypeColumnInfoMatcher implements ColumnInfoMatcher {
@@ -25,12 +26,9 @@ public class UtypeColumnInfoMatcher implements ColumnInfoMatcher {
     @Override
     public boolean isCompatible(ColumnInfo c1, ColumnInfo c2) {
         
-        // TODO: UTYPE identification
-        if (!StringUtils.isEmpty(c1.getUtype()) && !StringUtils.isEmpty(c2.getUtype())) {
-            if(StringUtils.equalsIgnoreCase(c1.getUtype(), c2.getUtype()))
-            {
-                return true;
-            }
+        boolean utypesMatch = compareUtypes(c1.getUtype(), c2.getUtype());
+        if (utypesMatch) {
+            return true;
         }
         
         // Fall back to name equality if the utypes are not equal or not available.
@@ -39,6 +37,34 @@ public class UtypeColumnInfoMatcher implements ColumnInfoMatcher {
             {
                 return true;
             }
+        }
+        
+        // If both utype and names are not equal
+        return false;
+    }
+    
+    private boolean compareUtypes(String utype1, String utype2) {
+        
+        // If either of them are empty they are not equal
+        if (StringUtils.isEmpty(utype1) || StringUtils.isEmpty(utype2)) {
+            return false;
+        }
+        
+        // if the strings are equal then they are equals
+        if (StringUtils.equalsIgnoreCase(utype1, utype2)) {
+            return true;
+        }
+        
+        // Use Utype comparisons
+        int u1 = Utypes.getUtypeFromString(utype1);
+        int u2 = Utypes.getUtypeFromString(utype2);
+        
+        if (Utypes.INVALID_UTYPE == u1 || Utypes.INVALID_UTYPE == u2) {
+            return false;
+        }
+        
+        if (u1 == u2) {
+            return true;
         }
         
         return false;

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/UtypeColumnInfoMatcher.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/UtypeColumnInfoMatcher.java
@@ -4,7 +4,7 @@ import org.apache.commons.lang.StringUtils;
 
 import uk.ac.starlink.table.ColumnInfo;
 
-public class UtypeColumnMatcher implements ColumnMatcher {
+public class UtypeColumnInfoMatcher implements ColumnInfoMatcher {
 
     @Override
     public boolean isCompatible(ColumnInfo c1, ColumnInfo c2) {

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/UtypeColumnMatcher.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/UtypeColumnMatcher.java
@@ -8,8 +8,10 @@ public class UtypeColumnMatcher implements ColumnMatcher {
 
     @Override
     public boolean isCompatible(ColumnInfo c1, ColumnInfo c2) {
-        if (StringUtils.containsIgnoreCase(c1.getUtype(), c2.getUtype()) ||
-            StringUtils.containsIgnoreCase(c2.getUtype(), c1.getUtype())) 
+        if (StringUtils.isEmpty(c1.getUtype()) || StringUtils.isEmpty(c2.getUtype())) {
+            return false;
+        }
+        if (StringUtils.equalsIgnoreCase(c1.getUtype(), c2.getUtype()))
         {
             return true;
         }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/UtypeColumnMatcher.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/UtypeColumnMatcher.java
@@ -1,0 +1,19 @@
+package cfa.vo.iris.visualizer.stil.tables;
+
+import org.apache.commons.lang.StringUtils;
+
+import uk.ac.starlink.table.ColumnInfo;
+
+public class UtypeColumnMatcher implements ColumnMatcher {
+
+    @Override
+    public boolean isCompatible(ColumnInfo c1, ColumnInfo c2) {
+        if (StringUtils.containsIgnoreCase(c1.getUtype(), c2.getUtype()) ||
+            StringUtils.containsIgnoreCase(c2.getUtype(), c1.getUtype())) 
+        {
+            return true;
+        }
+        return false;
+    }
+
+}

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainViewTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainViewTest.java
@@ -23,7 +23,6 @@ import org.uispec4j.ListBox;
 import org.uispec4j.Panel;
 import org.uispec4j.Table;
 import org.uispec4j.Window;
-import org.uispec4j.utils.ArrayUtils;
 
 import cfa.vo.iris.IrisComponent;
 import cfa.vo.iris.sed.ExtSed;
@@ -113,7 +112,7 @@ public class MetadataBrowserMainViewTest extends AbstractComponentGUITest {
         final Segment seg1 = createSampleSegment();
         sed.addSegment(seg1);
 
-        // 1 segment should have been added to table
+        // 1 segment should have been added to table and selected
         invokeWithRetry(20, 100, new Runnable() {
             @Override
             public void run() {
@@ -121,9 +120,9 @@ public class MetadataBrowserMainViewTest extends AbstractComponentGUITest {
                 assertEquals(1, starTableList.getSize());
                 assertEquals(1, segmentTable.getRowCount());
 
-                assertEquals(1, Double.parseDouble((String) plotterTable.getContentAt(0, 1)), 0.1);
-                assertEquals(2, Double.parseDouble((String) plotterTable.getContentAt(1, 1)), 0.1);
-                assertEquals(3, Double.parseDouble((String) plotterTable.getContentAt(2, 1)), 0.1);
+                assertEquals(1, Double.parseDouble((String) plotterTable.getContentAt(0, 2)), 0.1);
+                assertEquals(2, Double.parseDouble((String) plotterTable.getContentAt(1, 2)), 0.1);
+                assertEquals(3, Double.parseDouble((String) plotterTable.getContentAt(2, 2)), 0.1);
             }
         });
         
@@ -139,9 +138,9 @@ public class MetadataBrowserMainViewTest extends AbstractComponentGUITest {
                 assertEquals(2, starTableList.getSize());
                 assertEquals(2, segmentTable.getRowCount());
 
-                assertEquals(1, Double.parseDouble((String) plotterTable.getContentAt(0, 1)), 0.1);
-                assertEquals(2, Double.parseDouble((String) plotterTable.getContentAt(1, 1)), 0.1);
-                assertEquals(3, Double.parseDouble((String) plotterTable.getContentAt(2, 1)), 0.1);
+                assertEquals(1, Double.parseDouble((String) plotterTable.getContentAt(0, 2)), 0.1);
+                assertEquals(2, Double.parseDouble((String) plotterTable.getContentAt(1, 2)), 0.1);
+                assertEquals(3, Double.parseDouble((String) plotterTable.getContentAt(2, 2)), 0.1);
                 
                 assertEquals(1, Double.parseDouble((String) dataTable.getContentAt(0, 1)), 0.1);
                 assertEquals(2, Double.parseDouble((String) dataTable.getContentAt(1, 1)), 0.1);
@@ -150,14 +149,15 @@ public class MetadataBrowserMainViewTest extends AbstractComponentGUITest {
         });
         
         // Select the second segment
+        starTableList.clearSelection();
         starTableList.selectIndex(1);
         
         // 2 segments should have been added to table, first segment still selected
         invokeWithRetry(20, 100, new Runnable() {
             @Override
             public void run() {
-                assertEquals(100, Double.parseDouble((String) plotterTable.getContentAt(0, 1)), 0.1);
-                assertEquals(200, Double.parseDouble((String) plotterTable.getContentAt(1, 1)), 0.1);
+                assertEquals(100, Double.parseDouble((String) plotterTable.getContentAt(0, 2)), 0.1);
+                assertEquals(200, Double.parseDouble((String) plotterTable.getContentAt(1, 2)), 0.1);
                 
                 assertEquals(100, Double.parseDouble((String) dataTable.getContentAt(0, 1)), 0.1);
                 assertEquals(200, Double.parseDouble((String) dataTable.getContentAt(1, 1)), 0.1);
@@ -196,13 +196,14 @@ public class MetadataBrowserMainViewTest extends AbstractComponentGUITest {
             @Override
             public void run() {
                 assertTrue(StringUtils.contains(mbWindow.getTitle(), sed.getId()));
+                System.out.println(mbWindow.getTitle() + " ::: " + sed.getId());
                 assertEquals(2, mbView.selectedTables.size());
                 assertEquals(2, starTableList.getSize());
                 assertEquals(2, segmentTable.getRowCount());
 
-                assertEquals(1, Double.parseDouble((String) plotterTable.getContentAt(0, 1)), 0.1);
-                assertEquals(2, Double.parseDouble((String) plotterTable.getContentAt(1, 1)), 0.1);
-                assertEquals(3, Double.parseDouble((String) plotterTable.getContentAt(2, 1)), 0.1);
+                assertEquals(1, Double.parseDouble((String) plotterTable.getContentAt(0, 2)), 0.1);
+                assertEquals(2, Double.parseDouble((String) plotterTable.getContentAt(1, 2)), 0.1);
+                assertEquals(3, Double.parseDouble((String) plotterTable.getContentAt(2, 2)), 0.1);
             }
         });
     }

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainViewTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainViewTest.java
@@ -196,7 +196,6 @@ public class MetadataBrowserMainViewTest extends AbstractComponentGUITest {
             @Override
             public void run() {
                 assertTrue(StringUtils.contains(mbWindow.getTitle(), sed.getId()));
-                System.out.println(mbWindow.getTitle() + " ::: " + sed.getId());
                 assertEquals(2, mbView.selectedTables.size());
                 assertEquals(2, starTableList.getSize());
                 assertEquals(2, segmentTable.getRowCount());

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainViewTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainViewTest.java
@@ -23,6 +23,7 @@ import org.uispec4j.ListBox;
 import org.uispec4j.Panel;
 import org.uispec4j.Table;
 import org.uispec4j.Window;
+import org.uispec4j.utils.ArrayUtils;
 
 import cfa.vo.iris.IrisComponent;
 import cfa.vo.iris.sed.ExtSed;
@@ -213,7 +214,7 @@ public class MetadataBrowserMainViewTest extends AbstractComponentGUITest {
         sed.addSegment(createSampleSegment());
         sed.addSegment(createSampleSegment(new double[] {1}, new double[] {2}));
         sedManager.add(sed);
-
+        
         // verify selected sed
         invokeWithRetry(10, 100, new Runnable() {
             @Override

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/preferences/SedPreferencesTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/preferences/SedPreferencesTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 
 import cfa.vo.iris.sed.ExtSed;
 import cfa.vo.iris.visualizer.plotter.SegmentLayer;
-import cfa.vo.iris.visualizer.stil.IrisStarTableAdapter;
+import cfa.vo.iris.visualizer.stil.tables.IrisStarTableAdapter;
 import cfa.vo.sedlib.Segment;
 import cfa.vo.sedlib.Target;
 import cfa.vo.sedlib.TextParam;

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/preferences/SedPreferencesTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/preferences/SedPreferencesTest.java
@@ -34,7 +34,7 @@ public class SedPreferencesTest {
     @Test
     public void testPreferences() throws Exception {
         ExtSed sed = new ExtSed("test");
-        IrisStarTableAdapter adapter = new IrisStarTableAdapter();
+        IrisStarTableAdapter adapter = new IrisStarTableAdapter(null);
         
         SedPreferences prefs = new SedPreferences(sed, adapter);
         
@@ -92,7 +92,7 @@ public class SedPreferencesTest {
     @Test
     public void testSuffixesWithSameTargetNames() throws Exception {
         ExtSed sed = new ExtSed("test");
-        IrisStarTableAdapter adapter = new IrisStarTableAdapter();
+        IrisStarTableAdapter adapter = new IrisStarTableAdapter(null);
         
         SedPreferences prefs = new SedPreferences(sed, adapter);
         

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/tables/ColumnMappingStarTableTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/tables/ColumnMappingStarTableTest.java
@@ -16,7 +16,7 @@ public class ColumnMappingStarTableTest {
     @Test
     public void testColumnMappingStarTable() throws Exception {
         
-        ColumnMatcher matcher = new UtypeColumnMatcher();
+        ColumnInfoMatcher matcher = new UtypeColumnInfoMatcher();
         
         ColumnInfo c1 = new ColumnInfo("c1");
         ColumnInfo c2 = new ColumnInfo("c2");

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/tables/ColumnMappingStarTableTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/tables/ColumnMappingStarTableTest.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2016 Smithsonian Astrophysical Observatory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package cfa.vo.iris.visualizer.stil.tables;
 
 import static org.junit.Assert.*;

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/tables/ColumnMappingStarTableTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/tables/ColumnMappingStarTableTest.java
@@ -27,22 +27,10 @@ import uk.ac.starlink.table.MetadataStarTable;
 import uk.ac.starlink.table.PrimitiveArrayColumn;
 import uk.ac.starlink.table.StarTable;
 
-public class ColumnMappingStarTableTest {
+public class ColumnMappingStarTableTest extends VisualizerStarTableTest {
     
     @Test
     public void testColumnMappingStarTable() throws Exception {
-        
-        ColumnInfoMatcher matcher = new UtypeColumnInfoMatcher();
-        
-        ColumnInfo c1 = new ColumnInfo("c1");
-        ColumnInfo c2 = new ColumnInfo("c2");
-        ColumnInfo c3 = new ColumnInfo("c3");
-        ColumnInfo c4 = new ColumnInfo("c4");
-        
-        c1.setUtype("c1");
-        c2.setUtype("c2");
-        c3.setUtype("c3");
-        c4.setUtype("c4");
         
         StarTable metadata = new MetadataStarTable(new ColumnInfo[] {c1,c2,c3,c4});
         

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/tables/ColumnMappingStarTableTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/tables/ColumnMappingStarTableTest.java
@@ -1,0 +1,50 @@
+package cfa.vo.iris.visualizer.stil.tables;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.uispec4j.utils.ArrayUtils;
+
+import uk.ac.starlink.table.ColumnInfo;
+import uk.ac.starlink.table.ColumnStarTable;
+import uk.ac.starlink.table.MetadataStarTable;
+import uk.ac.starlink.table.PrimitiveArrayColumn;
+import uk.ac.starlink.table.StarTable;
+
+public class ColumnMappingStarTableTest {
+    
+    @Test
+    public void testColumnMappingStarTable() throws Exception {
+        
+        ColumnMatcher matcher = new UtypeColumnMatcher();
+        
+        ColumnInfo c1 = new ColumnInfo("c1");
+        ColumnInfo c2 = new ColumnInfo("c2");
+        ColumnInfo c3 = new ColumnInfo("c3");
+        ColumnInfo c4 = new ColumnInfo("c4");
+        
+        c1.setUtype("c1");
+        c2.setUtype("c2");
+        c3.setUtype("c3");
+        c4.setUtype("c4");
+        
+        StarTable metadata = new MetadataStarTable(new ColumnInfo[] {c1,c2,c3,c4});
+        
+        ColumnStarTable base = new ColumnStarTable() {
+            @Override
+            public long getRowCount() {
+                return 1;
+            }
+        };
+        base.addColumn(PrimitiveArrayColumn.makePrimitiveColumn(c1, new double[] {1.0}));
+        base.addColumn(PrimitiveArrayColumn.makePrimitiveColumn(c3, new double[] {3.0}));
+        
+        ColumnMappingStarTable test = new ColumnMappingStarTable(base, metadata, matcher);
+
+        ArrayUtils.assertEquals(new int[] {0,2,1,3}, test.getColumnMap());
+        ArrayUtils.assertEquals(new Object[] {1.0, null, 3.0, null}, test.getRow(0));
+        assertEquals(4, test.getColumnCount());
+        assertEquals(1, test.getRowCount());
+        assertEquals(base, test.getOriginalTable());
+    }
+}

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/tables/ColumnMetadataStarTableTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/tables/ColumnMetadataStarTableTest.java
@@ -18,7 +18,7 @@ public class ColumnMetadataStarTableTest {
     @Test
     public void testColumnMetadataStarTable() {
         
-        UtypeColumnMatcher matcher = new UtypeColumnMatcher();
+        ColumnInfoMatcher matcher = new UtypeColumnInfoMatcher();
         
         ColumnInfo c1 = new ColumnInfo("c1");
         ColumnInfo c2 = new ColumnInfo("c2");

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/tables/ColumnMetadataStarTableTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/tables/ColumnMetadataStarTableTest.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2016 Smithsonian Astrophysical Observatory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package cfa.vo.iris.visualizer.stil.tables;
 
 import static org.junit.Assert.*;

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/tables/ColumnMetadataStarTableTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/tables/ColumnMetadataStarTableTest.java
@@ -1,0 +1,61 @@
+package cfa.vo.iris.visualizer.stil.tables;
+
+import static org.junit.Assert.*;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import org.junit.Test;
+
+import uk.ac.starlink.table.ColumnData;
+import uk.ac.starlink.table.ColumnInfo;
+import uk.ac.starlink.table.ColumnStarTable;
+import uk.ac.starlink.table.ConstantColumn;
+import uk.ac.starlink.table.StarTable;
+
+public class ColumnMetadataStarTableTest {
+    
+    @Test
+    public void testColumnMetadataStarTable() {
+        
+        UtypeColumnMatcher matcher = new UtypeColumnMatcher();
+        
+        ColumnInfo c1 = new ColumnInfo("c1");
+        ColumnInfo c2 = new ColumnInfo("c2");
+        ColumnInfo c3 = new ColumnInfo("c3");
+        
+        c1.setUtype("c1");
+        c2.setUtype("c2");
+        c3.setUtype("c3");
+        
+        ColumnData d1 = new ConstantColumn(c1, null);
+        ColumnData d2 = new ConstantColumn(c2, null);
+        ColumnData d3 = new ConstantColumn(c3, null);
+        
+        StarTable s1 = getStarTable(new ColumnData[] {d1, d2});
+        StarTable s2 = getStarTable(new ColumnData[] {d2, d3});
+        
+        List<StarTable> tables = new LinkedList<>();
+        tables.add(s1);
+        tables.add(s2);
+        
+        ColumnMetadataStarTable test = new ColumnMetadataStarTable(tables, matcher);
+        
+        assertEquals(3, test.getColumnCount());
+    }
+    
+    private static StarTable getStarTable(ColumnData[] data) {
+        ColumnStarTable c = new ColumnStarTable() {
+            @Override
+            public long getRowCount() {
+                return 0;
+            }
+        };
+        
+        for (ColumnData d : data) {
+            c.addColumn(d);
+        }
+        
+        return c;
+    }
+}

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/tables/IrisStarTableAdapterTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/tables/IrisStarTableAdapterTest.java
@@ -26,7 +26,7 @@ public class IrisStarTableAdapterTest {
         IrisStarTable table = adapter.convertSegment(seg);
         
         SegmentStarTable plotterTable = table.getPlotterTable();
-        StarTable dataTable = table.getDataTable();
+        StarTable dataTable = table.getSegmentDataTable();
         assertEquals(table.getName(), plotterTable.getName());
         
         // Name, spec values, flux values, original flux values
@@ -44,7 +44,7 @@ public class IrisStarTableAdapterTest {
         final IrisStarTable table = adapter.convertSegment(seg);
 
         assertEquals(356, table.getRowCount());
-        assertEquals(356, table.getDataTable().getRowCount());
+        assertEquals(356, table.getSegmentDataTable().getRowCount());
         
         // Incl. flux error
         assertEquals(5, table.getColumnCount());
@@ -64,7 +64,7 @@ public class IrisStarTableAdapterTest {
         TestUtils.invokeWithRetry(10, 100, new Runnable() {
             @Override
             public void run() {
-                assertEquals(2, table.getDataTable().getColumnCount());
+                assertEquals(2, table.getSegmentDataTable().getColumnCount());
             }
         });
     }

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/tables/IrisStarTableAdapterTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/tables/IrisStarTableAdapterTest.java
@@ -55,13 +55,17 @@ public class IrisStarTableAdapterTest {
     public void testConvertAsync() throws Exception {
         Segment seg = TestUtils.createSampleSegment();
         
-        IrisStarTable table = adapter.convertSegmentAsync(seg);
+        final IrisStarTable table = adapter.convertSegmentAsync(seg);
         
         // Name, spec values, flux values, original flux values
         assertEquals(4, table.getColumnCount());
         
         // Wait for serialization to finish
-        Thread.sleep(100);
-        assertEquals(2, table.getDataTable().getColumnCount());
+        TestUtils.invokeWithRetry(10, 100, new Runnable() {
+            @Override
+            public void run() {
+                assertEquals(2, table.getDataTable().getColumnCount());
+            }
+        });
     }
 }

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/tables/IrisStarTableAdapterTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/tables/IrisStarTableAdapterTest.java
@@ -1,0 +1,67 @@
+package cfa.vo.iris.visualizer.stil.tables;
+
+import static org.junit.Assert.*;
+
+import java.util.concurrent.Executors;
+
+import org.junit.Test;
+import org.uispec4j.utils.ArrayUtils;
+
+import cfa.vo.iris.sed.ExtSed;
+import cfa.vo.iris.sed.stil.SegmentStarTable;
+import cfa.vo.iris.test.unit.TestUtils;
+import cfa.vo.sedlib.Segment;
+import cfa.vo.sedlib.io.SedFormat;
+import cfa.vo.testdata.TestData;
+import uk.ac.starlink.table.StarTable;
+
+public class IrisStarTableAdapterTest {
+    
+    private IrisStarTableAdapter adapter = new IrisStarTableAdapter(Executors.newSingleThreadExecutor());
+    
+    @Test
+    public void testSerialization() throws Exception {
+        Segment seg = TestUtils.createSampleSegment();
+        
+        IrisStarTable table = adapter.convertSegment(seg);
+        
+        SegmentStarTable plotterTable = table.getPlotterTable();
+        StarTable dataTable = table.getDataTable();
+        assertEquals(table.getName(), plotterTable.getName());
+        
+        // Name, spec values, flux values, original flux values
+        assertEquals(4, table.getColumnCount());
+        
+        // just flux and spec values
+        assertEquals(2, dataTable.getColumnCount());
+    }
+    
+    @Test
+    public void testVOCompliantTable() throws Exception {
+        // This file hasn't been showing up in the plotter, so verifying that serialization works here.
+        Segment seg = ExtSed.read(TestData.class.getResource("m87_saved.vot").openStream(), SedFormat.VOT).getSegment(0);
+        
+        final IrisStarTable table = adapter.convertSegment(seg);
+
+        assertEquals(356, table.getRowCount());
+        assertEquals(356, table.getDataTable().getRowCount());
+        
+        // Incl. flux error
+        assertEquals(5, table.getColumnCount());
+        ArrayUtils.assertEquals(new Object[] {"MESSIER 087",1.21E25,1.45E-13,1.45E-13,3.14E-14}, table.getRow(0));
+    }
+    
+    @Test
+    public void testConvertAsync() throws Exception {
+        Segment seg = TestUtils.createSampleSegment();
+        
+        IrisStarTable table = adapter.convertSegmentAsync(seg);
+        
+        // Name, spec values, flux values, original flux values
+        assertEquals(4, table.getColumnCount());
+        
+        // Wait for serialization to finish
+        Thread.sleep(100);
+        assertEquals(2, table.getDataTable().getColumnCount());
+    }
+}

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/tables/StackedStarTableTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/tables/StackedStarTableTest.java
@@ -30,27 +30,14 @@ import cfa.vo.iris.test.unit.TestUtils;
 import cfa.vo.sedlib.Segment;
 import cfa.vo.sedlib.io.SedFormat;
 import cfa.vo.testdata.TestData;
-import uk.ac.starlink.table.ColumnInfo;
 import uk.ac.starlink.table.ColumnStarTable;
 import uk.ac.starlink.table.PrimitiveArrayColumn;
 import uk.ac.starlink.table.StarTable;
 
-public class StackedStarTableTest {
-    
-    ColumnInfoMatcher matcher = new UtypeColumnInfoMatcher();
+public class StackedStarTableTest extends VisualizerStarTableTest {
     
     @Test
     public void testStackedStarTable() throws Exception {
-        
-        ColumnInfo c1 = new ColumnInfo("c1");
-        ColumnInfo c2 = new ColumnInfo("c2");
-        ColumnInfo c3 = new ColumnInfo("c3");
-        ColumnInfo c4 = new ColumnInfo("c4");
-        
-        c1.setUtype("c1");
-        c2.setUtype("c2");
-        c3.setUtype("c3");
-        c4.setUtype("c4");
         
         ColumnStarTable data1 = new ColumnStarTable() {
             @Override
@@ -103,6 +90,15 @@ public class StackedStarTableTest {
         
         List<StarTable> tables = new ArrayList<>();
         tables.add(dataTable);
+        
+        for (int i=0; i<dataTable.getColumnCount(); i++) {
+            System.out.println("o " + dataTable.getColumnInfo(i).getUtype());
+        }
+        
+        StarTable meta = new ColumnMetadataStarTable(tables, matcher);
+        for (int i=0; i<meta.getColumnCount(); i++) {
+            System.out.println("x " + meta.getColumnInfo(i).getUtype());
+        }
         
         StackedStarTable test = new StackedStarTable(tables, matcher);
         assertEquals(16, test.getColumnCount());

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/tables/StackedStarTableTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/tables/StackedStarTableTest.java
@@ -15,7 +15,7 @@ import uk.ac.starlink.table.StarTable;
 
 public class StackedStarTableTest {
     
-    ColumnMatcher matcher = new UtypeColumnMatcher();
+    ColumnInfoMatcher matcher = new UtypeColumnInfoMatcher();
     
     @Test
     public void testStackedStarTable() throws Exception {

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/tables/StackedStarTableTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/tables/StackedStarTableTest.java
@@ -30,6 +30,7 @@ import cfa.vo.iris.test.unit.TestUtils;
 import cfa.vo.sedlib.Segment;
 import cfa.vo.sedlib.io.SedFormat;
 import cfa.vo.testdata.TestData;
+import uk.ac.starlink.table.ColumnInfo;
 import uk.ac.starlink.table.ColumnStarTable;
 import uk.ac.starlink.table.PrimitiveArrayColumn;
 import uk.ac.starlink.table.StarTable;
@@ -121,6 +122,43 @@ public class StackedStarTableTest extends VisualizerStarTableTest {
         long start = pt1.getRowCount();
         ArrayUtils.assertEquals(pt2.getRow(0), Arrays.copyOfRange(test.getRow(start), 0, pt2.getColumnCount()));
         assertNull(test.getRow(start)[test.getColumnCount() - 1]);
+    }
+    
+    @Test
+    public void testDifferentUtypePrefixes() {
+        
+        // These should line up to the same column
+        String utype1 = "spec:Spectrum.Char.FluxAxis.Accuracy.StatError";
+        String utype2 = "phot:Spectrum.Char.FluxAxis.Accuracy.StatError";
+        
+        ColumnInfo c1 = new ColumnInfo("c1");
+        ColumnInfo c2 = new ColumnInfo("c2");
+        
+        c1.setUtype(utype1);
+        c2.setUtype(utype2);
+        
+        ColumnStarTable data1 = new ColumnStarTable() {
+            @Override
+            public long getRowCount() {
+                return 1;
+            }
+        };
+        data1.addColumn(PrimitiveArrayColumn.makePrimitiveColumn(c1, new double[] {1.0}));
+        
+        ColumnStarTable data2 = new ColumnStarTable() {
+            @Override
+            public long getRowCount() {
+                return 1;
+            }
+        };
+        data2.addColumn(PrimitiveArrayColumn.makePrimitiveColumn(c2, new double[] {2.0}));
+        
+        List<StarTable> tables = new ArrayList<>(2);
+        tables.add(data1);
+        tables.add(data2);
+        
+        StackedStarTable test = new StackedStarTable(tables, matcher);
+        assertEquals(1, test.getColumnCount());
     }
 
 }

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/tables/StackedStarTableTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/tables/StackedStarTableTest.java
@@ -1,0 +1,64 @@
+package cfa.vo.iris.visualizer.stil.tables;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+import org.uispec4j.utils.ArrayUtils;
+
+import uk.ac.starlink.table.ColumnInfo;
+import uk.ac.starlink.table.ColumnStarTable;
+import uk.ac.starlink.table.PrimitiveArrayColumn;
+import uk.ac.starlink.table.StarTable;
+
+public class StackedStarTableTest {
+    
+    @Test
+    public void testStackedStarTable() throws Exception {
+        
+        ColumnMatcher matcher = new UtypeColumnMatcher();
+        
+        ColumnInfo c1 = new ColumnInfo("c1");
+        ColumnInfo c2 = new ColumnInfo("c2");
+        ColumnInfo c3 = new ColumnInfo("c3");
+        ColumnInfo c4 = new ColumnInfo("c4");
+        
+        c1.setUtype("c1");
+        c2.setUtype("c2");
+        c3.setUtype("c3");
+        c4.setUtype("c4");
+        
+        ColumnStarTable data1 = new ColumnStarTable() {
+            @Override
+            public long getRowCount() {
+                return 1;
+            }
+        };
+        data1.addColumn(PrimitiveArrayColumn.makePrimitiveColumn(c1, new double[] {1.0}));
+        data1.addColumn(PrimitiveArrayColumn.makePrimitiveColumn(c3, new double[] {3.0}));
+        
+        ColumnStarTable data2 = new ColumnStarTable() {
+            @Override
+            public long getRowCount() {
+                return 1;
+            }
+        };
+        data2.addColumn(PrimitiveArrayColumn.makePrimitiveColumn(c2, new double[] {2.0}));
+        data2.addColumn(PrimitiveArrayColumn.makePrimitiveColumn(c3, new double[] {3.0}));
+        data2.addColumn(PrimitiveArrayColumn.makePrimitiveColumn(c4, new double[] {4.0}));
+        
+        List<StarTable> tables = new ArrayList<>(2);
+        tables.add(data1);
+        tables.add(data2);
+        
+        StackedStarTable test = new StackedStarTable(tables, matcher);
+        
+        assertEquals(4, test.getColumnCount());
+        assertEquals(2, test.getRowCount());
+        ArrayUtils.assertEquals(new Object[] {1.0, 3.0, null, null}, test.getRow(0));
+        ArrayUtils.assertEquals(new Object[] {null, 3.0, 2.0, 4.0}, test.getRow(1));
+    }
+
+}

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/tables/StackedStarTableTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/tables/StackedStarTableTest.java
@@ -15,10 +15,10 @@ import uk.ac.starlink.table.StarTable;
 
 public class StackedStarTableTest {
     
+    ColumnMatcher matcher = new UtypeColumnMatcher();
+    
     @Test
     public void testStackedStarTable() throws Exception {
-        
-        ColumnMatcher matcher = new UtypeColumnMatcher();
         
         ColumnInfo c1 = new ColumnInfo("c1");
         ColumnInfo c2 = new ColumnInfo("c2");
@@ -59,6 +59,14 @@ public class StackedStarTableTest {
         assertEquals(2, test.getRowCount());
         ArrayUtils.assertEquals(new Object[] {1.0, 3.0, null, null}, test.getRow(0));
         ArrayUtils.assertEquals(new Object[] {null, 3.0, 2.0, 4.0}, test.getRow(1));
+    }
+    
+    @Test
+    public void testEmptyStarTable() throws Exception {
+        StackedStarTable test = new StackedStarTable(new ArrayList<StarTable>(), null);
+
+        assertEquals(0, test.getColumnCount());
+        assertEquals(0, test.getRowCount());
     }
 
 }

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/tables/StackedStarTableTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/tables/StackedStarTableTest.java
@@ -86,7 +86,7 @@ public class StackedStarTableTest extends VisualizerStarTableTest {
         Segment seg1 = ExtSed.read(TestData.class.getResource("3c273.vot").openStream(), SedFormat.VOT).getSegment(0);
         IrisStarTable table1 = adapter.convertSegment(seg1);
         
-        StarTable dataTable = table1.getDataTable();
+        StarTable dataTable = table1.getSegmentDataTable();
         
         List<StarTable> tables = new ArrayList<>();
         tables.add(dataTable);

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/tables/StackedStarTableTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/tables/StackedStarTableTest.java
@@ -91,15 +91,6 @@ public class StackedStarTableTest extends VisualizerStarTableTest {
         List<StarTable> tables = new ArrayList<>();
         tables.add(dataTable);
         
-        for (int i=0; i<dataTable.getColumnCount(); i++) {
-            System.out.println("o " + dataTable.getColumnInfo(i).getUtype());
-        }
-        
-        StarTable meta = new ColumnMetadataStarTable(tables, matcher);
-        for (int i=0; i<meta.getColumnCount(); i++) {
-            System.out.println("x " + meta.getColumnInfo(i).getUtype());
-        }
-        
         StackedStarTable test = new StackedStarTable(tables, matcher);
         assertEquals(16, test.getColumnCount());
         for (int i=0; i<test.getColumnCount(); i++) {

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/tables/StackedStarTableTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/tables/StackedStarTableTest.java
@@ -94,10 +94,10 @@ public class StackedStarTableTest {
     @Test
     public void testVOTableData() throws Exception {
         
-        IrisStarTableAdapter adapter = new IrisStarTableAdapter();
+        IrisStarTableAdapter adapter = new IrisStarTableAdapter(null);
         
         Segment seg1 = ExtSed.read(TestData.class.getResource("3c273.vot").openStream(), SedFormat.VOT).getSegment(0);
-        IrisStarTable table1 = adapter.convertStarTable(seg1);
+        IrisStarTable table1 = adapter.convertSegment(seg1);
         
         StarTable dataTable = table1.getDataTable();
         
@@ -111,7 +111,7 @@ public class StackedStarTableTest {
         }
         
         Segment seg2 = TestUtils.createSampleSegment(new double[] {1,2,3}, new double[] {1,2,3});
-        IrisStarTable table2 = adapter.convertStarTable(seg2);
+        IrisStarTable table2 = adapter.convertSegment(seg2);
         tables.add(table2);
 
         StarTable pt1 = table1.getPlotterTable();

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/tables/VisualizerStarTableTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/tables/VisualizerStarTableTest.java
@@ -1,0 +1,41 @@
+package cfa.vo.iris.visualizer.stil.tables;
+
+import org.junit.Before;
+
+import cfa.vo.sedlib.common.Utypes;
+import uk.ac.starlink.table.ColumnInfo;
+
+public abstract class VisualizerStarTableTest {
+    
+    ColumnInfoMatcher matcher = new UtypeColumnInfoMatcher();
+    
+    ColumnInfo c1;
+    ColumnInfo c2;
+    ColumnInfo c3;
+    ColumnInfo c4;
+    
+    String utype1;
+    String utype2;
+    String utype3;
+    String utype4;
+    
+    @Before
+    public void setup() {
+        matcher = new UtypeColumnInfoMatcher();
+        
+        c1 = new ColumnInfo("c1");
+        c2 = new ColumnInfo("c2");
+        c3 = new ColumnInfo("c3");
+        c4 = new ColumnInfo("c4");
+        
+        utype1 = Utypes.getName(Utypes.SEG_CHAR_CHARAXIS);
+        utype2 = Utypes.getName(Utypes.SEG_CHAR_FLUXAXIS);
+        utype3 = Utypes.getName(Utypes.SEG_CHAR_SPECTRALAXIS);
+        utype4 = Utypes.getName(Utypes.SEG_DATAID_CREATIONTYPE);
+        
+        c1.setUtype(utype1);
+        c2.setUtype(utype2);
+        c3.setUtype(utype3);
+        c4.setUtype(utype4);
+    }
+}


### PR DESCRIPTION
This PR closes

https://github.com/ChandraCXC/iris-dev/issues/19
https://github.com/ChandraCXC/iris-dev/issues/20

And additional deals with making the metadata browser/visualizer component more stable in general.

We include a new class, StackedStarTable, which is essentially a http://www.star.bristol.ac.uk/~mbt/stil/javadocs/uk/ac/starlink/table/ConcatStarTable.html that also maps all the columns in the provided list of startables into a single metadata star table. Users provide a column matcher class which determines whether or not two columns should "line up". In our case we have implemented a single class, the UtypeColumnInfoMatcher, which may or may not need to be improved upon in the future. For now it appears to line data up well in the test cases that I have provided.

This is achieved through wrapping StarTables into several different other star tables provided by both stil and iris. In particular, a ColumnMappingStarTable uses a ColumnPermutedStarTable and ConstantColumns/JoinStarTables to map an existing StarTable's columns into a provided metadata star table.

e.g.

Provided a metadata table with columns, A - B - C - D, and a data table with columns D - B, the ColumnMappingStarTable maps the baseTable columns to the metadata columns, and turns the dataTable to something looking like, * - B - * - D, where the * are empty columns. From there, it is a simple matter to get a PrimaryMetadataTable by simply creating a set by way of a ColumnMetadataStarTable - which takes a list of startables and produces the smallest columninfo set containing all the tables' columns. Important to note that all of this is generic to StarTables, rather than Iris.

The metadatabrowser now uses StackedStarTables in place of regular StarTables in it's data panels to support viewing of multiple segment's data simultaneously.

I also added some work in refactoring IrisStarTables/SegmentStarTables to make them easier to read and more robust to errors. SegmentStarTables are now the primary data holders for all information related to plotting - and can be extended to be more dynamic than they are now when we are actually interested in working with double[] of data. This was done in an effort to make filtering tasks easier, but there is still more work to be done there.

Lastly was some minor clean up to error handling and the addition of a few more unit tests to verify these changes.