### PR TITLE
iris-dev#15 Several Mouse Function for the Plotter

### DIFF
--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.java
@@ -25,6 +25,8 @@ import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.ListCellRenderer;
 
+import org.apache.commons.lang.ArrayUtils;
+
 import cfa.vo.iris.IWorkspace;
 import cfa.vo.iris.sed.ExtSed;
 import cfa.vo.iris.visualizer.plotter.SegmentLayer;
@@ -157,6 +159,23 @@ public class MetadataBrowserMainView extends javax.swing.JInternalFrame {
     /*
      * getters and setters
      */
+    
+    public void addRowToSelection(int starTableIndex, int irow) {
+        
+        // If the star table isn't currently selected, add it to the selection
+        int[] selection = starTableList.getSelectedIndices();
+        if (ArrayUtils.indexOf(selection, starTableIndex) < 0) {
+            starTableList.setSelectedIndices(ArrayUtils.add(selection, starTableIndex));
+        }
+        
+        // TODO: This will be complicated by masking and sorting, those methods should be taken
+        // care of by Iris star tables, and the sorting model in our jtables.
+        
+        // Select the correct row
+        IrisStarTable selectedTable = selectedTables.get(starTableIndex);
+        int index = IrisStarTable.getTableStartIndex(selectedStarTables, selectedTable);
+        plotterStarJTable.selectRowIndex(index + irow);
+    }
     
     public ExtSed getSelectedSed() {
         return selectedSed;

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.java
@@ -155,11 +155,13 @@ public class MetadataBrowserMainView extends javax.swing.JInternalFrame {
         setSegmentDataTable(segmentDataTable);
     }
     
-    
-    /*
-     * getters and setters
+    /**
+     * Specifies a star table (by index) and a row to be added to the selected plotter/
+     * data table tabs' row selections.
+     * 
+     * @param starTableIndex - index of the star table in the selectedTables list.
+     * @param irow - row to be selected in the star table.
      */
-    
     public void addRowToSelection(int starTableIndex, int irow) {
         
         // If the star table isn't currently selected, add it to the selection
@@ -176,6 +178,12 @@ public class MetadataBrowserMainView extends javax.swing.JInternalFrame {
         int index = IrisStarTable.getTableStartIndex(selectedStarTables, selectedTable);
         plotterStarJTable.selectRowIndex(index + irow);
     }
+    
+    
+    /*
+     * getters and setters
+     */
+    
     
     public ExtSed getSelectedSed() {
         return selectedSed;

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/MouseCoordinateMotionListener.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/MouseCoordinateMotionListener.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2016 Chandra X-Ray Observatory.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cfa.vo.iris.visualizer.plotter;
+
+import java.awt.Point;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseMotionListener;
+import java.text.DecimalFormat;
+
+import cfa.vo.iris.visualizer.stil.StilPlotter;
+import uk.ac.starlink.ttools.plot2.Surface;
+import uk.ac.starlink.ttools.plot2.task.PlotDisplay;
+
+public class MouseCoordinateMotionListener extends StilPlotterMouseListener 
+    implements MouseMotionListener {
+    
+    private PlotDisplay display;
+    
+    private final static DecimalFormat df = new DecimalFormat("0.######E0");
+    static {
+        df.setMaximumFractionDigits(6);
+    }
+
+    @Override
+    public void setPlotterView(PlotterView plotterView) {
+        super.setPlotterView(plotterView);
+    }
+
+    @Override
+    public void activate(PlotDisplay display) {
+        display.addMouseMotionListener(this);
+    }
+
+    @Override
+    public void mouseDragged(MouseEvent evt) {
+    }
+
+    @Override
+    public void mouseMoved(MouseEvent evt) {
+        if (display == null || display.getSurface() == null) {
+            return;
+        }
+
+        Surface surface = display.getSurface();
+
+        Point p = evt.getPoint();
+        if (!surface.getPlotBounds().contains(p)) {
+            return;
+        }
+
+        double[] loc = surface.graphicsToData(p, null);
+        plotterView.setXcoord(formatNumber(loc[0]));
+        plotterView.setYcoord(formatNumber(loc[1]));
+    }
+
+    private static String formatNumber(double d) {
+        return df.format(d);
+    }
+}

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/MouseCoordinateMotionListener.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/MouseCoordinateMotionListener.java
@@ -41,6 +41,7 @@ public class MouseCoordinateMotionListener extends StilPlotterMouseListener
 
     @Override
     public void activate(PlotDisplay display) {
+        this.display = display;
         display.addMouseMotionListener(this);
     }
 

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/MouseCoordinateMotionListener.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/MouseCoordinateMotionListener.java
@@ -22,6 +22,11 @@ import java.awt.event.MouseMotionListener;
 import uk.ac.starlink.ttools.plot2.Surface;
 import uk.ac.starlink.ttools.plot2.task.PlotDisplay;
 
+/**
+ * MouseListener that displays the mouse's current coordinates (in the PlotDisplay's
+ * coordinate system) in the relevant PlotterView text objects.
+ *
+ */
 public class MouseCoordinateMotionListener extends StilPlotterMouseListener 
     implements MouseMotionListener {
     

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/MouseCoordinateMotionListener.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/MouseCoordinateMotionListener.java
@@ -18,21 +18,14 @@ package cfa.vo.iris.visualizer.plotter;
 import java.awt.Point;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseMotionListener;
-import java.text.DecimalFormat;
 
-import cfa.vo.iris.visualizer.stil.StilPlotter;
 import uk.ac.starlink.ttools.plot2.Surface;
 import uk.ac.starlink.ttools.plot2.task.PlotDisplay;
 
 public class MouseCoordinateMotionListener extends StilPlotterMouseListener 
     implements MouseMotionListener {
     
-    private PlotDisplay display;
-    
-    private final static DecimalFormat df = new DecimalFormat("0.######E0");
-    static {
-        df.setMaximumFractionDigits(6);
-    }
+    private PlotDisplay<?,?> display;
 
     @Override
     public void setPlotterView(PlotterView plotterView) {
@@ -40,7 +33,7 @@ public class MouseCoordinateMotionListener extends StilPlotterMouseListener
     }
 
     @Override
-    public void activate(PlotDisplay display) {
+    public void activate(PlotDisplay<?,?> display) {
         this.display = display;
         display.addMouseMotionListener(this);
     }
@@ -65,9 +58,5 @@ public class MouseCoordinateMotionListener extends StilPlotterMouseListener
         double[] loc = surface.graphicsToData(p, null);
         plotterView.setXcoord(formatNumber(loc[0]));
         plotterView.setYcoord(formatNumber(loc[1]));
-    }
-
-    private static String formatNumber(double d) {
-        return df.format(d);
     }
 }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/MouseListenerManager.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/MouseListenerManager.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 Chandra X-Ray Observatory.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package cfa.vo.iris.visualizer.plotter;
 
 import java.util.LinkedHashSet;
@@ -16,6 +31,7 @@ public class MouseListenerManager {
     // Collection of all mouse listeners the plotter
     MouseCoordinateMotionListener mouseCoordinateMotionListener;
     PlotPointSelectionListener pointSelectionListener;
+    PlotPointSelectionDetailsListener pointDetailsListener;
     
     public MouseListenerManager() {
         this.listeners = new LinkedHashSet<>();
@@ -24,9 +40,13 @@ public class MouseListenerManager {
         mouseCoordinateMotionListener = new MouseCoordinateMotionListener();
         listeners.add(mouseCoordinateMotionListener);
         
-        // Prints point selection values to stdout
+        // Selects points in the MB from the plotter
         pointSelectionListener = new PlotPointSelectionListener();
         listeners.add(pointSelectionListener);
+        
+        // Shows a tooltip when clicking on a point
+        pointDetailsListener = new PlotPointSelectionDetailsListener();
+        listeners.add(pointDetailsListener);
     }
     
     public void setPlotterView(PlotterView view) {

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/MouseListenerManager.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/MouseListenerManager.java
@@ -1,0 +1,50 @@
+package cfa.vo.iris.visualizer.plotter;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import cfa.vo.iris.visualizer.plotter.MouseCoordinateMotionListener;
+import uk.ac.starlink.ttools.plot2.geom.PlaneAspect;
+import uk.ac.starlink.ttools.plot2.geom.PlaneSurfaceFactory.Profile;
+import uk.ac.starlink.ttools.plot2.task.PlotDisplay;
+
+public class MouseListenerManager {
+    
+    private Set<StilPlotterMouseListener> listeners;
+    private PlotterView view;
+    
+    // Collection of all mouse listeners the plotter
+    MouseCoordinateMotionListener mouseCoordinateMotionListener;
+    PlotPointSelectionListener pointSelectionListener;
+    
+    public MouseListenerManager() {
+        this.listeners = new LinkedHashSet<>();
+        
+        // Shows mouse coordinates in the plot view window
+        mouseCoordinateMotionListener = new MouseCoordinateMotionListener();
+        listeners.add(mouseCoordinateMotionListener);
+        
+        // Prints point selection values to stdout
+        pointSelectionListener = new PlotPointSelectionListener();
+        listeners.add(pointSelectionListener);
+    }
+    
+    public void setPlotterView(PlotterView view) {
+        this.view = view;
+        for (StilPlotterMouseListener listener : listeners) {
+            listener.setPlotterView(view);
+        }
+    }
+    
+    public Set<StilPlotterMouseListener> getListeners() {
+        return listeners;
+    }
+    
+    public void activateListeners(PlotDisplay<Profile, PlaneAspect> plotDisplay) {
+        for (StilPlotterMouseListener listener : listeners) {
+            if (listener.isActive()) {
+                listener.activate(plotDisplay);
+            }
+        }
+    }
+}

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/MouseListenerManager.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/MouseListenerManager.java
@@ -23,6 +23,12 @@ import uk.ac.starlink.ttools.plot2.geom.PlaneAspect;
 import uk.ac.starlink.ttools.plot2.geom.PlaneSurfaceFactory.Profile;
 import uk.ac.starlink.ttools.plot2.task.PlotDisplay;
 
+/**
+ * Manages all mouse listeners that are applied to the StilPlotter. 
+ * Listeners will always be added whenever a PlotDisplay object is created
+ * in the StilPlotter by way of the @activateListeners method.
+ *
+ */
 public class MouseListenerManager {
     
     private Set<StilPlotterMouseListener> listeners;

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotPointSelectionDetailsListener.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotPointSelectionDetailsListener.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2016 Chandra X-Ray Observatory.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cfa.vo.iris.visualizer.plotter;
+
+import java.util.logging.Logger;
+
+import javax.swing.JMenuItem;
+import javax.swing.JPopupMenu;
+
+import cfa.vo.iris.sed.stil.SegmentStarTable.Column;
+import cfa.vo.iris.visualizer.metadata.MetadataBrowserMainView;
+import cfa.vo.iris.visualizer.stil.tables.IrisStarTable;
+import uk.ac.starlink.ttools.jel.ColumnIdentifier;
+import uk.ac.starlink.ttools.plot2.task.PlotDisplay;
+import uk.ac.starlink.ttools.plot2.task.PointSelectionEvent;
+import uk.ac.starlink.ttools.plot2.task.PointSelectionListener;
+
+/**
+ * Shows a tooltip with point name and details when selecting a point
+ * in the plotter.
+ *
+ * TODO: This functionality should ideally be done by a mouse hover function - but
+ *  the current implemenation of a PlotDisplay in Stil limits our access to point
+ *  values to point selection events.
+ */
+public class PlotPointSelectionDetailsListener extends StilPlotterMouseListener
+        implements PointSelectionListener 
+{
+    
+    private static Logger logger = Logger.getLogger(PlotPointSelectionDetailsListener.class.getName());
+    
+    private PlotDisplay<?, ?> display;
+
+    @Override
+    public void pointSelected(PointSelectionEvent evt) {
+        try {
+            processEvent(evt);
+        } catch (Exception e) {
+            logger.warning(e.getMessage());
+        }
+    }
+    
+    private void processEvent(PointSelectionEvent evt) throws Exception {
+        MetadataBrowserMainView mbView = this.getPlotterView().getMetadataBrowserView();
+        
+        long[] rows = evt.getClosestRows();
+        for (int i=0; i*2<rows.length; i++) {
+            if (rows[2*i] < 0) {
+                continue;
+            }
+            
+            // Get selected star table based on PointSelectionEvent
+            IrisStarTable table = mbView.getSelectedTables().get(i);
+            ColumnIdentifier id = new ColumnIdentifier(table);
+            
+            // Grab the selected row, format the info String
+            Object[] row = table.getRow(rows[2*i]);
+            double x = (double) row[id.getColumnIndex(Column.Spectral_Value.name())];
+            double y = (double) row[id.getColumnIndex(Column.Flux_Value.name())];
+            String tt = String.format("%s (%s, %s)", table.getName(), formatNumber(x), formatNumber(y));
+            
+            // Display the row in a popup menu
+            JPopupMenu popup = new JPopupMenu();
+            popup.add(new JMenuItem(tt));
+            popup.show(display, evt.getPoint().x, evt.getPoint().y);
+            
+            return;
+        }
+    }
+
+    @Override
+    public void activate(PlotDisplay<?, ?> display) {
+        display.addPointSelectionListener(this);
+        this.display = display;
+    }
+}

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotPointSelectionDetailsListener.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotPointSelectionDetailsListener.java
@@ -15,6 +15,8 @@
  */
 package cfa.vo.iris.visualizer.plotter;
 
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
 import java.util.logging.Logger;
 
 import javax.swing.JMenuItem;
@@ -43,6 +45,7 @@ public class PlotPointSelectionDetailsListener extends StilPlotterMouseListener
     private static Logger logger = Logger.getLogger(PlotPointSelectionDetailsListener.class.getName());
     
     private PlotDisplay<?, ?> display;
+    PointDataPopup popup = new PointDataPopup();
 
     @Override
     public void pointSelected(PointSelectionEvent evt) {
@@ -73,8 +76,7 @@ public class PlotPointSelectionDetailsListener extends StilPlotterMouseListener
             String tt = String.format("%s (%s, %s)", table.getName(), formatNumber(x), formatNumber(y));
             
             // Display the row in a popup menu
-            JPopupMenu popup = new JPopupMenu();
-            popup.add(new JMenuItem(tt));
+            popup.setDataString(tt);
             popup.show(display, evt.getPoint().x, evt.getPoint().y);
             
             return;
@@ -85,5 +87,46 @@ public class PlotPointSelectionDetailsListener extends StilPlotterMouseListener
     public void activate(PlotDisplay<?, ?> display) {
         display.addPointSelectionListener(this);
         this.display = display;
+    }
+    
+    private static class PointDataPopup extends JPopupMenu {
+        
+        private JMenuItem item;
+        
+        public PointDataPopup() {
+            
+            item = new JMenuItem();
+            add(item);
+            
+            // Remove these to avoid highlighting the menu item
+            item.removeMouseListener(item.getMouseListeners()[0]);
+            item.removeMouseMotionListener(item.getMouseMotionListeners()[0]);
+            
+            // Get rid of the popup like a tooltip
+            addMouseListener(new MouseListener() {
+                @Override
+                public void mouseClicked(MouseEvent arg0) {
+                    setVisible(false);
+                }
+                @Override
+                public void mouseEntered(MouseEvent arg0) {
+                }
+                @Override
+                public void mouseExited(MouseEvent arg0) {
+                    setVisible(false);
+                }
+                @Override
+                public void mousePressed(MouseEvent arg0) {
+                    setVisible(false);
+                }
+                @Override
+                public void mouseReleased(MouseEvent arg0) {
+                }
+            });
+        }
+        
+        public void setDataString(String tt) {
+            item.setText(tt);
+        }
     }
 }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotPointSelectionDetailsListener.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotPointSelectionDetailsListener.java
@@ -66,7 +66,10 @@ public class PlotPointSelectionDetailsListener extends StilPlotterPointSelection
         }
         // Display the row in a popup menu
         popup.setDataString(tt);
-        popup.show(display, evt.getPoint().x, evt.getPoint().y);
+        
+        // The popup shows up so that the mouse cursor is over the JPopup, so that when the mouse
+        // moves off of the window it will disappear in a predictable manner.
+        popup.show(display, evt.getPoint().x - 3, evt.getPoint().y - 3);
         
         return;
     }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotPointSelectionDetailsListener.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotPointSelectionDetailsListener.java
@@ -36,7 +36,8 @@ import uk.ac.starlink.ttools.plot2.task.PointSelectionListener;
  *
  * TODO: This functionality should ideally be done by a mouse hover function - but
  *  the current implemenation of a PlotDisplay in Stil limits our access to point
- *  values to point selection events.
+ *  values to point selection events - so we simulate a tooltip using a custom JPopup
+ *  Object.
  */
 public class PlotPointSelectionDetailsListener extends StilPlotterMouseListener
         implements PointSelectionListener 
@@ -61,6 +62,8 @@ public class PlotPointSelectionDetailsListener extends StilPlotterMouseListener
         
         long[] rows = evt.getClosestRows();
         for (int i=0; i*2<rows.length; i++) {
+            // If the row value is < 0, there was no point near to the mouse click event
+            // See http://tinyurl.com/gq9o7te
             if (rows[2*i] < 0) {
                 continue;
             }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotPointSelectionListener.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotPointSelectionListener.java
@@ -20,6 +20,11 @@ import uk.ac.starlink.ttools.plot2.task.PlotDisplay;
 import uk.ac.starlink.ttools.plot2.task.PointSelectionEvent;
 import uk.ac.starlink.ttools.plot2.task.PointSelectionListener;
 
+/**
+ * MouseListener which allows users to click on the PlotDisplay and add the selected
+ * point to the selection in the metadata browser.
+ *
+ */
 public class PlotPointSelectionListener extends StilPlotterMouseListener
     implements PointSelectionListener 
 {
@@ -30,6 +35,8 @@ public class PlotPointSelectionListener extends StilPlotterMouseListener
         
         long[] rows = evt.getClosestRows();
         for (int i=0; i*2<rows.length; i++) {
+            // It is possible that the Event will contain multiple selected points, but
+            // we will only use the first point selected. See http://tinyurl.com/gq9o7te
             if (rows[2*i] >= 0) {
                 mbView.addRowToSelection(i, (int) rows[2*i]);
                 return;

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotPointSelectionListener.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotPointSelectionListener.java
@@ -1,0 +1,22 @@
+package cfa.vo.iris.visualizer.plotter;
+
+import org.apache.commons.lang.builder.ReflectionToStringBuilder;
+
+import uk.ac.starlink.ttools.plot2.task.PlotDisplay;
+import uk.ac.starlink.ttools.plot2.task.PointSelectionEvent;
+import uk.ac.starlink.ttools.plot2.task.PointSelectionListener;
+
+public class PlotPointSelectionListener extends StilPlotterMouseListener
+    implements PointSelectionListener 
+{
+
+    @Override
+    public void pointSelected(PointSelectionEvent evt) {
+        System.out.println(ReflectionToStringBuilder.toString(evt));
+    }
+
+    @Override
+    public void activate(PlotDisplay display) {
+        display.addPointSelectionListener(this);
+    }
+}

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotPointSelectionListener.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotPointSelectionListener.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 Chandra X-Ray Observatory.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package cfa.vo.iris.visualizer.plotter;
 
 import cfa.vo.iris.visualizer.metadata.MetadataBrowserMainView;
@@ -11,14 +26,13 @@ public class PlotPointSelectionListener extends StilPlotterMouseListener
     
     @Override
     public void pointSelected(PointSelectionEvent evt) {
-        
-        // Get selected star tables out of the Metadata Browser
         MetadataBrowserMainView mbView = this.getPlotterView().getMetadataBrowserView();
         
         long[] rows = evt.getClosestRows();
         for (int i=0; i*2<rows.length; i++) {
             if (rows[2*i] >= 0) {
                 mbView.addRowToSelection(i, (int) rows[2*i]);
+                return;
             }
         }
     }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotPointSelectionListener.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotPointSelectionListener.java
@@ -12,6 +12,7 @@ public class PlotPointSelectionListener extends StilPlotterMouseListener
 
     @Override
     public void pointSelected(PointSelectionEvent evt) {
+        // TODO: Something better than this
         System.out.println(ReflectionToStringBuilder.toString(evt));
     }
 

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotPointSelectionListener.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotPointSelectionListener.java
@@ -1,7 +1,6 @@
 package cfa.vo.iris.visualizer.plotter;
 
-import org.apache.commons.lang.builder.ReflectionToStringBuilder;
-
+import cfa.vo.iris.visualizer.metadata.MetadataBrowserMainView;
 import uk.ac.starlink.ttools.plot2.task.PlotDisplay;
 import uk.ac.starlink.ttools.plot2.task.PointSelectionEvent;
 import uk.ac.starlink.ttools.plot2.task.PointSelectionListener;
@@ -9,15 +8,23 @@ import uk.ac.starlink.ttools.plot2.task.PointSelectionListener;
 public class PlotPointSelectionListener extends StilPlotterMouseListener
     implements PointSelectionListener 
 {
-
+    
     @Override
     public void pointSelected(PointSelectionEvent evt) {
-        // TODO: Something better than this
-        System.out.println(ReflectionToStringBuilder.toString(evt));
+        
+        // Get selected star tables out of the Metadata Browser
+        MetadataBrowserMainView mbView = this.getPlotterView().getMetadataBrowserView();
+        
+        long[] rows = evt.getClosestRows();
+        for (int i=0; i*2<rows.length; i++) {
+            if (rows[2*i] >= 0) {
+                mbView.addRowToSelection(i, (int) rows[2*i]);
+            }
+        }
     }
-
+    
     @Override
-    public void activate(PlotDisplay display) {
+    public void activate(PlotDisplay<?,?> display) {
         display.addPointSelectionListener(this);
     }
 }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotPointSelectionListener.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotPointSelectionListener.java
@@ -18,30 +18,18 @@ package cfa.vo.iris.visualizer.plotter;
 import cfa.vo.iris.visualizer.metadata.MetadataBrowserMainView;
 import uk.ac.starlink.ttools.plot2.task.PlotDisplay;
 import uk.ac.starlink.ttools.plot2.task.PointSelectionEvent;
-import uk.ac.starlink.ttools.plot2.task.PointSelectionListener;
 
 /**
  * MouseListener which allows users to click on the PlotDisplay and add the selected
  * point to the selection in the metadata browser.
  *
  */
-public class PlotPointSelectionListener extends StilPlotterMouseListener
-    implements PointSelectionListener 
+public class PlotPointSelectionListener extends StilPlotterPointSelectionListener
 {
-    
     @Override
-    public void pointSelected(PointSelectionEvent evt) {
+    public void handleSelection(int starTableIndex, int irow, PointSelectionEvent evt) {
         MetadataBrowserMainView mbView = this.getPlotterView().getMetadataBrowserView();
-        
-        long[] rows = evt.getClosestRows();
-        for (int i=0; i*2<rows.length; i++) {
-            // It is possible that the Event will contain multiple selected points, but
-            // we will only use the first point selected. See http://tinyurl.com/gq9o7te
-            if (rows[2*i] >= 0) {
-                mbView.addRowToSelection(i, (int) rows[2*i]);
-                return;
-            }
-        }
+        mbView.addRowToSelection(starTableIndex, irow);
     }
     
     @Override

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.form
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.form
@@ -389,6 +389,13 @@
       </SubComponents>
     </Container>
     <Container class="cfa.vo.iris.visualizer.stil.StilPlotter" name="plotter">
+      <Properties>
+        <Property name="name" type="java.lang.String" value="plotter" noResource="true"/>
+      </Properties>
+      <AccessibilityProperties>
+        <Property name="AccessibleContext.accessibleName" type="java.lang.String" value="plotter"/>
+        <Property name="AccessibleContext.accessibleDescription" type="java.lang.String" value=""/>
+      </AccessibilityProperties>
 
       <Layout class="org.netbeans.modules.form.compat2.layouts.DesignGridLayout">
         <Property name="columns" type="int" value="0"/>

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.form
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.form
@@ -193,7 +193,7 @@
                   <EmptySpace type="separate" max="-2" attributes="0"/>
                   <Component id="left" min="-2" max="-2" attributes="0"/>
                   <EmptySpace max="-2" attributes="0"/>
-                  <Component id="right" min="-2" max="-2" attributes="0"/>
+                  <Component id="left1" min="-2" pref="16" max="-2" attributes="0"/>
                   <EmptySpace max="-2" attributes="0"/>
                   <Component id="up" min="-2" max="-2" attributes="0"/>
                   <EmptySpace max="-2" attributes="0"/>
@@ -214,14 +214,13 @@
         </DimensionLayout>
         <DimensionLayout dim="1">
           <Group type="103" groupAlignment="0" attributes="0">
-              <Group type="102" attributes="0">
+              <Group type="102" alignment="0" attributes="0">
                   <EmptySpace max="-2" attributes="0"/>
                   <Group type="103" groupAlignment="3" attributes="0">
                       <Component id="btnReset" alignment="3" min="-2" max="-2" attributes="0"/>
                       <Component id="zoomIn" alignment="3" min="-2" max="-2" attributes="0"/>
                       <Component id="zoomOut" alignment="3" min="-2" max="-2" attributes="0"/>
                       <Component id="left" alignment="3" min="-2" max="-2" attributes="0"/>
-                      <Component id="right" alignment="3" min="-2" max="-2" attributes="0"/>
                       <Component id="up" alignment="3" min="-2" max="-2" attributes="0"/>
                       <Component id="down" alignment="3" min="-2" max="-2" attributes="0"/>
                       <Component id="txtXposition" alignment="3" min="-2" max="-2" attributes="0"/>
@@ -229,6 +228,7 @@
                       <Component id="metadataButton" alignment="3" min="-2" max="-2" attributes="0"/>
                       <Component id="btnUnits" alignment="3" min="-2" max="-2" attributes="0"/>
                       <Component id="fluxOrDensity" alignment="3" min="-2" max="-2" attributes="0"/>
+                      <Component id="left1" alignment="3" min="-2" max="-2" attributes="0"/>
                   </Group>
                   <EmptySpace max="32767" attributes="0"/>
               </Group>
@@ -253,14 +253,6 @@
               <BindingParameter name="javax.swing.binding.ParameterKeys.TEXT_CHANGE_STRATEGY" value="javax.swing.binding.TextChangeStrategy.ON_TYPE"/>
             </BindingProperty>
           </BindingProperties>
-        </Component>
-        <Component class="cfa.vo.iris.gui.JButtonArrow" name="right">
-          <Properties>
-            <Property name="text" type="java.lang.String" value="jButtonArrow2"/>
-          </Properties>
-          <AuxValues>
-            <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new cfa.vo.iris.gui.JButtonArrow(BasicArrowButton.EAST)"/>
-          </AuxValues>
         </Component>
         <Component class="javax.swing.JButton" name="zoomIn">
           <Properties>
@@ -336,6 +328,14 @@
           </Properties>
           <AuxValues>
             <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new cfa.vo.iris.gui.JButtonArrow(BasicArrowButton.NORTH)"/>
+          </AuxValues>
+        </Component>
+        <Component class="cfa.vo.iris.gui.JButtonArrow" name="left1">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="jButtonArrow1"/>
+          </Properties>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new cfa.vo.iris.gui.JButtonArrow(BasicArrowButton.EAST)"/>
           </AuxValues>
         </Component>
       </SubComponents>

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.form
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.form
@@ -198,13 +198,11 @@
                   <Component id="up" min="-2" max="-2" attributes="0"/>
                   <EmptySpace max="-2" attributes="0"/>
                   <Component id="down" min="-2" max="-2" attributes="0"/>
-                  <EmptySpace min="-2" pref="64" max="-2" attributes="0"/>
-                  <Component id="chckbxAbsolute" min="-2" max="-2" attributes="0"/>
-                  <EmptySpace type="separate" max="-2" attributes="0"/>
-                  <Component id="txtXposition" min="-2" max="-2" attributes="0"/>
+                  <EmptySpace min="-2" pref="135" max="-2" attributes="0"/>
+                  <Component id="txtXposition" min="-2" pref="100" max="-2" attributes="0"/>
                   <EmptySpace max="-2" attributes="0"/>
-                  <Component id="txtYposition" min="-2" max="-2" attributes="0"/>
-                  <EmptySpace pref="57" max="32767" attributes="0"/>
+                  <Component id="txtYposition" min="-2" pref="100" max="-2" attributes="0"/>
+                  <EmptySpace pref="30" max="32767" attributes="0"/>
                   <Component id="metadataButton" min="-2" max="-2" attributes="0"/>
                   <EmptySpace type="separate" max="-2" attributes="0"/>
                   <Component id="fluxOrDensity" min="-2" max="-2" attributes="0"/>
@@ -226,7 +224,6 @@
                       <Component id="right" alignment="3" min="-2" max="-2" attributes="0"/>
                       <Component id="up" alignment="3" min="-2" max="-2" attributes="0"/>
                       <Component id="down" alignment="3" min="-2" max="-2" attributes="0"/>
-                      <Component id="chckbxAbsolute" alignment="3" min="-2" max="-2" attributes="0"/>
                       <Component id="txtXposition" alignment="3" min="-2" max="-2" attributes="0"/>
                       <Component id="txtYposition" alignment="3" min="-2" max="-2" attributes="0"/>
                       <Component id="metadataButton" alignment="3" min="-2" max="-2" attributes="0"/>
@@ -250,8 +247,12 @@
         <Component class="javax.swing.JTextField" name="txtXposition">
           <Properties>
             <Property name="editable" type="boolean" value="false"/>
-            <Property name="text" type="java.lang.String" value="x-position"/>
           </Properties>
+          <BindingProperties>
+            <BindingProperty name="text" source="Form" sourcePath="${xcoord}" target="txtXposition" targetPath="text" updateStrategy="0" immediately="false">
+              <BindingParameter name="javax.swing.binding.ParameterKeys.TEXT_CHANGE_STRATEGY" value="javax.swing.binding.TextChangeStrategy.ON_TYPE"/>
+            </BindingProperty>
+          </BindingProperties>
         </Component>
         <Component class="cfa.vo.iris.gui.JButtonArrow" name="right">
           <Properties>
@@ -297,11 +298,6 @@
             </Property>
           </Properties>
         </Component>
-        <Component class="javax.swing.JCheckBox" name="chckbxAbsolute">
-          <Properties>
-            <Property name="text" type="java.lang.String" value="Absolute"/>
-          </Properties>
-        </Component>
         <Component class="cfa.vo.iris.gui.JButtonArrow" name="left">
           <Properties>
             <Property name="text" type="java.lang.String" value="jButtonArrow1"/>
@@ -327,8 +323,12 @@
         <Component class="javax.swing.JTextField" name="txtYposition">
           <Properties>
             <Property name="editable" type="boolean" value="false"/>
-            <Property name="text" type="java.lang.String" value="y-position"/>
           </Properties>
+          <BindingProperties>
+            <BindingProperty name="text" source="Form" sourcePath="${ycoord}" target="txtYposition" targetPath="text" updateStrategy="0" immediately="false">
+              <BindingParameter name="javax.swing.binding.ParameterKeys.TEXT_CHANGE_STRATEGY" value="javax.swing.binding.TextChangeStrategy.ON_TYPE"/>
+            </BindingProperty>
+          </BindingProperties>
         </Component>
         <Component class="cfa.vo.iris.gui.JButtonArrow" name="up">
           <Properties>

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
@@ -252,7 +252,6 @@ public class PlotterView extends JInternalFrame {
         jPanel1 = new javax.swing.JPanel();
         btnReset = new javax.swing.JButton();
         txtXposition = new javax.swing.JTextField();
-        right = new cfa.vo.iris.gui.JButtonArrow(BasicArrowButton.EAST);
         zoomIn = new javax.swing.JButton();
         btnUnits = new javax.swing.JButton();
         down = new cfa.vo.iris.gui.JButtonArrow(BasicArrowButton.SOUTH);
@@ -262,6 +261,7 @@ public class PlotterView extends JInternalFrame {
         metadataButton = new javax.swing.JButton();
         txtYposition = new javax.swing.JTextField();
         up = new cfa.vo.iris.gui.JButtonArrow(BasicArrowButton.NORTH);
+        left1 = new cfa.vo.iris.gui.JButtonArrow(BasicArrowButton.EAST);
         jPanel2 = new javax.swing.JPanel();
         secondaryPlotOptions = new javax.swing.JSpinner();
         tglbtnShowHideResiduals = new javax.swing.JToggleButton();
@@ -296,8 +296,6 @@ public class PlotterView extends JInternalFrame {
 
         org.jdesktop.beansbinding.Binding binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${xcoord}"), txtXposition, org.jdesktop.beansbinding.BeanProperty.create("text"));
         bindingGroup.addBinding(binding);
-
-        right.setText("jButtonArrow2");
 
         zoomIn.setText("In");
         zoomIn.setEnabled(false);
@@ -338,6 +336,8 @@ public class PlotterView extends JInternalFrame {
 
         up.setText("jButtonArrow3");
 
+        left1.setText("jButtonArrow1");
+
         javax.swing.GroupLayout jPanel1Layout = new javax.swing.GroupLayout(jPanel1);
         jPanel1.setLayout(jPanel1Layout);
         jPanel1Layout.setHorizontalGroup(
@@ -352,7 +352,7 @@ public class PlotterView extends JInternalFrame {
                 .addGap(18, 18, 18)
                 .addComponent(left, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(right, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addComponent(left1, javax.swing.GroupLayout.PREFERRED_SIZE, 16, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(up, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
@@ -378,14 +378,14 @@ public class PlotterView extends JInternalFrame {
                     .addComponent(zoomIn)
                     .addComponent(zoomOut)
                     .addComponent(left, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(right, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(up, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(down, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(txtXposition, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(txtYposition, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(metadataButton)
                     .addComponent(btnUnits)
-                    .addComponent(fluxOrDensity, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                    .addComponent(fluxOrDensity, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(left1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
                 .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
 
@@ -580,6 +580,7 @@ public class PlotterView extends JInternalFrame {
     private javax.swing.JPanel jPanel1;
     private javax.swing.JPanel jPanel2;
     private cfa.vo.iris.gui.JButtonArrow left;
+    private cfa.vo.iris.gui.JButtonArrow left1;
     private javax.swing.JMenuBar menuBar;
     private javax.swing.JButton metadataButton;
     private javax.swing.JMenu mnEdit;

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
@@ -53,6 +53,10 @@ public class PlotterView extends JInternalFrame {
     private MetadataBrowserMainView metadataBrowser;
     private UnitsManagerFrame unitsManagerFrame;
     
+    // Plot mouse coordinate locations
+    private String xcoord;
+    private String ycoord;
+    
     private static double ZOOM_SCALE = 0.5;
     
     /**
@@ -213,7 +217,28 @@ public class PlotterView extends JInternalFrame {
         this.plotter.reset(source, true);
     }
     
-
+    public String getXcoord() {
+        return xcoord;
+    }
+    
+    private static final String XCOORD_PROPERTY = "xcoord";
+    public void setXcoord(String x) {
+        String old = this.xcoord;
+        this.xcoord = x;
+        firePropertyChange(XCOORD_PROPERTY, old, xcoord);
+    }
+    
+    public String getYcoord() {
+        return ycoord;
+    }
+    
+    private static final String YCOORD_PROPERTY = "ycoord";
+    public void setYcoord(String y) {
+        String old = this.ycoord;
+        this.ycoord = y;
+        firePropertyChange(YCOORD_PROPERTY, old, ycoord);
+    }
+    
     /**
      * This method is called from within the constructor to initialize the form.
      * WARNING: Do NOT modify this code. The content of this method is always

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
@@ -261,7 +261,6 @@ public class PlotterView extends JInternalFrame {
         btnUnits = new javax.swing.JButton();
         down = new cfa.vo.iris.gui.JButtonArrow(BasicArrowButton.SOUTH);
         fluxOrDensity = new javax.swing.JSpinner();
-        chckbxAbsolute = new javax.swing.JCheckBox();
         left = new cfa.vo.iris.gui.JButtonArrow(BasicArrowButton.WEST);
         zoomOut = new javax.swing.JButton();
         metadataButton = new javax.swing.JButton();
@@ -298,7 +297,9 @@ public class PlotterView extends JInternalFrame {
         });
 
         txtXposition.setEditable(false);
-        txtXposition.setText("x-position");
+
+        org.jdesktop.beansbinding.Binding binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${xcoord}"), txtXposition, org.jdesktop.beansbinding.BeanProperty.create("text"));
+        bindingGroup.addBinding(binding);
 
         right.setText("jButtonArrow2");
 
@@ -322,8 +323,6 @@ public class PlotterView extends JInternalFrame {
 
         fluxOrDensity.setModel(new javax.swing.SpinnerListModel(new String[] {"Flux", "Flux Density"}));
 
-        chckbxAbsolute.setText("Absolute");
-
         left.setText("jButtonArrow1");
 
         zoomOut.setText("Out");
@@ -337,7 +336,9 @@ public class PlotterView extends JInternalFrame {
         metadataButton.setText("Metadata");
 
         txtYposition.setEditable(false);
-        txtYposition.setText("y-position");
+
+        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${ycoord}"), txtYposition, org.jdesktop.beansbinding.BeanProperty.create("text"));
+        bindingGroup.addBinding(binding);
 
         up.setText("jButtonArrow3");
 
@@ -360,13 +361,11 @@ public class PlotterView extends JInternalFrame {
                 .addComponent(up, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(down, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addGap(64, 64, 64)
-                .addComponent(chckbxAbsolute)
-                .addGap(18, 18, 18)
-                .addComponent(txtXposition, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addGap(135, 135, 135)
+                .addComponent(txtXposition, javax.swing.GroupLayout.PREFERRED_SIZE, 100, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(txtYposition, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, 57, Short.MAX_VALUE)
+                .addComponent(txtYposition, javax.swing.GroupLayout.PREFERRED_SIZE, 100, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, 30, Short.MAX_VALUE)
                 .addComponent(metadataButton)
                 .addGap(18, 18, 18)
                 .addComponent(fluxOrDensity, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
@@ -386,7 +385,6 @@ public class PlotterView extends JInternalFrame {
                     .addComponent(right, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(up, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(down, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(chckbxAbsolute)
                     .addComponent(txtXposition, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(txtYposition, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(metadataButton)
@@ -487,7 +485,7 @@ public class PlotterView extends JInternalFrame {
         mntmAutoFixed.setText("Fixed");
         mntmAutoFixed.setToolTipText("<html>Fix the plot ranges when the SED changes. Otherwise, <br/> \nthe plot ranges automatically update when a SED changes.</html>");
 
-        org.jdesktop.beansbinding.Binding binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, plotter, org.jdesktop.beansbinding.ELProperty.create("${visualizerPreferences.plotPreferences.fixed}"), mntmAutoFixed, org.jdesktop.beansbinding.BeanProperty.create("selected"));
+        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, plotter, org.jdesktop.beansbinding.ELProperty.create("${visualizerPreferences.plotPreferences.fixed}"), mntmAutoFixed, org.jdesktop.beansbinding.BeanProperty.create("selected"));
         bindingGroup.addBinding(binding);
 
         jMenu1.add(mntmAutoFixed);
@@ -577,7 +575,6 @@ public class PlotterView extends JInternalFrame {
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JButton btnReset;
     private javax.swing.JButton btnUnits;
-    private javax.swing.JCheckBox chckbxAbsolute;
     private cfa.vo.iris.gui.JButtonArrow down;
     private javax.swing.JSpinner fluxOrDensity;
     private javax.swing.JMenu jMenu1;

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
@@ -176,6 +176,9 @@ public class PlotterView extends JInternalFrame {
         });
         
         addPlotChangeListener();
+        
+        // Set listeners to point to this view
+        preferences.getMouseListenerManager().setPlotterView(this);
     }
     
     protected void addPlotChangeListener() {

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
@@ -416,6 +416,8 @@ public class PlotterView extends JInternalFrame {
                 .addContainerGap())
         );
 
+        plotter.setName("plotter"); // NOI18N
+
         menuBar.setName("menuBar"); // NOI18N
 
         mnF.setText("File");
@@ -523,6 +525,9 @@ public class PlotterView extends JInternalFrame {
                 .addComponent(jPanel2, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
         );
 
+        plotter.getAccessibleContext().setAccessibleName("plotter");
+        plotter.getAccessibleContext().setAccessibleDescription("");
+
         bindingGroup.bind();
 
         pack();
@@ -595,7 +600,6 @@ public class PlotterView extends JInternalFrame {
     private javax.swing.JRadioButtonMenuItem mntmYlog;
     private javax.swing.ButtonGroup plotTypeButtonGroup;
     private cfa.vo.iris.visualizer.stil.StilPlotter plotter;
-    private cfa.vo.iris.gui.JButtonArrow right;
     private javax.swing.JSpinner secondaryPlotOptions;
     private javax.swing.JToggleButton tglbtnShowHideResiduals;
     private javax.swing.JTextField txtXposition;

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
@@ -35,6 +35,7 @@ import java.util.logging.Logger;
 import javax.swing.JFileChooser;
 import javax.swing.JFrame;
 import javax.swing.JInternalFrame;
+import javax.swing.plaf.basic.BasicArrowButton;
 
 public class PlotterView extends JInternalFrame {
     
@@ -550,8 +551,6 @@ public class PlotterView extends JInternalFrame {
         
         if (fixed)
            plotPrefs.setFixed(true);
-        
-        metadataBrowser.resetData();
     }//GEN-LAST:event_btnResetActionPerformed
 
     private void mntmExportActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_mntmExportActionPerformed

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
@@ -35,7 +35,6 @@ import java.util.logging.Logger;
 import javax.swing.JFileChooser;
 import javax.swing.JFrame;
 import javax.swing.JInternalFrame;
-import javax.swing.plaf.basic.BasicArrowButton;
 
 public class PlotterView extends JInternalFrame {
     
@@ -45,8 +44,6 @@ public class PlotterView extends JInternalFrame {
     
     private IWorkspace ws;
     private IrisApplication app;
-    private final VisualizerComponentPreferences preferences;
-
     // Plotting Components
     // StilPlotter plotter initialized in initComponents()
     private JInternalFrame residuals;
@@ -54,8 +51,8 @@ public class PlotterView extends JInternalFrame {
     private UnitsManagerFrame unitsManagerFrame;
     
     // Plot mouse coordinate locations
-    private String xcoord;
-    private String ycoord;
+    private String xcoord = "0E0";
+    private String ycoord = "0E0";
     
     private static double ZOOM_SCALE = 0.5;
     
@@ -85,9 +82,7 @@ public class PlotterView extends JInternalFrame {
         
         this.ws = ws;
         this.app = app;
-        this.preferences = preferences;
-        
-        this.metadataBrowser = new MetadataBrowserMainView(ws, preferences);       
+        this.metadataBrowser = new MetadataBrowserMainView(ws, preferences);
         this.residuals = new JInternalFrame();
         
         initComponents();

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/StilPlotterMouseListener.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/StilPlotterMouseListener.java
@@ -1,0 +1,27 @@
+package cfa.vo.iris.visualizer.plotter;
+
+import uk.ac.starlink.ttools.plot2.task.PlotDisplay;
+
+public abstract class StilPlotterMouseListener {
+    
+    PlotterView plotterView;
+    boolean active = true;
+    
+    public abstract void activate(PlotDisplay display);
+
+    public PlotterView getPlotterView() {
+        return plotterView;
+    }
+
+    public void setPlotterView(PlotterView plotterView) {
+        this.plotterView = plotterView;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+}

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/StilPlotterMouseListener.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/StilPlotterMouseListener.java
@@ -1,4 +1,21 @@
+/*
+ * Copyright 2016 Chandra X-Ray Observatory.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package cfa.vo.iris.visualizer.plotter;
+
+import java.text.DecimalFormat;
 
 import uk.ac.starlink.ttools.plot2.task.PlotDisplay;
 
@@ -6,6 +23,11 @@ public abstract class StilPlotterMouseListener {
     
     PlotterView plotterView;
     boolean active = true;
+    
+    protected final static DecimalFormat df = new DecimalFormat("0.######E0");
+    static {
+        df.setMaximumFractionDigits(6);
+    }
     
     public abstract void activate(PlotDisplay<?,?> display);
 
@@ -23,5 +45,9 @@ public abstract class StilPlotterMouseListener {
 
     public void setActive(boolean active) {
         this.active = active;
+    }
+    
+    protected static String formatNumber(double d) {
+        return df.format(d);
     }
 }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/StilPlotterMouseListener.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/StilPlotterMouseListener.java
@@ -7,7 +7,7 @@ public abstract class StilPlotterMouseListener {
     PlotterView plotterView;
     boolean active = true;
     
-    public abstract void activate(PlotDisplay display);
+    public abstract void activate(PlotDisplay<?,?> display);
 
     public PlotterView getPlotterView() {
         return plotterView;

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/StilPlotterPointSelectionListener.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/StilPlotterPointSelectionListener.java
@@ -1,0 +1,47 @@
+package cfa.vo.iris.visualizer.plotter;
+
+import java.util.logging.Logger;
+
+import uk.ac.starlink.ttools.plot2.task.PointSelectionEvent;
+import uk.ac.starlink.ttools.plot2.task.PointSelectionListener;
+
+public abstract class StilPlotterPointSelectionListener
+        extends StilPlotterMouseListener
+        implements PointSelectionListener
+{
+    
+    private static Logger logger = Logger.getLogger(StilPlotterPointSelectionListener.class.getName());
+    
+    @Override
+    public void pointSelected(PointSelectionEvent evt) {
+        try {
+            processEvent(evt);
+        } catch (Exception e) {
+            // Mouse events are handled asynchronously by the swing EDT, so just log a warning.
+            logger.warning(e.getMessage());
+        }
+    }
+    
+    /**
+     * Convert a PointSelectionEvent to a StarTable index in selectedTables and a row
+     * coordinate within that table.
+     * @param evt
+     */
+    private void processEvent(PointSelectionEvent evt) {
+        
+        // TODO: Change this to increment by the number of layers in a given segment layer, 
+        // rather than just 2.
+        long[] rows = evt.getClosestRows();
+        for (int i=0; i*2<rows.length; i++) {
+            // It is possible that the Event will contain multiple selected points, but
+            // we will only use the first point selected. See http://tinyurl.com/gq9o7te
+            if (rows[2*i] >= 0) {
+                handleSelection(i, (int) rows[2*i], evt);
+                return;
+            }
+        }
+        
+    }
+    
+    public abstract void handleSelection(int starTableIndex, int irow, PointSelectionEvent evt);
+}

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerComponentPreferences.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerComponentPreferences.java
@@ -34,6 +34,7 @@ import cfa.vo.iris.events.SegmentEvent;
 import cfa.vo.iris.events.SegmentEvent.SegmentPayload;
 import cfa.vo.iris.events.SegmentListener;
 import cfa.vo.iris.sed.ExtSed;
+import cfa.vo.iris.visualizer.plotter.MouseListenerManager;
 import cfa.vo.iris.visualizer.plotter.PlotPreferences;
 import cfa.vo.iris.visualizer.plotter.SegmentLayer;
 import cfa.vo.iris.visualizer.stil.tables.ColumnInfoMatcher;
@@ -51,6 +52,7 @@ public class VisualizerComponentPreferences {
     private static final ExecutorService visualizerExecutor = Executors.newFixedThreadPool(5);
     
     PlotPreferences plotPreferences;
+    MouseListenerManager mouseListenerManager;
     IrisStarTableAdapter adapter;
     ColumnInfoMatcher columnInfoMatcher;
     final IWorkspace ws;
@@ -59,8 +61,11 @@ public class VisualizerComponentPreferences {
     public VisualizerComponentPreferences(IWorkspace ws) {
         this.ws = ws;
         
-        // TODO: change serialization when we have something that works
+        // For converting segments to IrisStarTables
         this.adapter = new IrisStarTableAdapter(visualizerExecutor);
+        
+        // Manages all mouse listeners over the plotter
+        this.mouseListenerManager = new MouseListenerManager();
         
         // Create and add preferences for the SED
         this.sedPreferences = Collections.synchronizedMap(new IdentityHashMap<ExtSed, SedPreferences>());
@@ -118,6 +123,14 @@ public class VisualizerComponentPreferences {
      */
     public IrisStarTableAdapter getAdapter() {
         return adapter;
+    }
+    
+    /**
+     * @return
+     *  MouseListeners for the stil plotter.
+     */
+    public MouseListenerManager getMouseListenerManager() {
+        return mouseListenerManager;
     }
     
     /**

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/IrisStarJTable.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/IrisStarJTable.java
@@ -21,6 +21,7 @@ import java.awt.event.MouseEvent;
 
 import javax.swing.table.JTableHeader;
 import javax.swing.table.TableColumnModel;
+import java.awt.Rectangle;
 
 import org.apache.commons.lang.StringUtils;
 import cfa.vo.iris.utils.UTYPE;
@@ -85,6 +86,12 @@ public class IrisStarJTable extends StarJTable {
                 c.setHeaderValue(utype);
             }
         }
+    }
+    
+    public void selectRowIndex(int irow) {
+        // TODO: Handle sorting when we add it.
+        this.selectionModel.addSelectionInterval(irow, irow);
+        this.scrollRectToVisible(new Rectangle(this.getCellRect(irow, 0, true)));
     }
     
     protected class StarJTableHeader extends JTableHeader {

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/StilPlotter.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/StilPlotter.java
@@ -304,7 +304,14 @@ public class StilPlotter extends JPanel {
         logger.log(Level.FINE, "plot environment:");
         logger.log(Level.FINE, ReflectionToStringBuilder.toString(env));
         
-        return new PlanePlot2Task().createPlotComponent(env, cached);
+        
+        PlotDisplay<PlaneSurfaceFactory.Profile,PlaneAspect> display =
+                new PlanePlot2Task().createPlotComponent(env, cached);
+        
+        // Always update mouse listeners with the new display
+        preferences.getMouseListenerManager().activateListeners(display);
+        
+        return display;
     }
 
     protected void setupMapEnvironment(ExtSed sed) throws IOException {

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/IrisStarTable.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/IrisStarTable.java
@@ -16,6 +16,7 @@
 
 package cfa.vo.iris.visualizer.stil.tables;
 
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.Future;
 
@@ -111,5 +112,22 @@ public class IrisStarTable extends WrapperStarTable {
     
     public String getYUnits() {
         return plotterTable.getFluxUnits().toString();
+    }
+    
+    /**
+     * Returns the row start index for the specified table in the list of StarTables.
+     */
+    public static int getTableStartIndex(List<IrisStarTable> tables, IrisStarTable table) {
+        // TODO: Handle masking when we merge this.
+        int index = 0;
+        
+        for (IrisStarTable t : tables) {
+            if (t.equals(table)) {
+                return index;
+            }
+            index = index + ((int) table.getRowCount());
+        }
+        
+        return -1;
     }
 }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/IrisStarTable.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/IrisStarTable.java
@@ -125,7 +125,7 @@ public class IrisStarTable extends WrapperStarTable {
             if (t.equals(table)) {
                 return index;
             }
-            index = index + ((int) table.getRowCount());
+            index = index + ((int) t.getRowCount());
         }
         
         return -1;

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainViewTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainViewTest.java
@@ -316,7 +316,7 @@ public class MetadataBrowserMainViewTest extends AbstractComponentGUITest {
         final Segment seg2 = createSampleSegment(x2, y2);
         sed.addSegment(seg2);
         
-        invokeWithRetry(20, 100, new Runnable() {
+        invokeWithRetry(50, 100, new Runnable() {
             @Override
             public void run() {
                 // two tables in selection, 1 selected, no rows selected
@@ -330,7 +330,7 @@ public class MetadataBrowserMainViewTest extends AbstractComponentGUITest {
         // Selecting a point should add the first row to selection
         mbView.addRowToSelection(0, 0);
         
-        invokeWithRetry(20, 100, new Runnable() {
+        invokeWithRetry(50, 100, new Runnable() {
             @Override
             public void run() {
                 // first row should be selected, still just one star table
@@ -342,7 +342,7 @@ public class MetadataBrowserMainViewTest extends AbstractComponentGUITest {
         // Select the only point in the second star table
         mbView.addRowToSelection(1, 0);
         
-        invokeWithRetry(20, 100, new Runnable() {
+        invokeWithRetry(50, 100, new Runnable() {
             @Override
             public void run() {
                 // Both rows should be selected, ditto both star tables


### PR DESCRIPTION
Small PR which will setup later tasks for other mouse listeners.

For now, this closes: https://github.com/ChandraCXC/iris-dev/issues/15, and will display the mouse's coordinates in the stil plotter in the two places we reserved for them in the plot view.

I figure for now we can put mouse listener classes into the MouseListenerManager class, which the StilPlotter can maintain a pointer to to make sure each new mouse listener is added to the PlotDisplay whenever one is created. I left it in the preferences class so that other callers have access if necessary.

There's also a simple, silly Point Selection Listener in place just to show how it works. Whomever picks up the point selection event tasks can use it as a template for what point selection events look like.

[EDIT]

This now also closes 
https://github.com/ChandraCXC/iris-dev/issues/28
https://github.com/ChandraCXC/iris-dev/issues/29

As mentioned in TODOS/comments, there is going to be more work when we implement sorting and after we merge the masking PR (https://github.com/ChandraCXC/iris/pull/272). I think the separation is pretty clear in the code, and that this won't have to change when those are implemented.

Also note that point selection in the PlotDisplay VIA hovering is pretty limited, it would be nice if the PlotDisplay class supported calling https://github.com/Starlink/starjava/blob/master/ttools/src/main/uk/ac/starlink/ttools/plot2/task/PlotDisplay.java#L405 or had some other way get get at nearest points other than the single interface. I added a question for them in the UDF. For now the selection/metadata listeners preserve existing Iris2.1 behaviour.