### PR TITLE
iris-dev#53 Show Column Metadata in Tooltip

### DIFF
--- a/iris-common/src/main/java/cfa/vo/iris/sed/stil/SegmentStarTable.java
+++ b/iris-common/src/main/java/cfa/vo/iris/sed/stil/SegmentStarTable.java
@@ -115,6 +115,10 @@ public class SegmentStarTable extends RandomStarTable {
         setSpecErrValues((double[]) getDataFromSegment(Utypes.SEG_DATA_SPECTRALAXIS_ACC_STATERR));
         setSpecErrValuesHi((double[]) getDataFromSegment(Utypes.SEG_DATA_SPECTRALAXIS_ACC_STATERRHIGH));
         setSpecErrValuesLo((double[]) getDataFromSegment(Utypes.SEG_DATA_SPECTRALAXIS_ACC_STATERRLOW));
+        
+        // Update column unit values
+        updateSpecColumnUnitStrings();
+        updateFluxColumnUnitStrings();
     }
 
     @Override
@@ -163,26 +167,28 @@ public class SegmentStarTable extends RandomStarTable {
      * @throws UnitsException
      */
     public void setSpecUnits(XUnit newUnit) throws UnitsException {
-        if (newUnit.equals(this.specUnits)) return;
-        
         setSpecValues(units.convertX(specValues, specUnits, newUnit));
         setSpecErrValues(units.convertX(specErrValues, specUnits, newUnit));
         setSpecErrValuesLo(units.convertX(specErrValuesLo, specUnits, newUnit));
         setSpecErrValuesHi(units.convertX(specErrValuesHi, specUnits, newUnit));
         specUnits = newUnit;
         
+        // Update column unit values
+        updateSpecColumnUnitStrings();
+        
         // This may change Y values, so update them accordingly.
         setFluxUnits(fluxUnits);
-        
-        // Update column unit values
+    }
+    
+    private void updateSpecColumnUnitStrings() {
         for (int i=0; i<this.getColumnCount(); i++) {
             if (StringUtils.contains(getColumnInfo(i).getUtype(), "spec"))
-                getColumnInfo(i).setUnitString(newUnit.toString());
+                getColumnInfo(i).setUnitString(specUnits.toString());
         }
     }
     
     /**
-     * Sets the flux axis units for this star table, which updates all relevat flux
+     * Sets the flux axis units for this star table, which updates all relevant flux
      * valued columns in the table.
      * 
      * @param newUnit
@@ -198,11 +204,16 @@ public class SegmentStarTable extends RandomStarTable {
         setFluxErrValuesLo(units.convertY(fluxErrValuesLo, specValues, fluxUnits, specUnits, newUnit));
         setFluxErrValuesHi(units.convertY(fluxErrValuesLo, specValues, fluxUnits, specUnits, newUnit));
         
-        // Update values
         fluxUnits = newUnit;
+        
+        // Update column units
+        updateFluxColumnUnitStrings();
+    }
+    
+    private void updateFluxColumnUnitStrings() {
         for (int i=0; i<this.getColumnCount(); i++) {
             if (StringUtils.contains(getColumnInfo(i).getUtype(), "flux"))
-                getColumnInfo(i).setUnitString(newUnit.toString());
+                getColumnInfo(i).setUnitString(fluxUnits.toString());
         }
     }
 

--- a/iris-common/src/test/java/cfa/vo/iris/sed/stil/SegmentStarTableTest.java
+++ b/iris-common/src/test/java/cfa/vo/iris/sed/stil/SegmentStarTableTest.java
@@ -45,8 +45,13 @@ public class SegmentStarTableTest {
         assertEquals(Column.Flux_Value.name(), table.getColumnInfo(2).getName());
         assertEquals(Column.Original_Flux_Value.name(), table.getColumnInfo(3).getName());
         assertEquals(Column.Flux_Error.name(), table.getColumnInfo(4).getName());
+        
         assertEquals(new XUnits("Hz"), table.getSpecUnits());
         assertEquals(new YUnits("Jy"), table.getFluxUnits());
+        assertEquals("Hz", table.getColumnInfo(id.getColumnIndex(Column.Spectral_Value.name())).getUnitString());
+        assertEquals("Jy", table.getColumnInfo(id.getColumnIndex(Column.Flux_Value.name())).getUnitString());
+        assertEquals("Jy", table.getColumnInfo(id.getColumnIndex(Column.Original_Flux_Value.name())).getUnitString());
+        assertEquals("Jy", table.getColumnInfo(id.getColumnIndex(Column.Flux_Error.name())).getUnitString());
         
         int col = id.getColumnIndex(Column.Flux_Error.name());
         assertTrue(col >= 0);
@@ -65,5 +70,10 @@ public class SegmentStarTableTest {
         col = id.getColumnIndex(Column.Flux_Error.name());
         assertTrue(col >= 0);
         assertEquals(new Double("5.61E-6"), (Double) table.getCell(0, col), 1E-8);
+        
+        assertEquals('\u03BC' + "m", table.getColumnInfo(id.getColumnIndex(Column.Spectral_Value.name())).getUnitString());
+        assertEquals("erg/s/cm2/Angstrom", table.getColumnInfo(id.getColumnIndex(Column.Flux_Value.name())).getUnitString());
+        assertEquals("erg/s/cm2/Angstrom", table.getColumnInfo(id.getColumnIndex(Column.Original_Flux_Value.name())).getUnitString());
+        assertEquals("erg/s/cm2/Angstrom", table.getColumnInfo(id.getColumnIndex(Column.Flux_Error.name())).getUnitString());
     }
 }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/IrisStarJTable.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/IrisStarJTable.java
@@ -16,9 +16,15 @@
 
 package cfa.vo.iris.visualizer.stil;
 
-import org.apache.commons.lang.StringUtils;
+import java.awt.Point;
+import java.awt.event.MouseEvent;
 
+import javax.swing.table.JTableHeader;
+import javax.swing.table.TableColumnModel;
+
+import org.apache.commons.lang.StringUtils;
 import cfa.vo.iris.utils.UTYPE;
+import uk.ac.starlink.table.ColumnInfo;
 import uk.ac.starlink.table.StarTable;
 import uk.ac.starlink.table.gui.StarJTable;
 import uk.ac.starlink.table.gui.StarTableColumn;
@@ -28,6 +34,8 @@ import uk.ac.starlink.table.gui.StarTableColumn;
  *
  */
 public class IrisStarJTable extends StarJTable {
+    
+    private static final long serialVersionUID = -6504087912203707631L;
     
     // Use ColumnNames or Utypes in the column header fields
     private boolean utypeAsNames = false;
@@ -50,13 +58,21 @@ public class IrisStarJTable extends StarJTable {
         this.utypeAsNames = utypeAsNames;
     }
     
+    @Override 
+    protected JTableHeader createDefaultTableHeader() {
+        return new StarJTableHeader(columnModel);
+    }
+    
     @Override
     public void setStarTable(StarTable table, boolean showIndex) {
         super.setStarTable(table, showIndex);
         
-        if (!utypeAsNames) {
-            return;
+        if (utypeAsNames) {
+            setUtypeColumnNames();
         }
+    }
+    
+    private void setUtypeColumnNames() {
         
         // If we're using utypes as column names, override existing settings here.
         for (int i=0;i < columnModel.getColumnCount(); i++) {
@@ -68,6 +84,42 @@ public class IrisStarJTable extends StarJTable {
                 String utype = UTYPE.trimPrefix(c.getColumnInfo().getUtype());
                 c.setHeaderValue(utype);
             }
+        }
+    }
+    
+    private class StarJTableHeader extends JTableHeader {
+        
+        private static final long serialVersionUID = -3882589620263074781L;
+        
+        public StarJTableHeader(TableColumnModel model) {
+            super(model);
+        }
+        
+        @Override
+        public String getToolTipText(MouseEvent evt) {
+            Point p = evt.getPoint();
+            int index = columnModel.getColumnIndexAtX(p.x);
+            String tt = printColumnInfo((StarTableColumn) columnModel.getColumn(index));
+            return tt;
+        }
+        
+        private String printColumnInfo(StarTableColumn column) {
+            ColumnInfo info = column.getColumnInfo();
+            
+            StringBuilder bb = new StringBuilder();
+            bb.append("<html>");
+            if (!StringUtils.isEmpty(info.getName())) {
+                bb.append(String.format("name: %s<br>", info.getName()));
+            }
+            if (!StringUtils.isEmpty(info.getUnitString())) {
+                bb.append(String.format("unit: %s<br>", info.getUnitString()));
+            }
+            if (!StringUtils.isEmpty(info.getUtype())) {
+                bb.append(String.format("utype: %s<br>", info.getUtype()));
+            }
+            bb.append("</html>");
+            
+            return bb.toString();
         }
     }
 }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/IrisStarJTable.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/IrisStarJTable.java
@@ -87,7 +87,7 @@ public class IrisStarJTable extends StarJTable {
         }
     }
     
-    private class StarJTableHeader extends JTableHeader {
+    protected class StarJTableHeader extends JTableHeader {
         
         private static final long serialVersionUID = -3882589620263074781L;
         

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/IrisStarJTableTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/IrisStarJTableTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2016 Chandra X-Ray Observatory.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cfa.vo.iris.visualizer.stil;
+
+import static org.junit.Assert.*;
+
+import java.awt.event.MouseEvent;
+
+import javax.swing.table.TableColumn;
+import javax.swing.table.TableColumnModel;
+
+import org.apache.commons.lang.StringUtils;
+import org.junit.Test;
+import cfa.vo.iris.sed.stil.SegmentStarTable;
+import cfa.vo.iris.test.unit.TestUtils;
+import cfa.vo.iris.visualizer.stil.IrisStarJTable.StarJTableHeader;
+
+public class IrisStarJTableTest {
+    
+    @Test
+    public void testColumnHeaderTooltips() throws Exception {
+        IrisStarJTable table = new IrisStarJTable();
+        SegmentStarTable segTable = new SegmentStarTable(TestUtils.createSampleSegment());
+        
+        table.setStarTable(segTable);
+        StarJTableHeader header = (StarJTableHeader) table.getTableHeader();
+        TableColumnModel columnModel = table.getColumnModel();
+        
+        // Location of x pointer
+        int xLoc = 0;
+        
+        // Index
+        TableColumn col = columnModel.getColumn(0);
+        MouseEvent evt = new MouseEvent(header, 0, 0, 0, xLoc, 0, 1, false);
+        String text = header.getToolTipText(evt);
+        assertTrue(StringUtils.contains(text, "name: Index"));
+        
+        // Segment_Id
+        xLoc = xLoc + col.getWidth() + 1;
+        col = columnModel.getColumn(1);
+        evt = new MouseEvent(header, 0, 0, 0, xLoc, 0, 1, false);
+        text = header.getToolTipText(evt);
+        assertTrue(StringUtils.contains(text, "name: Segment_Id"));
+        
+        // Spectral Value
+        xLoc = xLoc + col.getWidth() + 1;
+        col = columnModel.getColumn(2);
+        evt = new MouseEvent(header, 0, 0, 0, xLoc, 0, 1, false);
+        text = header.getToolTipText(evt);
+        assertTrue(StringUtils.contains(text, "name: Spectral_Value"));
+        assertTrue(StringUtils.contains(text, "unit: Angstrom"));
+        
+        // Switch Spectral and Flux value columns
+        columnModel.moveColumn(3, 2);
+        evt = new MouseEvent(header, 0, 0, 0, xLoc, 0, 1, false);
+        text = header.getToolTipText(evt);
+        assertTrue(StringUtils.contains(text, "name: Flux_Value"));
+        assertTrue(StringUtils.contains(text, "unit: Jy"));
+    }
+}


### PR DESCRIPTION
Closes https://github.com/ChandraCXC/iris-dev/issues/53

Added a custom JTableHeader to the IrisStarJTable class to support showing tooltips that look something like:

name: DataFluxStatErr
unit: Jy
utype: some.utype

Also fixed an issue with the units strings not being set on SegmentStarTable creation and updated the test to cover that case.

Supports permuting and resizing columns.