### PR TITLE
Add zoom button functionality

### DIFF
--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.form
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.form
@@ -257,7 +257,6 @@
         <Component class="javax.swing.JButton" name="zoomIn">
           <Properties>
             <Property name="text" type="java.lang.String" value="In"/>
-            <Property name="enabled" type="boolean" value="false"/>
           </Properties>
           <Events>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="zoomInActionPerformed"/>
@@ -301,7 +300,6 @@
         <Component class="javax.swing.JButton" name="zoomOut">
           <Properties>
             <Property name="text" type="java.lang.String" value="Out"/>
-            <Property name="enabled" type="boolean" value="false"/>
           </Properties>
           <Events>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="zoomOutActionPerformed"/>

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
@@ -55,7 +55,7 @@ public class PlotterView extends JInternalFrame {
     private String xcoord = "0E0";
     private String ycoord = "0E0";
     
-    private static double ZOOM_SCALE = 0.5;
+    public static double ZOOM_SCALE = 0.5;
     
     /**
      * Create the frame.

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
@@ -298,7 +298,6 @@ public class PlotterView extends JInternalFrame {
         bindingGroup.addBinding(binding);
 
         zoomIn.setText("In");
-        zoomIn.setEnabled(false);
         zoomIn.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 zoomInActionPerformed(evt);
@@ -320,7 +319,6 @@ public class PlotterView extends JInternalFrame {
         left.setText("jButtonArrow1");
 
         zoomOut.setText("Out");
-        zoomOut.setEnabled(false);
         zoomOut.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 zoomOutActionPerformed(evt);

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
@@ -538,7 +538,7 @@ public class PlotterView extends JInternalFrame {
 
     private void zoomOutActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_zoomOutActionPerformed
         // zoom out by a factor
-        this.plotter.zoom(1 - ZOOM_SCALE);
+        this.plotter.zoom(1 - ZOOM_SCALE*2/3);
     }//GEN-LAST:event_zoomOutActionPerformed
 
     private void btnResetActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnResetActionPerformed

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/StilPlotter.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/StilPlotter.java
@@ -23,6 +23,7 @@ import cfa.vo.iris.sed.quantities.SPVMagnitude;
 import cfa.vo.iris.sed.quantities.SPVYQuantity;
 import cfa.vo.iris.sed.quantities.SPVYUnit;
 import cfa.vo.iris.visualizer.plotter.PlotPreferences;
+import cfa.vo.iris.visualizer.plotter.PlotPreferences.PlotType;
 import cfa.vo.iris.visualizer.plotter.SegmentLayer;
 import cfa.vo.iris.visualizer.preferences.SedPreferences;
 import cfa.vo.iris.visualizer.preferences.VisualizerComponentPreferences;
@@ -46,6 +47,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import uk.ac.starlink.ttools.plot2.geom.PlaneSurface;
 
 public class StilPlotter extends JPanel {
 
@@ -191,21 +193,86 @@ public class StilPlotter extends JPanel {
      */
     public void zoom(double zoomFactor) {
         
-        throw new UnsupportedOperationException("The zoom functionality is"
-                + "currently unsupported.");
+        double xmax = this.getPlotDisplay().getAspect().getXMax();
+        double xmin = this.getPlotDisplay().getAspect().getXMin();
+        double ymax = this.getPlotDisplay().getAspect().getYMax();
+        double ymin = this.getPlotDisplay().getAspect().getYMin();
+        
+        double [] xlimits = zoomAxis(zoomFactor, xmin, xmax, 
+                getPlotPreferences().getXlog());
+        double [] ylimits = zoomAxis(zoomFactor, ymin, ymax, 
+                getPlotPreferences().getYlog());
+                
+        // create new aspect for zoomed view
+        PlaneAspect zoomedAspect = new PlaneAspect(xlimits, ylimits);
+        this.getPlotDisplay().setAspect(zoomedAspect);
+    }
+    
+        /**
+     * Calculate new zoomed axis range.
+     * @param zoomFactor - scale factor to zoom in/out by
+     * @param min - min axis value
+     * @param max - max axis value
+     * @param isLog - flag if the axis is in log-space (true) or not (false)
+     * @return a double array of the zoomed min and max range: [min, max]
+     */
+    private double[] zoomAxis(double zoomFactor, double min, double max, boolean isLog) {
+        
+        // zooming is dependent on the axis spacing.
+        if (isLog) {
+            return zoomLogAxis(zoomFactor, min, max);
+        } else {
+            return zoomLinearAxis(zoomFactor, min, max);
+        }
+    }
+    
+    /**
+     * Calculate new zoomed range for a logarithmically-spaced axis.
+     * @param zoomFactor
+     * @param min
+     * @param max
+     * @return a double array of the zoomed min and max range: [min, max]
+     */
+    private double[] zoomLogAxis(double zoomFactor, double min, double max) {
+        
+        // calculate central value
+        double centerFactor = (Math.log10(max) - Math.log10(min))/2;
+        double center = centerFactor + Math.log10(min);
+        center = Math.pow(10, center);
 
-        // TODO: this algorithm is BAD! Need to implement a better one.
-//        double xmax = this.getPlotDisplay().getAspect().getXMax();
-//        double xmin = this.getPlotDisplay().getAspect().getXMin();
-//        double ymax = this.getPlotDisplay().getAspect().getYMax();
-//        double ymin = this.getPlotDisplay().getAspect().getYMin();
-//        
-//        double[] ylimits = new double[] {ymin*zoomFactor, ymax-ymax*(zoomFactor-1)};
-//        double[] xlimits = new double[] {xmin*zoomFactor, xmax-xmax*(zoomFactor-1)};
-//        
-//        PlaneAspect zoomedAspect = new PlaneAspect(xlimits, ylimits);
-//        
-//        this.getPlotDisplay().setAspect(zoomedAspect);
+        // calculate zoomed range
+        double f1 = 1. / zoomFactor;
+        double zlo = center * Math.pow( min / center, f1 );
+        double zhi = center * Math.pow( max / center, f1 );
+        return zlo > Double.MIN_VALUE && zhi < Double.MAX_VALUE
+                ? new double[] { zlo, zhi }
+                : new double[] { min, max };
+    }
+    
+    /**
+     * Calculate new zoomed range for a linearly-spaced axis.
+     * @param zoomFactor
+     * @param min
+     * @param max
+     * @return a double array of the zoomed min and max range: [min, max]
+     */
+    private double[] zoomLinearAxis(double zoomFactor, double min, double max) {
+        
+        // calculate the central axis value
+        double center = (Math.abs(max) - Math.abs(min))/2;
+        if (min < 0 && max > 0) {
+            // pass. leave xcenter as it is
+        } else {
+            center = min + Math.abs(center);
+        }
+
+        // calculate zoomed axis range
+        double f1 = 1. / zoomFactor;
+        double zlo = center + ( min - center ) * f1;
+        double zhi = center + ( max - center ) * f1;
+        return zlo > -Double.MAX_VALUE && zhi < +Double.MAX_VALUE
+                ? new double[] { zlo, zhi }
+                : new double[] { min, max };
     }
     
     /**

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/StilPlotter.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/StilPlotter.java
@@ -47,6 +47,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import uk.ac.starlink.ttools.plot2.Axis;
 import uk.ac.starlink.ttools.plot2.geom.PlaneSurface;
 
 public class StilPlotter extends JPanel {
@@ -208,7 +209,7 @@ public class StilPlotter extends JPanel {
         this.getPlotDisplay().setAspect(zoomedAspect);
     }
     
-        /**
+    /**
      * Calculate new zoomed axis range.
      * @param zoomFactor - scale factor to zoom in/out by
      * @param min - min axis value
@@ -218,61 +219,29 @@ public class StilPlotter extends JPanel {
      */
     private double[] zoomAxis(double zoomFactor, double min, double max, boolean isLog) {
         
-        // zooming is dependent on the axis spacing.
         if (isLog) {
-            return zoomLogAxis(zoomFactor, min, max);
+            
+            // calculate central axis value
+            double centerFactor = (Math.log10(max) - Math.log10(min))/2;
+            double center = centerFactor + Math.log10(min);
+            center = Math.pow(10, center);
+            
+            // calculate zoomed min and max values
+            return Axis.zoom(min, max, center, zoomFactor, isLog);
+            
         } else {
-            return zoomLinearAxis(zoomFactor, min, max);
+            
+            // calculate the central axis value
+            double center = (Math.abs(max) - Math.abs(min))/2;
+            if (min < 0 && max > 0) {
+                // pass. leave xcenter as it is
+            } else {
+                center = min + Math.abs(center);
+            }
+            
+            // calculate zoomed min and max values
+            return Axis.zoom(min, max, center, zoomFactor, isLog);
         }
-    }
-    
-    /**
-     * Calculate new zoomed range for a logarithmically-spaced axis.
-     * @param zoomFactor
-     * @param min
-     * @param max
-     * @return a double array of the zoomed min and max range: [min, max]
-     */
-    private double[] zoomLogAxis(double zoomFactor, double min, double max) {
-        
-        // calculate central value
-        double centerFactor = (Math.log10(max) - Math.log10(min))/2;
-        double center = centerFactor + Math.log10(min);
-        center = Math.pow(10, center);
-
-        // calculate zoomed range
-        double f1 = 1. / zoomFactor;
-        double zlo = center * Math.pow( min / center, f1 );
-        double zhi = center * Math.pow( max / center, f1 );
-        return zlo > Double.MIN_VALUE && zhi < Double.MAX_VALUE
-                ? new double[] { zlo, zhi }
-                : new double[] { min, max };
-    }
-    
-    /**
-     * Calculate new zoomed range for a linearly-spaced axis.
-     * @param zoomFactor
-     * @param min
-     * @param max
-     * @return a double array of the zoomed min and max range: [min, max]
-     */
-    private double[] zoomLinearAxis(double zoomFactor, double min, double max) {
-        
-        // calculate the central axis value
-        double center = (Math.abs(max) - Math.abs(min))/2;
-        if (min < 0 && max > 0) {
-            // pass. leave xcenter as it is
-        } else {
-            center = min + Math.abs(center);
-        }
-
-        // calculate zoomed axis range
-        double f1 = 1. / zoomFactor;
-        double zlo = center + ( min - center ) * f1;
-        double zhi = center + ( max - center ) * f1;
-        return zlo > -Double.MAX_VALUE && zhi < +Double.MAX_VALUE
-                ? new double[] { zlo, zhi }
-                : new double[] { min, max };
     }
     
     /**

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/StilPlotterTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/StilPlotterTest.java
@@ -176,4 +176,53 @@ public class StilPlotterTest {
         assertEquals(1, aspect3.getXMin(), .0001);
         assertEquals(1, aspect3.getYMin(), .0001);
     }
+    
+    // TODO: uncomment when we figure out why assertEquals() isn't working
+    //@Test
+    public void testZoom() throws Exception {
+        
+        sed = ExtSed.read(TestData.class.getResource("3c273.vot").openStream(), SedFormat.VOT);
+        StilPlotter plot = new StilPlotter(ws, preferences);
+        preferences.update(sed);
+        
+        // Get initial bounds
+        plot.reset(sed, false);
+        PlotDisplay<Profile, PlaneAspect> display = plot.getPlotDisplay();
+        PlaneAspect aspect1 = display.getAspect();
+        
+        // zoom in
+        plot.zoom(1.5);
+        
+        PlaneAspect aspect = (PlaneAspect) plot.getPlotDisplay().getAspect();
+        double xmax = aspect.getXMax();
+        double xmin = aspect.getXMin();
+        double ymax = aspect.getYMax();
+        double ymin = aspect.getYMin();
+        
+        // expected ranges (log space)
+        double expectedXmax = 1.7779708E21;
+        double expectedXmin = 5.7953144E9;
+        double expectedYmax = 7.3199692;
+        double expectedYmin = 3.1956419E-9;
+        
+        assertEquals(expectedXmax, xmax, 0.01);
+        assertEquals(expectedXmin, xmin, 0.01);
+        assertEquals(expectedYmax, ymax, 0.01);
+        assertEquals(expectedYmin, ymin, 0.01);
+        
+        // zoom out. Plot should be back at the ranges it was at before.
+        plot.zoom(0.5);
+        
+        aspect = (PlaneAspect) plot.getPlotDisplay().getAspect();
+        xmax = aspect.getXMax();
+        xmin = aspect.getXMin();
+        ymax = aspect.getYMax();
+        ymin = aspect.getYMin();
+        
+        assertEquals(xmax, aspect1.getXMax(), 0.000001);
+        assertEquals(xmin, aspect1.getXMin(), 0.000001);
+        assertEquals(ymax, aspect1.getYMax(), 0.000001);
+        assertEquals(ymin, aspect1.getYMin(), 0.000001);
+        
+    }
 }

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/StilPlotterTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/StilPlotterTest.java
@@ -22,6 +22,7 @@ import cfa.vo.iris.sed.ExtSed;
 import cfa.vo.iris.sed.stil.StarTableAdapter;
 import cfa.vo.iris.test.App;
 import cfa.vo.iris.test.Ws;
+import cfa.vo.iris.visualizer.plotter.PlotterView;
 import cfa.vo.iris.visualizer.preferences.VisualizerComponentPreferences;
 import cfa.vo.sedlib.ISegment;
 import cfa.vo.sedlib.Segment;
@@ -37,6 +38,7 @@ import uk.ac.starlink.ttools.plot2.geom.PlaneSurfaceFactory.Profile;
 import uk.ac.starlink.ttools.plot2.task.PlotDisplay;
 import uk.ac.starlink.ttools.task.MapEnvironment;
 import cfa.vo.testdata.TestData;
+import java.text.DecimalFormat;
 import uk.ac.starlink.task.BooleanParameter;
 
 public class StilPlotterTest {
@@ -177,8 +179,7 @@ public class StilPlotterTest {
         assertEquals(1, aspect3.getYMin(), .0001);
     }
     
-    // TODO: uncomment when we figure out why assertEquals() isn't working
-    //@Test
+    @Test
     public void testZoom() throws Exception {
         
         sed = ExtSed.read(TestData.class.getResource("3c273.vot").openStream(), SedFormat.VOT);
@@ -205,13 +206,18 @@ public class StilPlotterTest {
         double expectedYmax = 7.3199692;
         double expectedYmin = 3.1956419E-9;
         
-        assertEquals(expectedXmax, xmax, 0.01);
-        assertEquals(expectedXmin, xmin, 0.01);
-        assertEquals(expectedYmax, ymax, 0.01);
-        assertEquals(expectedYmin, ymin, 0.01);
+        DecimalFormat df = new DecimalFormat("#.#####");
+        String df_format = df.format(xmax);
+        double ndf = Double.valueOf(df_format);
+        
+        assertEquals(Math.log10(expectedXmax), Math.log10(xmax), 0.000001);
+        assertEquals(Math.log10(expectedXmin), Math.log10(xmin), 0.000001);
+        assertEquals(Math.log10(expectedYmax), Math.log10(ymax), 0.000001);
+        assertEquals(Math.log10(expectedYmin), Math.log10(ymin), 0.000001);
         
         // zoom out. Plot should be back at the ranges it was at before.
-        plot.zoom(0.5);
+        // scale factor: 1 - PlotterView.ZOOM_SCALE * 2/3
+        plot.zoom(1 - PlotterView.ZOOM_SCALE * 2/3);
         
         aspect = (PlaneAspect) plot.getPlotDisplay().getAspect();
         xmax = aspect.getXMax();
@@ -219,10 +225,10 @@ public class StilPlotterTest {
         ymax = aspect.getYMax();
         ymin = aspect.getYMin();
         
-        assertEquals(xmax, aspect1.getXMax(), 0.000001);
-        assertEquals(xmin, aspect1.getXMin(), 0.000001);
-        assertEquals(ymax, aspect1.getYMax(), 0.000001);
-        assertEquals(ymin, aspect1.getYMin(), 0.000001);
+        assertEquals(Math.log10(xmax), Math.log10(aspect1.getXMax()), 0.000001);
+        assertEquals(Math.log10(xmin), Math.log10(aspect1.getXMin()), 0.000001);
+        assertEquals(Math.log10(ymax), Math.log10(aspect1.getYMax()), 0.000001);
+        assertEquals(Math.log10(ymin), Math.log10(aspect1.getYMin()), 0.000001);
         
     }
 }


### PR DESCRIPTION
This PR addresses the zoom in/out buttons previously disabled in PR #270. The zooming algorithm uses STILTS's [Axis::zoom() method](https://github.com/Starlink/starjava/blob/master/ttools/src/main/uk/ac/starlink/ttools/plot2/Axis.java#L486) to calculate the min and max range values. The tricky part of the algorithm is determining the central value of an axis, which depends on the axis spacing (log or linear).

Tests are in StillPlotterTest which test that zooming in once and zooming back out brings you back to the same view.