### PR TITLE
Add usage instructions to the Plotter.

### DIFF
--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.form
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.form
@@ -51,7 +51,7 @@
             </MenuItem>
           </SubComponents>
         </Menu>
-        <Menu class="javax.swing.JMenu" name="jMenu1">
+        <Menu class="javax.swing.JMenu" name="mnView">
           <Properties>
             <Property name="text" type="java.lang.String" value="View"/>
           </Properties>
@@ -131,6 +131,21 @@
             </MenuItem>
           </SubComponents>
         </Menu>
+        <Menu class="javax.swing.JMenu" name="mnHelp">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="Help"/>
+          </Properties>
+          <SubComponents>
+            <MenuItem class="javax.swing.JCheckBoxMenuItem" name="mntmShowNavHelp">
+              <Properties>
+                <Property name="text" type="java.lang.String" value="Show plotter navigation help"/>
+              </Properties>
+              <Events>
+                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="mntmShowNavHelpActionPerformed"/>
+              </Events>
+            </MenuItem>
+          </SubComponents>
+        </Menu>
       </SubComponents>
     </Menu>
   </NonVisualComponents>
@@ -155,12 +170,11 @@
       <Group type="103" groupAlignment="0" attributes="0">
           <Component id="jPanel1" max="32767" attributes="0"/>
           <Group type="102" attributes="0">
-              <Component id="jPanel2" min="-2" max="-2" attributes="0"/>
-              <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
-          </Group>
-          <Group type="102" alignment="0" attributes="0">
               <EmptySpace max="-2" attributes="0"/>
-              <Component id="plotter" max="32767" attributes="0"/>
+              <Group type="103" groupAlignment="0" attributes="0">
+                  <Component id="plotter" max="32767" attributes="0"/>
+                  <Component id="jPanel2" alignment="1" max="32767" attributes="0"/>
+              </Group>
               <EmptySpace max="-2" attributes="0"/>
           </Group>
       </Group>
@@ -169,10 +183,11 @@
       <Group type="103" groupAlignment="0" attributes="0">
           <Group type="102" alignment="0" attributes="0">
               <Component id="jPanel1" min="-2" max="-2" attributes="0"/>
-              <EmptySpace max="-2" attributes="0"/>
-              <Component id="plotter" pref="484" max="32767" attributes="0"/>
+              <EmptySpace min="-2" max="-2" attributes="0"/>
+              <Component id="plotter" pref="421" max="32767" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
               <Component id="jPanel2" min="-2" max="-2" attributes="0"/>
+              <EmptySpace min="-2" pref="5" max="-2" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -202,7 +217,7 @@
                   <Component id="txtXposition" min="-2" pref="100" max="-2" attributes="0"/>
                   <EmptySpace max="-2" attributes="0"/>
                   <Component id="txtYposition" min="-2" pref="100" max="-2" attributes="0"/>
-                  <EmptySpace pref="30" max="32767" attributes="0"/>
+                  <EmptySpace max="32767" attributes="0"/>
                   <Component id="metadataButton" min="-2" max="-2" attributes="0"/>
                   <EmptySpace type="separate" max="-2" attributes="0"/>
                   <Component id="fluxOrDensity" min="-2" max="-2" attributes="0"/>
@@ -342,50 +357,119 @@
     </Container>
     <Container class="javax.swing.JPanel" name="jPanel2">
 
-      <Layout>
-        <DimensionLayout dim="0">
-          <Group type="103" groupAlignment="0" attributes="0">
-              <Group type="102" attributes="0">
-                  <EmptySpace max="-2" attributes="0"/>
-                  <Component id="tglbtnShowHideResiduals" min="-2" max="-2" attributes="0"/>
-                  <EmptySpace max="-2" attributes="0"/>
-                  <Component id="secondaryPlotOptions" min="-2" max="-2" attributes="0"/>
-                  <EmptySpace max="-2" attributes="0"/>
-              </Group>
-          </Group>
-        </DimensionLayout>
-        <DimensionLayout dim="1">
-          <Group type="103" groupAlignment="0" attributes="0">
-              <Group type="102" attributes="0">
-                  <EmptySpace max="-2" attributes="0"/>
-                  <Group type="103" groupAlignment="3" attributes="0">
-                      <Component id="tglbtnShowHideResiduals" alignment="3" min="-2" max="-2" attributes="0"/>
-                      <Component id="secondaryPlotOptions" alignment="3" min="-2" max="-2" attributes="0"/>
-                  </Group>
-                  <EmptySpace max="-2" attributes="0"/>
-              </Group>
-          </Group>
-        </DimensionLayout>
+      <Layout class="org.netbeans.modules.form.compat2.layouts.DesignGridLayout">
+        <Property name="columns" type="int" value="0"/>
+        <Property name="rows" type="int" value="1"/>
       </Layout>
       <SubComponents>
-        <Component class="javax.swing.JSpinner" name="secondaryPlotOptions">
+        <Container class="javax.swing.JPanel" name="jPanel3">
+
+          <Layout>
+            <DimensionLayout dim="0">
+              <Group type="103" groupAlignment="0" attributes="0">
+                  <Group type="102" attributes="0">
+                      <EmptySpace max="-2" attributes="0"/>
+                      <Component id="tglbtnShowHideResiduals" min="-2" max="-2" attributes="0"/>
+                      <EmptySpace max="-2" attributes="0"/>
+                      <Component id="secondaryPlotOptions" min="-2" max="-2" attributes="0"/>
+                      <EmptySpace max="-2" attributes="0"/>
+                  </Group>
+              </Group>
+            </DimensionLayout>
+            <DimensionLayout dim="1">
+              <Group type="103" groupAlignment="0" attributes="0">
+                  <Group type="102" attributes="0">
+                      <EmptySpace max="-2" attributes="0"/>
+                      <Group type="103" alignment="0" groupAlignment="3" attributes="0">
+                          <Component id="tglbtnShowHideResiduals" alignment="3" min="-2" max="-2" attributes="0"/>
+                          <Component id="secondaryPlotOptions" alignment="3" min="-2" max="-2" attributes="0"/>
+                      </Group>
+                      <EmptySpace max="-2" attributes="0"/>
+                  </Group>
+              </Group>
+            </DimensionLayout>
+          </Layout>
+          <SubComponents>
+            <Component class="javax.swing.JToggleButton" name="tglbtnShowHideResiduals">
+              <Properties>
+                <Property name="text" type="java.lang.String" value="Show Residuals"/>
+              </Properties>
+            </Component>
+            <Component class="javax.swing.JSpinner" name="secondaryPlotOptions">
+              <Properties>
+                <Property name="model" type="javax.swing.SpinnerModel" editor="org.netbeans.modules.form.editors2.SpinnerModelEditor">
+                  <SpinnerModel type="list">
+                    <ListItem value="Residuals"/>
+                    <ListItem value="Ratios"/>
+                  </SpinnerModel>
+                </Property>
+              </Properties>
+              <AuxValues>
+                <AuxValue name="JavaCodeGenerator_InitCodePre" type="java.lang.String" value="//JFormattedTextField txtBoxShowHideResiduals = ((JSpinner.ListEditor) secondaryPlotOptions.getEditor()).getTextField();&#xa;//txtBoxShowHideResiduals.setEditable(false);"/>
+              </AuxValues>
+            </Component>
+          </SubComponents>
+        </Container>
+        <Container class="javax.swing.JPanel" name="plotterNavigationPanel">
           <Properties>
-            <Property name="model" type="javax.swing.SpinnerModel" editor="org.netbeans.modules.form.editors2.SpinnerModelEditor">
-              <SpinnerModel type="list">
-                <ListItem value="Residuals"/>
-                <ListItem value="Ratios"/>
-              </SpinnerModel>
+            <Property name="border" type="javax.swing.border.Border" editor="org.netbeans.modules.form.editors2.BorderEditor">
+              <Border info="org.netbeans.modules.form.compat2.border.TitledBorderInfo">
+                <TitledBorder title="Plotter Navigation"/>
+              </Border>
             </Property>
           </Properties>
           <AuxValues>
-            <AuxValue name="JavaCodeGenerator_InitCodePre" type="java.lang.String" value="//JFormattedTextField txtBoxShowHideResiduals = ((JSpinner.ListEditor) secondaryPlotOptions.getEditor()).getTextField();&#xa;//txtBoxShowHideResiduals.setEditable(false);"/>
+            <AuxValue name="JavaCodeGenerator_InitCodePre" type="java.lang.String" value="plotterNavigationPanel.setVisible(false);&#xa;this.validate();&#xa;this.repaint();"/>
           </AuxValues>
-        </Component>
-        <Component class="javax.swing.JToggleButton" name="tglbtnShowHideResiduals">
-          <Properties>
-            <Property name="text" type="java.lang.String" value="Show Residuals"/>
-          </Properties>
-        </Component>
+
+          <Layout>
+            <DimensionLayout dim="0">
+              <Group type="103" groupAlignment="0" attributes="0">
+                  <Group type="102" alignment="0" attributes="0">
+                      <Component id="jLabel1" max="32767" attributes="0"/>
+                      <EmptySpace min="-2" pref="44" max="-2" attributes="0"/>
+                      <Component id="jLabel2" max="32767" attributes="0"/>
+                  </Group>
+              </Group>
+            </DimensionLayout>
+            <DimensionLayout dim="1">
+              <Group type="103" groupAlignment="0" attributes="0">
+                  <Group type="103" alignment="0" groupAlignment="3" attributes="0">
+                      <Component id="jLabel1" alignment="3" min="-2" pref="45" max="-2" attributes="0"/>
+                      <Component id="jLabel2" alignment="3" min="-2" pref="45" max="-2" attributes="0"/>
+                  </Group>
+              </Group>
+            </DimensionLayout>
+          </Layout>
+          <SubComponents>
+            <Component class="javax.swing.JLabel" name="jLabel1">
+              <Properties>
+                <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
+                  <Font name="DejaVu Sans" size="10" style="0"/>
+                </Property>
+                <Property name="text" type="java.lang.String" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+                  <Connection code="navigationHelp1" type="code"/>
+                </Property>
+              </Properties>
+              <AuxValues>
+                <AuxValue name="JavaCodeGenerator_InitCodePre" type="java.lang.String" value="String navigationHelp1 = &quot;&lt;html&gt;&quot;+&#xa;&quot;Scroll: zoom in and out&lt;br/&gt;&quot;+&#xa;&quot;Click and drag: pan the viewport&lt;/html&gt;&quot;;"/>
+              </AuxValues>
+            </Component>
+            <Component class="javax.swing.JLabel" name="jLabel2">
+              <Properties>
+                <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
+                  <Font name="DejaVu Sans" size="10" style="0"/>
+                </Property>
+                <Property name="text" type="java.lang.String" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+                  <Connection code="navigationHelp2" type="code"/>
+                </Property>
+              </Properties>
+              <AuxValues>
+                <AuxValue name="JavaCodeGenerator_InitCodePre" type="java.lang.String" value="String navigationHelp2 = &quot;&lt;html&gt;&quot;+&#xa;&quot;Shift + click + drag: zoom box&lt;br/&gt;&quot;+&#xa;&quot;Scroll on X or Y axis: expand/shrink along axis&lt;br/&gt;&quot;+&#xa;&quot;&lt;/html&gt;&quot;;"/>
+              </AuxValues>
+            </Component>
+          </SubComponents>
+        </Container>
       </SubComponents>
     </Container>
     <Container class="cfa.vo.iris.visualizer.stil.StilPlotter" name="plotter">

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
@@ -95,9 +95,8 @@ public class PlotterView extends JInternalFrame {
         plotter.reset(null, true);
         
         // units chooser frame
-        //this.unitsManagerFrame = new UnitsManagerFrame(plotter.getSed(), this.preferences);
         this.unitsManagerFrame = new UnitsManagerFrame(plotter);
-        
+                
         // Action for opening metadata browser
         metadataButton.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
@@ -263,8 +262,12 @@ public class PlotterView extends JInternalFrame {
         up = new cfa.vo.iris.gui.JButtonArrow(BasicArrowButton.NORTH);
         left1 = new cfa.vo.iris.gui.JButtonArrow(BasicArrowButton.EAST);
         jPanel2 = new javax.swing.JPanel();
-        secondaryPlotOptions = new javax.swing.JSpinner();
+        jPanel3 = new javax.swing.JPanel();
         tglbtnShowHideResiduals = new javax.swing.JToggleButton();
+        secondaryPlotOptions = new javax.swing.JSpinner();
+        plotterNavigationPanel = new javax.swing.JPanel();
+        jLabel1 = new javax.swing.JLabel();
+        jLabel2 = new javax.swing.JLabel();
         plotter = new cfa.vo.iris.visualizer.stil.StilPlotter();
         menuBar = new javax.swing.JMenuBar();
         mnF = new javax.swing.JMenu();
@@ -274,7 +277,7 @@ public class PlotterView extends JInternalFrame {
         mntmSave = new javax.swing.JMenuItem();
         mnEdit = new javax.swing.JMenu();
         mntmSomething = new javax.swing.JMenuItem();
-        jMenu1 = new javax.swing.JMenu();
+        mnView = new javax.swing.JMenu();
         mnPlotType = new javax.swing.JMenu();
         mntmLog = new javax.swing.JRadioButtonMenuItem();
         mntmLinear = new javax.swing.JRadioButtonMenuItem();
@@ -284,6 +287,8 @@ public class PlotterView extends JInternalFrame {
         mntmAutoFixed = new javax.swing.JCheckBoxMenuItem();
         mntmGridOnOff = new javax.swing.JCheckBoxMenuItem();
         mntmCoplot = new javax.swing.JMenuItem();
+        mnHelp = new javax.swing.JMenu();
+        mntmShowNavHelp = new javax.swing.JCheckBoxMenuItem();
 
         btnReset.setText("Reset");
         btnReset.addActionListener(new java.awt.event.ActionListener() {
@@ -361,7 +366,7 @@ public class PlotterView extends JInternalFrame {
                 .addComponent(txtXposition, javax.swing.GroupLayout.PREFERRED_SIZE, 100, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(txtYposition, javax.swing.GroupLayout.PREFERRED_SIZE, 100, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, 30, Short.MAX_VALUE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                 .addComponent(metadataButton)
                 .addGap(18, 18, 18)
                 .addComponent(fluxOrDensity, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
@@ -389,32 +394,72 @@ public class PlotterView extends JInternalFrame {
                 .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
 
+        jPanel2.setLayout(new java.awt.GridLayout());
+
+        tglbtnShowHideResiduals.setText("Show Residuals");
+
         //JFormattedTextField txtBoxShowHideResiduals = ((JSpinner.ListEditor) secondaryPlotOptions.getEditor()).getTextField();
         //txtBoxShowHideResiduals.setEditable(false);
         secondaryPlotOptions.setModel(new javax.swing.SpinnerListModel(new String[] {"Residuals", "Ratios"}));
 
-        tglbtnShowHideResiduals.setText("Show Residuals");
-
-        javax.swing.GroupLayout jPanel2Layout = new javax.swing.GroupLayout(jPanel2);
-        jPanel2.setLayout(jPanel2Layout);
-        jPanel2Layout.setHorizontalGroup(
-            jPanel2Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(jPanel2Layout.createSequentialGroup()
+        javax.swing.GroupLayout jPanel3Layout = new javax.swing.GroupLayout(jPanel3);
+        jPanel3.setLayout(jPanel3Layout);
+        jPanel3Layout.setHorizontalGroup(
+            jPanel3Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGroup(jPanel3Layout.createSequentialGroup()
                 .addContainerGap()
                 .addComponent(tglbtnShowHideResiduals)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(secondaryPlotOptions, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addContainerGap())
         );
-        jPanel2Layout.setVerticalGroup(
-            jPanel2Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(jPanel2Layout.createSequentialGroup()
+        jPanel3Layout.setVerticalGroup(
+            jPanel3Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGroup(jPanel3Layout.createSequentialGroup()
                 .addContainerGap()
-                .addGroup(jPanel2Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                .addGroup(jPanel3Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(tglbtnShowHideResiduals)
                     .addComponent(secondaryPlotOptions, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
                 .addContainerGap())
         );
+
+        jPanel2.add(jPanel3);
+
+        plotterNavigationPanel.setVisible(false);
+        this.validate();
+        this.repaint();
+        plotterNavigationPanel.setBorder(javax.swing.BorderFactory.createTitledBorder("Plotter Navigation"));
+
+        String navigationHelp1 = "<html>"+
+        "Scroll: zoom in and out<br/>"+
+        "Click and drag: pan the viewport</html>";
+        jLabel1.setFont(new java.awt.Font("DejaVu Sans", 0, 10)); // NOI18N
+        jLabel1.setText(navigationHelp1);
+
+        String navigationHelp2 = "<html>"+
+        "Shift + click + drag: zoom box<br/>"+
+        "Scroll on X or Y axis: expand/shrink along axis<br/>"+
+        "</html>";
+        jLabel2.setFont(new java.awt.Font("DejaVu Sans", 0, 10)); // NOI18N
+        jLabel2.setText(navigationHelp2);
+
+        javax.swing.GroupLayout plotterNavigationPanelLayout = new javax.swing.GroupLayout(plotterNavigationPanel);
+        plotterNavigationPanel.setLayout(plotterNavigationPanelLayout);
+        plotterNavigationPanelLayout.setHorizontalGroup(
+            plotterNavigationPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGroup(plotterNavigationPanelLayout.createSequentialGroup()
+                .addComponent(jLabel1, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                .addGap(44, 44, 44)
+                .addComponent(jLabel2, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+        );
+        plotterNavigationPanelLayout.setVerticalGroup(
+            plotterNavigationPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGroup(plotterNavigationPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                .addComponent(jLabel1, javax.swing.GroupLayout.PREFERRED_SIZE, 45, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addComponent(jLabel2, javax.swing.GroupLayout.PREFERRED_SIZE, 45, javax.swing.GroupLayout.PREFERRED_SIZE))
+        );
+
+        jPanel2.add(plotterNavigationPanel);
 
         plotter.setName("plotter"); // NOI18N
 
@@ -448,7 +493,7 @@ public class PlotterView extends JInternalFrame {
 
         menuBar.add(mnEdit);
 
-        jMenu1.setText("View");
+        mnView.setText("View");
 
         mnPlotType.setText("Plot Type");
 
@@ -473,12 +518,12 @@ public class PlotterView extends JInternalFrame {
         mntmYlog.setName("mntmYlog"); // NOI18N
         mnPlotType.add(mntmYlog);
 
-        jMenu1.add(mnPlotType);
+        mnView.add(mnPlotType);
 
         mntmErrorBars.setSelected(true);
         mntmErrorBars.setText("Error Bars");
         mntmErrorBars.setEnabled(false);
-        jMenu1.add(mntmErrorBars);
+        mnView.add(mntmErrorBars);
 
         mntmAutoFixed.setText("Fixed");
         mntmAutoFixed.setToolTipText("<html>Fix the plot ranges when the SED changes. Otherwise, <br/> \nthe plot ranges automatically update when a SED changes.</html>");
@@ -486,19 +531,31 @@ public class PlotterView extends JInternalFrame {
         binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, plotter, org.jdesktop.beansbinding.ELProperty.create("${visualizerPreferences.plotPreferences.fixed}"), mntmAutoFixed, org.jdesktop.beansbinding.BeanProperty.create("selected"));
         bindingGroup.addBinding(binding);
 
-        jMenu1.add(mntmAutoFixed);
+        mnView.add(mntmAutoFixed);
 
         mntmGridOnOff.setText("Grid on/off");
 
         binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, plotter, org.jdesktop.beansbinding.ELProperty.create("${visualizerPreferences.plotPreferences.showGrid}"), mntmGridOnOff, org.jdesktop.beansbinding.BeanProperty.create("selected"));
         bindingGroup.addBinding(binding);
 
-        jMenu1.add(mntmGridOnOff);
+        mnView.add(mntmGridOnOff);
 
         mntmCoplot.setText("Coplot...");
-        jMenu1.add(mntmCoplot);
+        mnView.add(mntmCoplot);
 
-        menuBar.add(jMenu1);
+        menuBar.add(mnView);
+
+        mnHelp.setText("Help");
+
+        mntmShowNavHelp.setText("Show plotter navigation help");
+        mntmShowNavHelp.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                mntmShowNavHelpActionPerformed(evt);
+            }
+        });
+        mnHelp.add(mntmShowNavHelp);
+
+        menuBar.add(mnHelp);
 
         setJMenuBar(menuBar);
 
@@ -508,11 +565,10 @@ public class PlotterView extends JInternalFrame {
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addComponent(jPanel1, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
             .addGroup(layout.createSequentialGroup()
-                .addComponent(jPanel2, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addGap(0, 0, Short.MAX_VALUE))
-            .addGroup(layout.createSequentialGroup()
                 .addContainerGap()
-                .addComponent(plotter, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addComponent(plotter, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                    .addComponent(jPanel2, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
                 .addContainerGap())
         );
         layout.setVerticalGroup(
@@ -520,9 +576,10 @@ public class PlotterView extends JInternalFrame {
             .addGroup(layout.createSequentialGroup()
                 .addComponent(jPanel1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(plotter, javax.swing.GroupLayout.DEFAULT_SIZE, 484, Short.MAX_VALUE)
+                .addComponent(plotter, javax.swing.GroupLayout.DEFAULT_SIZE, 421, Short.MAX_VALUE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(jPanel2, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                .addComponent(jPanel2, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addGap(5, 5, 5))
         );
 
         plotter.getAccessibleContext().setAccessibleName("plotter");
@@ -571,21 +628,37 @@ public class PlotterView extends JInternalFrame {
         GUIUtils.moveToFront(unitsManagerFrame);
     }//GEN-LAST:event_btnUnitsActionPerformed
 
+    private void mntmShowNavHelpActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_mntmShowNavHelpActionPerformed
+        if (mntmShowNavHelp.isSelected()) {
+            plotterNavigationPanel.setVisible(true);
+            this.validate();
+            this.repaint();
+        } else {
+            plotterNavigationPanel.setVisible(false);
+            this.validate();
+            this.repaint();
+        }
+    }//GEN-LAST:event_mntmShowNavHelpActionPerformed
+
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JButton btnReset;
     private javax.swing.JButton btnUnits;
     private cfa.vo.iris.gui.JButtonArrow down;
     private javax.swing.JSpinner fluxOrDensity;
-    private javax.swing.JMenu jMenu1;
+    private javax.swing.JLabel jLabel1;
+    private javax.swing.JLabel jLabel2;
     private javax.swing.JPanel jPanel1;
     private javax.swing.JPanel jPanel2;
+    private javax.swing.JPanel jPanel3;
     private cfa.vo.iris.gui.JButtonArrow left;
     private cfa.vo.iris.gui.JButtonArrow left1;
     private javax.swing.JMenuBar menuBar;
     private javax.swing.JButton metadataButton;
     private javax.swing.JMenu mnEdit;
     private javax.swing.JMenu mnF;
+    private javax.swing.JMenu mnHelp;
     private javax.swing.JMenu mnPlotType;
+    private javax.swing.JMenu mnView;
     private javax.swing.JCheckBoxMenuItem mntmAutoFixed;
     private javax.swing.JMenuItem mntmCoplot;
     private javax.swing.JCheckBoxMenuItem mntmErrorBars;
@@ -596,11 +669,13 @@ public class PlotterView extends JInternalFrame {
     private javax.swing.JMenuItem mntmOpen;
     private javax.swing.JMenuItem mntmProperties;
     private javax.swing.JMenuItem mntmSave;
+    private javax.swing.JCheckBoxMenuItem mntmShowNavHelp;
     private javax.swing.JMenuItem mntmSomething;
     private javax.swing.JRadioButtonMenuItem mntmXlog;
     private javax.swing.JRadioButtonMenuItem mntmYlog;
     private javax.swing.ButtonGroup plotTypeButtonGroup;
     private cfa.vo.iris.visualizer.stil.StilPlotter plotter;
+    private javax.swing.JPanel plotterNavigationPanel;
     private javax.swing.JSpinner secondaryPlotOptions;
     private javax.swing.JToggleButton tglbtnShowHideResiduals;
     private javax.swing.JTextField txtXposition;


### PR DESCRIPTION
Addresses ChandraCXC/iris-dev#9.

This PR adds a panel containing basic usage instructions for navigating about the Plotter. The instruction panel can be turned on/off through the Help menu of the Plotter.

To get the behavior I wanted when showing/hiding the usage instructions, I enclosed the Residuals buttons and usage instructions panels in a Swing `GridLayout`.

What I'd really like to do is add tooltips to the STILTS PlotDisplay when a
user hovers over the X and Y axes, but hover listeners in STILTS are private
methods as @eholum had mentioned in PR #273.