### PR TITLE
Save fit summary in human format

### DIFF
--- a/iris-common/src/main/java/cfa/vo/iris/fitting/ConfResultsConverter.java
+++ b/iris-common/src/main/java/cfa/vo/iris/fitting/ConfResultsConverter.java
@@ -1,0 +1,54 @@
+package cfa.vo.iris.fitting;
+
+import cfa.vo.sherpa.ConfidenceResults;
+import org.apache.commons.lang.NotImplementedException;
+import org.jdesktop.beansbinding.Converter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ConfResultsConverter extends Converter<ConfidenceResults, List<ConfResultsConverter.ParameterLimits>> {
+
+    @Override
+    public List<ParameterLimits> convertForward(ConfidenceResults res) {
+        List<ParameterLimits> retVal = new ArrayList<>();
+        List<String> names = res.getParnames();
+        double[] mins = res.getParmins();
+        double[] maxes = res.getParmaxes();
+        int l = maxes.length;
+        for (int i=0; i<l; i++) {
+            retVal.add(new ParameterLimits(names.get(i), mins[i], maxes[i]));
+        }
+
+        return retVal;
+    }
+
+    @Override
+    public ConfidenceResults convertReverse(List<ParameterLimits> o) {
+        throw new NotImplementedException(); // read-only binding
+    }
+
+    public class ParameterLimits {
+        private String name;
+        private Double lowerLimit;
+        private Double upperLimit;
+
+        public ParameterLimits(String name, Double lower, Double upper) {
+            this.name = name;
+            this.lowerLimit = lower;
+            this.upperLimit = upper;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public Double getLowerLimit() {
+            return lowerLimit;
+        }
+
+        public Double getUpperLimit() {
+            return upperLimit;
+        }
+    }
+}

--- a/iris-common/src/main/java/cfa/vo/iris/fitting/FitConfiguration.java
+++ b/iris-common/src/main/java/cfa/vo/iris/fitting/FitConfiguration.java
@@ -36,6 +36,7 @@ public class FitConfiguration {
     private Stat stat;
     private Method method;
     private Confidence confidence;
+    private ConfidenceResults confResults;
     private Double rStat;
     private Integer nFev;
     private Double qVal;
@@ -87,6 +88,16 @@ public class FitConfiguration {
         Method oldMethod = this.method;
         this.method = method;
         propertyChangeSupport.firePropertyChange(PROP_METHOD, oldMethod, method);
+    }
+
+    public ConfidenceResults getConfidenceResults() {
+        return confResults;
+    }
+
+    public void setConfidenceResults(ConfidenceResults confResults) {
+        ConfidenceResults old = this.confResults;
+        this.confResults = confResults;
+        propertyChangeSupport.firePropertyChange(PROP_CONFIDENCE, old, confResults);
     }
 
     public Confidence getConfidence() {
@@ -252,6 +263,7 @@ public class FitConfiguration {
 
         builder.append(DefaultModel.toString(model));
         resultsToString(builder);
+        confToString(builder);
 
         return builder.toString();
     }
@@ -292,7 +304,18 @@ public class FitConfiguration {
         }
     }
 
-    private String resultsToString(StringBuilder builder) {
+    private void confToString(StringBuilder builder) {
+        if (confResults != null) {
+            List<ConfResultsConverter.ParameterLimits> parameterLimitsList =
+                    new ConfResultsConverter().convertForward(confResults);
+            builder.append(String.format("\nConfidence Limits at %4.2f sigma (%4.2f%%):\n", confResults.getSigma(), confResults.getPercent()));
+            for(ConfResultsConverter.ParameterLimits limits : parameterLimitsList) {
+                builder.append(String.format("%24s: (%12.5E, %12.5E)\n", limits.getName(), limits.getLowerLimit(), limits.getUpperLimit()));
+            }
+        }
+    }
+
+    private void resultsToString(StringBuilder builder) {
         builder.append("\nFit Results:\n")
                 .append(formatDouble("Final Fit Statistic", getStatVal()))
                 .append(formatDouble("Reduced Statistic", getrStat()))
@@ -304,7 +327,6 @@ public class FitConfiguration {
                 .append(formatString("Optimizer", getMethod().toString()))
                 .append(formatString("Statistic (Cost function)", getStat().toString()))
         ;
-        return builder.toString();
     }
 
     private String formatDouble(String name, Double value) {

--- a/iris-common/src/main/java/cfa/vo/iris/fitting/FitConfiguration.java
+++ b/iris-common/src/main/java/cfa/vo/iris/fitting/FitConfiguration.java
@@ -308,7 +308,7 @@ public class FitConfiguration {
     }
 
     private String formatDouble(String name, Double value) {
-        return String.format("\t\t%26s = %f\n", name, value);
+        return String.format("\t\t%26s = %12.5E\n", name, value);
     }
 
     private String formatInt(String name, Integer value) {

--- a/iris-common/src/main/java/cfa/vo/iris/fitting/FitConfiguration.java
+++ b/iris-common/src/main/java/cfa/vo/iris/fitting/FitConfiguration.java
@@ -264,6 +264,7 @@ public class FitConfiguration {
         builder.append(DefaultModel.toString(model));
         resultsToString(builder);
         confToString(builder);
+        userModelsToString(builder);
 
         return builder.toString();
     }
@@ -327,6 +328,14 @@ public class FitConfiguration {
                 .append(formatString("Optimizer", getMethod().toString()))
                 .append(formatString("Statistic (Cost function)", getStat().toString()))
         ;
+    }
+
+    private void userModelsToString(StringBuilder builder) {
+        builder.append("\nUser Models:\n");
+
+        for (UserModel m : userModelList) {
+            builder.append(String.format("\t\t%s: (file: %s, function: %s)\n", m.getName(), m.getFile(), m.getFunction()));
+        }
     }
 
     private String formatDouble(String name, Double value) {

--- a/iris-common/src/main/java/cfa/vo/iris/fitting/FitConfiguration.java
+++ b/iris-common/src/main/java/cfa/vo/iris/fitting/FitConfiguration.java
@@ -246,6 +246,16 @@ public class FitConfiguration {
         setDof(results.getDof().intValue());
     }
 
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+
+        builder.append(DefaultModel.toString(model));
+        resultsToString(builder);
+
+        return builder.toString();
+    }
+
     public void addPropertyChangeListener(java.beans.PropertyChangeListener listener )
     {
         propertyChangeSupport.addPropertyChangeListener( listener );
@@ -280,5 +290,32 @@ public class FitConfiguration {
             logger.info("adding model component " + id + " to expression");
             setExpression(model.getName() + " + " + id);
         }
+    }
+
+    private String resultsToString(StringBuilder builder) {
+        builder.append("\nFit Results:\n")
+                .append(formatDouble("Final Fit Statistic", getStatVal()))
+                .append(formatDouble("Reduced Statistic", getrStat()))
+                .append(formatDouble("Probability (Q-value)", getqVal()))
+                .append(formatInt("Degrees of Freedom", getDof()))
+                .append(formatInt("Data Points", getNumPoints()))
+                .append(formatInt("Function Evaluations", getnFev()))
+                .append("\n")
+                .append(formatString("Optimizer", getMethod().toString()))
+                .append(formatString("Statistic (Cost function)", getStat().toString()))
+        ;
+        return builder.toString();
+    }
+
+    private String formatDouble(String name, Double value) {
+        return String.format("\t\t%26s = %f\n", name, value);
+    }
+
+    private String formatInt(String name, Integer value) {
+        return String.format("\t\t%26s = %d\n", name, value);
+    }
+
+    private String formatString(String name, String value) {
+        return String.format("\t\t%26s = %s\n", name, value);
     }
 }

--- a/iris-common/src/test/java/cfa/vo/iris/test/unit/TestUtils.java
+++ b/iris-common/src/test/java/cfa/vo/iris/test/unit/TestUtils.java
@@ -4,6 +4,9 @@ import javax.swing.SwingUtilities;
 
 import cfa.vo.sedlib.Segment;
 import cfa.vo.sedlib.common.SedNoDataException;
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
 
 /**
  * Class for helpful utility functions to be used in unit testing.
@@ -46,5 +49,18 @@ public class TestUtils {
             }
         }
         throw last;
+    }
+
+    /**
+     * Convenience method for reading baseline test files from resource paths
+     *
+     * @param requestingClass The class requesting the resource. Resource can be found with paths relative to the argument
+     * @param path String path of the resource. May be relative or absolute
+     * @return String representing the file contents
+     * @throws Exception
+     */
+    public static String readFile(Class requestingClass, String path) throws Exception {
+        String p = requestingClass.getResource(path).getFile();
+        return FileUtils.readFileToString(new File(p));
     }
 }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/ConfidencePanel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/ConfidencePanel.java
@@ -17,13 +17,10 @@ package cfa.vo.iris.fitting;
 
 import cfa.vo.iris.gui.NarrowOptionPane;
 import cfa.vo.sherpa.ConfidenceResults;
-import org.apache.commons.lang.NotImplementedException;
 import org.jdesktop.beansbinding.BeanProperty;
-import org.jdesktop.beansbinding.Converter;
 import org.jdesktop.beansbinding.Property;
 import org.jdesktop.swingbinding.JTableBinding;
-import java.util.ArrayList;
-import java.util.List;
+
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -187,49 +184,4 @@ public class ConfidencePanel extends javax.swing.JPanel {
     private org.jdesktop.beansbinding.BindingGroup bindingGroup;
     // End of variables declaration//GEN-END:variables
 
-    private class ConfResultsConverter extends Converter<ConfidenceResults, List<ConfResultsConverter.ParameterLimits>> {
-
-        @Override
-        public List<ParameterLimits> convertForward(ConfidenceResults res) {
-            List<ParameterLimits> retVal = new ArrayList<>();
-            List<String> names = res.getParnames();
-            double[] mins = res.getParmins();
-            double[] maxes = res.getParmaxes();
-            int l = maxes.length;
-            for (int i=0; i<l; i++) {
-                retVal.add(new ParameterLimits(names.get(i), mins[i], maxes[i]));
-            }
-
-            return retVal;
-        }
-
-        @Override
-        public ConfidenceResults convertReverse(List<ParameterLimits> o) {
-            throw new NotImplementedException(); // read-only binding
-        }
-
-        public class ParameterLimits {
-            private String name;
-            private Double lowerLimit;
-            private Double upperLimit;
-
-            public ParameterLimits(String name, Double lower, Double upper) {
-                this.name = name;
-                this.lowerLimit = lower;
-                this.upperLimit = upper;
-            }
-
-            public String getName() {
-                return name;
-            }
-
-            public Double getLowerLimit() {
-                return lowerLimit;
-            }
-
-            public Double getUpperLimit() {
-                return upperLimit;
-            }
-        }
-    }
 }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FitController.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FitController.java
@@ -82,49 +82,9 @@ public class FitController {
 
     public void save(OutputStream os) {
         PrintWriter writer = new PrintWriter(os);
-        StringBuilder builder = new StringBuilder();
-
-        builder
-                .append("Iris Fitting Tool - Fit Summary\n")
-                .append("SED ID: ").append(sed.getId()).append("\n\n")
-                .append("Model Expression: ").append(sed.getFit().getModel().getName()).append("\n")
-                .append("Components:\n");
-
-
-        for (Model m : sed.getFit().getModel().getParts()) {
-            builder.append("\t").append(m.getName()).append("\n");
-            for (Parameter p : m.getPars()) {
-                builder.append(formatDouble(p.getName(), p.getVal()));
-            }
-        }
-
-        builder
-                .append("\nFit Results:\n")
-                .append(formatDouble("Final Fit Statistic", sed.getFit().getStatVal()))
-                .append(formatDouble("Reduced Statistic", sed.getFit().getrStat()))
-                .append(formatDouble("Probability (Q-value)", sed.getFit().getqVal()))
-                .append(formatInt("Degrees of Freedom", sed.getFit().getDof()))
-                .append(formatInt("Data Points", sed.getFit().getNumPoints()))
-                .append(formatInt("Function Evaluations", sed.getFit().getnFev()))
-                .append("\n")
-                .append(formatString("Optimizer", sed.getFit().getMethod().toString()))
-                .append(formatString("Statistic (Cost function)", sed.getFit().getStat().toString()))
-                ;
-
-
-        writer.write(builder.toString());
+        writer.write("Iris Fitting Tool - Fit Summary\n");
+        writer.write(String.format("SED ID: %s\n\n", sed.toString()));
+        writer.write(sed.getFit().toString());
         writer.flush();
-    }
-
-    private String formatDouble(String name, Double value) {
-        return String.format("\t\t%26s = %f\n", name, value);
-    }
-
-    private String formatInt(String name, Integer value) {
-        return String.format("\t\t%26s = %d\n", name, value);
-    }
-
-    private String formatString(String name, String value) {
-        return String.format("\t\t%26s = %s\n", name, value);
     }
 }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FitController.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FitController.java
@@ -1,16 +1,23 @@
 package cfa.vo.iris.fitting;
 
+import cfa.vo.iris.IrisApplication;
 import cfa.vo.iris.fitting.custom.CustomModelsManager;
 import cfa.vo.iris.fitting.custom.DefaultCustomModel;
 import cfa.vo.iris.fitting.custom.ModelsListener;
 import cfa.vo.iris.sed.ExtSed;
+import cfa.vo.sedlib.Param;
 import cfa.vo.sherpa.ConfidenceResults;
 import cfa.vo.sherpa.FitResults;
 import cfa.vo.sherpa.SherpaClient;
 import cfa.vo.sherpa.models.Model;
 import cfa.vo.sherpa.models.DefaultModel;
+import cfa.vo.sherpa.models.Parameter;
+import org.jdesktop.application.Application;
 
 import javax.swing.tree.TreeModel;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.logging.Logger;
 
 public class FitController {
@@ -71,5 +78,53 @@ public class FitController {
 
     public FitConfiguration getFit() {
         return sed.getFit();
+    }
+
+    public void save(OutputStream os) {
+        PrintWriter writer = new PrintWriter(os);
+        StringBuilder builder = new StringBuilder();
+
+        builder
+                .append("Iris Fitting Tool - Fit Summary\n")
+                .append("SED ID: ").append(sed.getId()).append("\n\n")
+                .append("Model Expression: ").append(sed.getFit().getModel().getName()).append("\n")
+                .append("Components:\n");
+
+
+        for (Model m : sed.getFit().getModel().getParts()) {
+            builder.append("\t").append(m.getName()).append("\n");
+            for (Parameter p : m.getPars()) {
+                builder.append(formatDouble(p.getName(), p.getVal()));
+            }
+        }
+
+        builder
+                .append("\nFit Results:\n")
+                .append(formatDouble("Final Fit Statistic", sed.getFit().getStatVal()))
+                .append(formatDouble("Reduced Statistic", sed.getFit().getrStat()))
+                .append(formatDouble("Probability (Q-value)", sed.getFit().getqVal()))
+                .append(formatInt("Degrees of Freedom", sed.getFit().getDof()))
+                .append(formatInt("Data Points", sed.getFit().getNumPoints()))
+                .append(formatInt("Function Evaluations", sed.getFit().getnFev()))
+                .append("\n")
+                .append(formatString("Optimizer", sed.getFit().getMethod().toString()))
+                .append(formatString("Statistic (Cost function)", sed.getFit().getStat().toString()))
+                ;
+
+
+        writer.write(builder.toString());
+        writer.flush();
+    }
+
+    private String formatDouble(String name, Double value) {
+        return String.format("\t\t%26s = %f\n", name, value);
+    }
+
+    private String formatInt(String name, Integer value) {
+        return String.format("\t\t%26s = %d\n", name, value);
+    }
+
+    private String formatString(String name, String value) {
+        return String.format("\t\t%26s = %s\n", name, value);
     }
 }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FitController.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FitController.java
@@ -1,25 +1,26 @@
 package cfa.vo.iris.fitting;
 
-import cfa.vo.iris.IrisApplication;
 import cfa.vo.iris.fitting.custom.CustomModelsManager;
 import cfa.vo.iris.fitting.custom.DefaultCustomModel;
 import cfa.vo.iris.fitting.custom.ModelsListener;
 import cfa.vo.iris.sed.ExtSed;
-import cfa.vo.sedlib.Param;
 import cfa.vo.sherpa.ConfidenceResults;
 import cfa.vo.sherpa.FitResults;
 import cfa.vo.sherpa.SherpaClient;
 import cfa.vo.sherpa.models.Model;
 import cfa.vo.sherpa.models.DefaultModel;
-import cfa.vo.sherpa.models.Parameter;
-import org.jdesktop.application.Application;
 
 import javax.swing.tree.TreeModel;
 import java.io.OutputStream;
 import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.util.logging.Logger;
 
+/**
+ * Controller class for the Fitting Tool component.
+ *
+ * The class is responsible for managing models and acting on them
+ * at the View's request.
+ */
 public class FitController {
 
     private ExtSed sed;
@@ -28,16 +29,43 @@ public class FitController {
 
     private final Logger logger = Logger.getLogger(FitController.class.getName());
 
+    /**
+     * The model for the fitting tool is actually the whole SED, at least in the current scenario
+     * where fits belong to SEDs.
+     *
+     * The model also delegates models management to a {@link CustomModelsManager} that must be initialized
+     * by the {@link cfa.vo.iris.visualizer.FittingToolComponent}.
+     *
+     * Finally, an instance of a {@link SherpaClient} is required in order to call the actual operations
+     * from the sherpa-samp service.
+     *
+     * There is an abuse of notations between Models in the MVC sense and Fitting Model Components, which
+     * are referred to as Model in the Iris/Sherpa interface specification.
+     *
+     * @param sed the current model
+     * @param manager a manager for custom Fitting Model Components
+     * @param client a representation of the sherpa-samp service.
+     */
     public FitController(ExtSed sed, CustomModelsManager manager, SherpaClient client) {
         this.sed = sed;
         this.client = client;
         modelsController = new ModelsController(manager);
     }
 
+    /**
+     * As part of the abstraction to the {@link FittingMainView} the controller
+     * allows clients to register to events pertaining custom Model Components, i.e. when models are
+     * added or removed from the models manager.
+     * @param listener a {@link ModelsListener} implementation
+     */
     public void addListener(ModelsListener listener) {
         modelsController.addListener(listener);
     }
 
+    /**
+     * Add a Fitting Model Component to the underlying model
+     * @param m The {@link Model} instance representing the Fitting Model Component to be added.
+     */
     public void addModel(Model m) {
         logger.info("Added model " + m);
         String id = client.createId();
@@ -45,41 +73,87 @@ public class FitController {
         sed.getFit().addModel(toAdd);
     }
 
+    /**
+     * Add a Custom Fitting Model Component to the underlying model. Implementation is tied to a concrete
+     * realization of the {@link cfa.vo.iris.fitting.custom.CustomModel} interface for "historical" reason, but
+     * this should probably be fixed.
+     * @param m The {@link DefaultCustomModel} instance representing the Custom Model Component to be added.
+     */
     public void addModel(DefaultCustomModel m) {
         logger.info("Added user model " + m);
         sed.getFit().addUserModel(m, client.createId());
     }
 
+    /**
+     * Filter existing models according to a simple string matching. Implementation is delegated to
+     * {@link ModelsController#filterModels(String)}
+     *
+     * @param searchString A string to be matched.
+     *
+     * @see {@link ModelsController#filterModels(String)}
+     */
     public void filterModels(String searchString) {
         modelsController.filterModels(searchString);
     }
 
+    /**
+     * Fit the current model and return results. Fitting is delegated to the sherpa-samp service attached to
+     * this instance.
+     * @return {@link FitResults} object representing the results of the fit.
+     * @throws Exception An exception may be thrown by the sherpa-samp service if the fitting operation failed.
+     */
     public FitResults fit() throws Exception {
         FitResults retVal = client.fit(sed);
         sed.getFit().integrateResults(retVal);
         return retVal;
     }
 
+    /**
+     * Compute confidence intervals for the current model. Computation is delegated to the sherpa-samp service attached to
+     * this instance.
+     * @return {@link ConfidenceResults} object representing the results of the confidence limits calculation
+     * @throws Exception an exception may be thrown by the sherpa-samp service if the operation failed
+     */
     public ConfidenceResults computeConfidence() throws Exception {
         return client.computeConfidence(sed);
     }
 
+    /**
+     * Return a {@link TreeModel} representation of the current fitting model
+     * @return a {@link TreeModel} instance
+     */
     public TreeModel getModelsTreeModel() {
         return modelsController.getModelsTreeModel();
     }
 
+    /**
+     * Return the current model
+     * @return {@link ExtSed} instance
+     */
     public ExtSed getSed() {
         return sed;
     }
 
+    /**
+     * Set the current model
+     * @param sed {@link ExtSed} instance
+     */
     public void setSed(ExtSed sed) {
         this.sed = sed;
     }
 
+    /**
+     * Convenience method that returns the {@link FitConfiguration} object attached to the current SED.
+     * @return {@link FitConfiguration} instance
+     */
     public FitConfiguration getFit() {
         return sed.getFit();
     }
 
+    /**
+     * Save a summary of the current model in a human readable format to an {@link OutputStream}
+     * @param os {@link OutputStream} to write to
+     */
     public void save(OutputStream os) {
         PrintWriter writer = new PrintWriter(os);
         writer.write("Iris Fitting Tool - Fit Summary\n");

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FitController.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FitController.java
@@ -115,7 +115,9 @@ public class FitController {
      * @throws Exception an exception may be thrown by the sherpa-samp service if the operation failed
      */
     public ConfidenceResults computeConfidence() throws Exception {
-        return client.computeConfidence(sed);
+        ConfidenceResults retVal = client.computeConfidence(sed);
+        getFit().setConfidenceResults(retVal);
+        return retVal;
     }
 
     /**

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.form
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.form
@@ -2,17 +2,29 @@
 
 <Form version="1.7" maxVersion="1.9" type="org.netbeans.modules.form.forminfo.JInternalFrameFormInfo">
   <NonVisualComponents>
-    <Menu class="javax.swing.JMenuBar" name="jMenuBar1">
+    <Menu class="javax.swing.JMenuBar" name="menuBar">
       <SubComponents>
         <Menu class="javax.swing.JMenu" name="jMenu1">
           <Properties>
             <Property name="text" type="java.lang.String" value="File"/>
           </Properties>
-        </Menu>
-        <Menu class="javax.swing.JMenu" name="menuBar">
-          <Properties>
-            <Property name="text" type="java.lang.String" value="Edit"/>
-          </Properties>
+          <SubComponents>
+            <MenuItem class="javax.swing.JMenuItem" name="saveTextMenuItem">
+              <Properties>
+                <Property name="text" type="java.lang.String" value="load"/>
+              </Properties>
+            </MenuItem>
+            <MenuItem class="javax.swing.JMenuItem" name="loadMenuItem">
+              <Properties>
+                <Property name="text" type="java.lang.String" value="saveXML"/>
+              </Properties>
+            </MenuItem>
+            <MenuItem class="javax.swing.JMenuItem" name="saveXmlMenuItem">
+              <Properties>
+                <Property name="text" type="java.lang.String" value="saveText"/>
+              </Properties>
+            </MenuItem>
+          </SubComponents>
         </Menu>
       </SubComponents>
     </Menu>
@@ -30,7 +42,7 @@
     </Property>
   </Properties>
   <SyntheticProperties>
-    <SyntheticProperty name="menuBar" type="java.lang.String" value="jMenuBar1"/>
+    <SyntheticProperty name="menuBar" type="java.lang.String" value="menuBar"/>
     <SyntheticProperty name="formSizePolicy" type="int" value="1"/>
   </SyntheticProperties>
   <AuxValues>
@@ -225,7 +237,7 @@
                                 <Component class="javax.swing.JComboBox" name="statisticCombo">
                                   <Properties>
                                     <Property name="model" type="javax.swing.ComboBoxModel" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-                                      <Connection code="new DefaultComboBoxModel&lt;&gt;(Stats.values())" type="code"/>
+                                      <Connection code="new DefaultComboBoxModel&lt;&gt;(Statistic.values())" type="code"/>
                                     </Property>
                                     <Property name="name" type="java.lang.String" value="statisticCombo" noResource="true"/>
                                   </Properties>
@@ -315,7 +327,7 @@
                             </DimensionLayout>
                             <DimensionLayout dim="1">
                               <Group type="103" groupAlignment="0" attributes="0">
-                                  <Component id="confidencePanel" alignment="1" pref="187" max="32767" attributes="0"/>
+                                  <Component id="confidencePanel" alignment="1" max="32767" attributes="0"/>
                               </Group>
                             </DimensionLayout>
                           </Layout>

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.java
@@ -15,7 +15,6 @@
  */
 package cfa.vo.iris.fitting;
 
-import cfa.vo.iris.IrisApplication;
 import cfa.vo.iris.events.SedCommand;
 import cfa.vo.iris.events.SedEvent;
 import cfa.vo.iris.events.SedListener;
@@ -23,11 +22,9 @@ import cfa.vo.iris.fitting.custom.DefaultCustomModel;
 import cfa.vo.iris.fitting.custom.ModelsListener;
 import cfa.vo.iris.gui.NarrowOptionPane;
 import cfa.vo.iris.sed.ExtSed;
-import cfa.vo.iris.visualizer.FittingToolComponent;
 import cfa.vo.sherpa.models.Model;
 import cfa.vo.sherpa.optimization.OptimizationMethod;
 import cfa.vo.sherpa.stats.Statistic;
-import org.jdesktop.application.Application;
 
 import javax.swing.*;
 import javax.swing.tree.*;
@@ -40,6 +37,7 @@ import java.io.FileOutputStream;
 public class FittingMainView extends JInternalFrame implements SedListener {
     private ExtSed sed;
     private FitController controller;
+    private JFileChooser chooser;
     public final String DEFAULT_DESCRIPTION = "Double click on a Component to add it to the list of selected Components.";
     public final String CUSTOM_DESCRIPTION = "User Model";
     public static final String PROP_SED = "sed";
@@ -49,9 +47,10 @@ public class FittingMainView extends JInternalFrame implements SedListener {
         SedEvent.getInstance().add(this);
     }
 
-    public FittingMainView(FitController controller) {
+    public FittingMainView(JFileChooser chooser, FitController controller) {
         this();
         this.controller = controller;
+        this.chooser = chooser;
         setSed(controller.getSed());
         initController();
         setUpAvailableModelsTree();
@@ -513,12 +512,10 @@ public class FittingMainView extends JInternalFrame implements SedListener {
     private class SaveTextAction extends AbstractAction {
         public SaveTextAction() {
             super("Save Text...");
-
         }
 
         @Override
         public void actionPerformed(ActionEvent actionEvent) {
-            JFileChooser chooser = new JFileChooser();
             int result = chooser.showOpenDialog(FittingMainView.this);
             if (result == JFileChooser.APPROVE_OPTION) {
                 try {

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.java
@@ -15,6 +15,7 @@
  */
 package cfa.vo.iris.fitting;
 
+import cfa.vo.iris.IrisApplication;
 import cfa.vo.iris.events.SedCommand;
 import cfa.vo.iris.events.SedEvent;
 import cfa.vo.iris.events.SedListener;
@@ -22,14 +23,19 @@ import cfa.vo.iris.fitting.custom.DefaultCustomModel;
 import cfa.vo.iris.fitting.custom.ModelsListener;
 import cfa.vo.iris.gui.NarrowOptionPane;
 import cfa.vo.iris.sed.ExtSed;
+import cfa.vo.iris.visualizer.FittingToolComponent;
 import cfa.vo.sherpa.models.Model;
 import cfa.vo.sherpa.optimization.OptimizationMethod;
 import cfa.vo.sherpa.stats.Statistic;
+import org.jdesktop.application.Application;
 
 import javax.swing.*;
 import javax.swing.tree.*;
+import java.awt.event.ActionEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 
 public class FittingMainView extends JInternalFrame implements SedListener {
     private ExtSed sed;
@@ -50,6 +56,7 @@ public class FittingMainView extends JInternalFrame implements SedListener {
         initController();
         setUpAvailableModelsTree();
         setUpModelViewerPanel();
+        setUpMenuBar();
         confidencePanel.setController(controller);
         revalidate();
         pack();
@@ -74,6 +81,10 @@ public class FittingMainView extends JInternalFrame implements SedListener {
 
     private void initController() {
         controller.addListener((ModelsListener) availableTree);
+    }
+
+    private void setUpMenuBar() {
+        saveTextMenuItem.setAction(new SaveTextAction());
     }
 
     private void setUpModelViewerPanel() {
@@ -127,9 +138,11 @@ public class FittingMainView extends JInternalFrame implements SedListener {
         availableTree = new CustomJTree();
         currentSedLabel = new javax.swing.JLabel();
         currentSedField = new javax.swing.JTextField();
-        jMenuBar1 = new javax.swing.JMenuBar();
+        menuBar = new javax.swing.JMenuBar();
         jMenu1 = new javax.swing.JMenu();
-        menuBar = new javax.swing.JMenu();
+        saveTextMenuItem = new javax.swing.JMenuItem();
+        loadMenuItem = new javax.swing.JMenuItem();
+        saveXmlMenuItem = new javax.swing.JMenuItem();
 
         setClosable(true);
         setDefaultCloseOperation(javax.swing.WindowConstants.HIDE_ON_CLOSE);
@@ -248,7 +261,7 @@ public class FittingMainView extends JInternalFrame implements SedListener {
         );
         confidenceContainerLayout.setVerticalGroup(
             confidenceContainerLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addComponent(confidencePanel, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.DEFAULT_SIZE, 187, Short.MAX_VALUE)
+            .addComponent(confidencePanel, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
         );
 
         jSplitPane2.setRightComponent(confidenceContainer);
@@ -376,12 +389,19 @@ public class FittingMainView extends JInternalFrame implements SedListener {
         getContentPane().add(jPanel1);
 
         jMenu1.setText("File");
-        jMenuBar1.add(jMenu1);
 
-        menuBar.setText("Edit");
-        jMenuBar1.add(menuBar);
+        saveTextMenuItem.setText("load");
+        jMenu1.add(saveTextMenuItem);
 
-        setJMenuBar(jMenuBar1);
+        loadMenuItem.setText("saveXML");
+        jMenu1.add(loadMenuItem);
+
+        saveXmlMenuItem.setText("saveText");
+        jMenu1.add(saveXmlMenuItem);
+
+        menuBar.add(jMenu1);
+
+        setJMenuBar(menuBar);
 
         bindingGroup.bind();
 
@@ -420,7 +440,6 @@ public class FittingMainView extends JInternalFrame implements SedListener {
     private javax.swing.JLabel jLabel1;
     private javax.swing.JLabel jLabel2;
     private javax.swing.JMenu jMenu1;
-    private javax.swing.JMenuBar jMenuBar1;
     private javax.swing.JPanel jPanel1;
     private javax.swing.JPanel jPanel2;
     private javax.swing.JPanel jPanel4;
@@ -431,12 +450,15 @@ public class FittingMainView extends JInternalFrame implements SedListener {
     private javax.swing.JSplitPane jSplitPane2;
     private javax.swing.JSplitPane jSplitPane3;
     private javax.swing.JSplitPane jSplitPane4;
-    private javax.swing.JMenu menuBar;
+    private javax.swing.JMenuItem loadMenuItem;
+    private javax.swing.JMenuBar menuBar;
     private javax.swing.JPanel modelPanel;
     private cfa.vo.iris.gui.widgets.ModelViewerPanel modelViewerPanel;
     private javax.swing.JComboBox optimizationCombo;
     private javax.swing.JPanel resultsContainer;
     private cfa.vo.iris.fitting.FitResultsPanel resultsPanel;
+    private javax.swing.JMenuItem saveTextMenuItem;
+    private javax.swing.JMenuItem saveXmlMenuItem;
     private javax.swing.JButton searchButton;
     private javax.swing.JTextField searchField;
     private javax.swing.JComboBox statisticCombo;
@@ -483,6 +505,26 @@ public class FittingMainView extends JInternalFrame implements SedListener {
                     }
                 } else {
                     descriptionArea.setText(DEFAULT_DESCRIPTION);
+                }
+            }
+        }
+    }
+
+    private class SaveTextAction extends AbstractAction {
+        public SaveTextAction() {
+            super("Save Text...");
+
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent actionEvent) {
+            JFileChooser chooser = new JFileChooser();
+            int result = chooser.showOpenDialog(FittingMainView.this);
+            if (result == JFileChooser.APPROVE_OPTION) {
+                try {
+                    controller.save(new FileOutputStream(chooser.getSelectedFile()));
+                } catch(FileNotFoundException ex) {
+                    NarrowOptionPane.showMessageDialog(FittingMainView.this, ex.getMessage(), "Error", NarrowOptionPane.ERROR_MESSAGE);
                 }
             }
         }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/ModelsTreeModel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/ModelsTreeModel.java
@@ -33,7 +33,9 @@ public class ModelsTreeModel extends DefaultTreeModel {
             parentNode.add(new DefaultMutableTreeNode(m));
         }
 
-        r.add(customTree);
+        if (customTree != null) {
+            r.add(customTree);
+        }
     }
 
     public List<Model> getList() {

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/FittingToolComponent.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/FittingToolComponent.java
@@ -144,7 +144,7 @@ public class FittingToolComponent implements IrisComponent {
                                 return;
                             }
                             FitController controller = new FitController(sed, customManager, sherpaClient);
-                            view = new FittingMainView(controller);
+                            view = new FittingMainView(ws.getFileChooser(), controller);
                             ws.addFrame(view);
                         } catch (Exception ex) {
                             throw new RuntimeException(ex);

--- a/iris-visualizer/src/test/java/cfa/vo/iris/fitting/FitControllerTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/fitting/FitControllerTest.java
@@ -1,0 +1,82 @@
+package cfa.vo.iris.fitting;
+
+import cfa.vo.interop.SAMPFactory;
+import cfa.vo.iris.fitting.custom.CustomModelsManager;
+import cfa.vo.iris.sed.ExtSed;
+import cfa.vo.sherpa.SherpaClient;
+import cfa.vo.sherpa.models.CompositeModel;
+import cfa.vo.sherpa.models.Model;
+import cfa.vo.sherpa.models.ModelFactory;
+import cfa.vo.sherpa.models.Parameter;
+import cfa.vo.sherpa.optimization.OptimizationMethod;
+import cfa.vo.sherpa.stats.Statistic;
+import org.apache.commons.io.FileUtils;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+
+import static org.junit.Assert.*;
+
+public class FitControllerTest {
+
+    @Test
+    public void testSave() throws Exception {
+        ExtSed sed = Mockito.mock(ExtSed.class);
+        FitConfiguration configuration = createFit();
+        Mockito.when(sed.getFit()).thenReturn(configuration);
+        Mockito.when(sed.getId()).thenReturn("MySed");
+        CustomModelsManager modelsManager = Mockito.mock(CustomModelsManager.class);
+        SherpaClient client = Mockito.mock(SherpaClient.class);
+
+        FitController controller = new FitController(sed, modelsManager, client);
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        controller.save(os);
+
+        assertEquals(getOutputString(), os.toString("UTF-8"));
+    }
+
+    private FitConfiguration createFit() {
+        FitConfiguration fit = new FitConfiguration();
+
+        ModelFactory factory = new ModelFactory();
+        Model m = factory.getModel("polynomial", "m1");
+        Parameter c0 = m.findParameter("c0");
+        c0.setFrozen(0);
+        c0.setVal(0.1);
+
+        Parameter c1 = m.findParameter("c1");
+        c1.setFrozen(0);
+        c1.setVal(0.2);
+
+        Model m2 = factory.getModel("powlaw1d", "m2");
+        m2.findParameter("gamma").setVal(0.01);
+        m2.findParameter("ampl").setVal(0.02);
+
+        CompositeModel cm = SAMPFactory.get(CompositeModel.class);
+        cm.setName("m1+m2");
+        cm.addPart(m);
+        cm.addPart(m2);
+
+        fit.setModel(cm);
+
+        fit.setMethod(OptimizationMethod.LevenbergMarquardt);
+        fit.setStat(Statistic.LeastSquares);
+
+        fit.setDof(30);
+        fit.setStatVal(0.1234);
+        fit.setrStat(0.4321);
+        fit.setqVal(0.1357);
+        fit.setDof(30);
+        fit.setNumPoints(430);
+        fit.setnFev(731);
+
+        return fit;
+    }
+
+    private String getOutputString() throws Exception {
+        String path = getClass().getResource("fit.output").getFile();
+        return FileUtils.readFileToString(new File(path));
+    }
+}

--- a/iris-visualizer/src/test/java/cfa/vo/iris/fitting/FitControllerTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/fitting/FitControllerTest.java
@@ -3,6 +3,7 @@ package cfa.vo.iris.fitting;
 import cfa.vo.interop.SAMPFactory;
 import cfa.vo.iris.fitting.custom.CustomModelsManager;
 import cfa.vo.iris.sed.ExtSed;
+import cfa.vo.sherpa.ConfidenceResults;
 import cfa.vo.sherpa.SherpaClient;
 import cfa.vo.sherpa.models.CompositeModel;
 import cfa.vo.sherpa.models.Model;
@@ -16,6 +17,8 @@ import org.mockito.Mockito;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
 
 import static org.junit.Assert.*;
 
@@ -71,6 +74,14 @@ public class FitControllerTest {
         fit.setDof(30);
         fit.setNumPoints(430);
         fit.setnFev(731);
+
+        ConfidenceResults confidenceResults = SAMPFactory.get(ConfidenceResults.class);
+        confidenceResults.setParnames(Arrays.asList("m1.c0", "m1.c1", "m2.c2"));
+        confidenceResults.setParmins(new double[]{-0.1, -0.2, -0.3});
+        confidenceResults.setParmaxes(new double[]{0.1, 0.2, 0.3});
+        confidenceResults.setSigma(1.6);
+        confidenceResults.setPercent(96.3);
+        fit.setConfidenceResults(confidenceResults);
 
         return fit;
     }

--- a/iris-visualizer/src/test/java/cfa/vo/iris/fitting/FitControllerTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/fitting/FitControllerTest.java
@@ -1,14 +1,13 @@
 package cfa.vo.iris.fitting;
 
 import cfa.vo.interop.SAMPFactory;
+import cfa.vo.iris.fitting.custom.CustomModelType;
 import cfa.vo.iris.fitting.custom.CustomModelsManager;
+import cfa.vo.iris.fitting.custom.DefaultCustomModel;
 import cfa.vo.iris.sed.ExtSed;
 import cfa.vo.sherpa.ConfidenceResults;
 import cfa.vo.sherpa.SherpaClient;
-import cfa.vo.sherpa.models.CompositeModel;
-import cfa.vo.sherpa.models.Model;
-import cfa.vo.sherpa.models.ModelFactory;
-import cfa.vo.sherpa.models.Parameter;
+import cfa.vo.sherpa.models.*;
 import cfa.vo.sherpa.optimization.OptimizationMethod;
 import cfa.vo.sherpa.stats.Statistic;
 import org.apache.commons.io.FileUtils;
@@ -17,8 +16,10 @@ import org.mockito.Mockito;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.Assert.*;
 
@@ -40,7 +41,7 @@ public class FitControllerTest {
         assertEquals(getOutputString(), os.toString("UTF-8"));
     }
 
-    private FitConfiguration createFit() {
+    private FitConfiguration createFit() throws Exception {
         FitConfiguration fit = new FitConfiguration();
 
         ModelFactory factory = new ModelFactory();
@@ -57,8 +58,15 @@ public class FitControllerTest {
         m2.findParameter("gamma").setVal(0.01);
         m2.findParameter("ampl").setVal(0.02);
 
-        CompositeModel cm = SAMPFactory.get(CompositeModel.class);
-        cm.setName("m1+m2");
+        DefaultCustomModel userModel = Mockito.mock(DefaultCustomModel.class);
+        Model model = new ModelStub();
+        UserModel um = new UserModelStub();
+        Mockito.stub(userModel.makeModel(Mockito.anyString())).toReturn(model);
+        Mockito.stub(userModel.makeUserModel(Mockito.anyString())).toReturn(um);
+        fit.addUserModel(userModel, "m3");
+
+        CompositeModel cm = fit.getModel();
+        cm.setName("m1+m2+m3");
         cm.addPart(m);
         cm.addPart(m2);
 
@@ -89,5 +97,187 @@ public class FitControllerTest {
     private String getOutputString() throws Exception {
         String path = getClass().getResource("fit.output").getFile();
         return FileUtils.readFileToString(new File(path));
+    }
+
+
+    private class ModelStub implements Model {
+        private List<Parameter> pars;
+
+        public ModelStub() {
+            pars = new ArrayList<>();
+            pars.add(new ParameterStub("m3.p1", 0.1, 1));
+            pars.add(new ParameterStub("m3.p2", 0.2, 0));
+            pars.add(new ParameterStub("m3.p3", 0.3, 0));
+        }
+
+        @Override
+        public String getName() {
+            return "tablemodel.m3";
+        }
+
+        @Override
+        public void setName(String name) {
+
+        }
+
+        @Override
+        public String getDescription() {
+            return null;
+        }
+
+        @Override
+        public void setDescription(String description) {
+
+        }
+
+        @Override
+        public List<Parameter> getPars() {
+            return pars;
+        }
+
+        @Override
+        public void addPar(Parameter par) {
+
+        }
+
+        @Override
+        public Parameter findParameter(String paramName) {
+            return null;
+        }
+    }
+
+    private class ParameterStub implements Parameter {
+        private String name;
+        private Double val;
+        private Integer frozen;
+
+        public ParameterStub(String name, Double val, Integer frozen) {
+            this.name = name;
+            this.val = val;
+            this.frozen = frozen;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public void setName(String name) {
+
+        }
+
+        @Override
+        public Double getVal() {
+            return val;
+        }
+
+        @Override
+        public void setVal(Double value) {
+
+        }
+
+        @Override
+        public Double getMin() {
+            return null;
+        }
+
+        @Override
+        public void setMin(Double min) {
+
+        }
+
+        @Override
+        public Double getMax() {
+            return null;
+        }
+
+        @Override
+        public void setMax(Double max) {
+
+        }
+
+        @Override
+        public Integer getFrozen() {
+            return frozen;
+        }
+
+        @Override
+        public void setFrozen(Integer frozen) {
+
+        }
+
+        @Override
+        public Integer getHidden() {
+            return null;
+        }
+
+        @Override
+        public void setHidden(Integer hidden) {
+
+        }
+
+        @Override
+        public Integer getAlwaysfrozen() {
+            return null;
+        }
+
+        @Override
+        public void setAlwaysfrozen(Integer alwaysfrozen) {
+
+        }
+
+        @Override
+        public String getUnits() {
+            return null;
+        }
+
+        @Override
+        public void setUnits(String units) {
+
+        }
+
+        @Override
+        public String getLink() {
+            return null;
+        }
+
+        @Override
+        public void setLink(String link) {
+
+        }
+    }
+
+    private class UserModelStub implements UserModel {
+
+        @Override
+        public String getName() {
+            return "function.m3";
+        }
+
+        @Override
+        public void setName(String name) {
+
+        }
+
+        @Override
+        public String getFile() {
+            return "file://somewhere/on/disk";
+        }
+
+        @Override
+        public void setFile(String path) {
+
+        }
+
+        @Override
+        public String getFunction() {
+            return "somefunc";
+        }
+
+        @Override
+        public void setFunction(String function) {
+
+        }
     }
 }

--- a/iris-visualizer/src/test/java/cfa/vo/iris/fitting/FitControllerTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/fitting/FitControllerTest.java
@@ -5,6 +5,7 @@ import cfa.vo.iris.fitting.custom.CustomModelType;
 import cfa.vo.iris.fitting.custom.CustomModelsManager;
 import cfa.vo.iris.fitting.custom.DefaultCustomModel;
 import cfa.vo.iris.sed.ExtSed;
+import cfa.vo.iris.test.unit.TestUtils;
 import cfa.vo.sherpa.ConfidenceResults;
 import cfa.vo.sherpa.SherpaClient;
 import cfa.vo.sherpa.models.*;
@@ -38,7 +39,7 @@ public class FitControllerTest {
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         controller.save(os);
 
-        assertEquals(getOutputString(), os.toString("UTF-8"));
+        assertEquals(TestUtils.readFile(getClass(), "fit.output"), os.toString("UTF-8"));
     }
 
     private FitConfiguration createFit() throws Exception {
@@ -92,11 +93,6 @@ public class FitControllerTest {
         fit.setConfidenceResults(confidenceResults);
 
         return fit;
-    }
-
-    private String getOutputString() throws Exception {
-        String path = getClass().getResource("fit.output").getFile();
-        return FileUtils.readFileToString(new File(path));
     }
 
 

--- a/iris-visualizer/src/test/java/cfa/vo/iris/fitting/FitControllerTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/fitting/FitControllerTest.java
@@ -26,7 +26,7 @@ public class FitControllerTest {
         ExtSed sed = Mockito.mock(ExtSed.class);
         FitConfiguration configuration = createFit();
         Mockito.when(sed.getFit()).thenReturn(configuration);
-        Mockito.when(sed.getId()).thenReturn("MySed");
+        Mockito.when(sed.toString()).thenReturn("MySed (Segments: 3)");
         CustomModelsManager modelsManager = Mockito.mock(CustomModelsManager.class);
         SherpaClient client = Mockito.mock(SherpaClient.class);
 

--- a/iris-visualizer/src/test/java/cfa/vo/iris/fitting/FittingMainViewTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/fitting/FittingMainViewTest.java
@@ -15,6 +15,7 @@ import org.uispec4j.TextBox;
 import org.uispec4j.Window;
 import org.uispec4j.assertion.UISpecAssert;
 
+import javax.swing.*;
 import javax.swing.tree.DefaultMutableTreeNode;
 
 public class FittingMainViewTest {
@@ -31,8 +32,9 @@ public class FittingMainViewTest {
         CustomModelsManager modelsManager = Mockito.mock(CustomModelsManager.class);
         Mockito.when(modelsManager.getCustomModels()).thenReturn(new DefaultMutableTreeNode("Custom Models"));
         SherpaClient client = Mockito.mock(SherpaClient.class);
+        JFileChooser chooser = Mockito.mock(JFileChooser.class);
         FitController controller = new FitController(sed, modelsManager, client);
-        FittingMainView view = new FittingMainView(controller);
+        FittingMainView view = new FittingMainView(chooser, controller);
 
         fittingView = new Window(view);
         sedId = fittingView.getInputTextBox("currentSedField");

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/FittingToolComponentTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/FittingToolComponentTest.java
@@ -228,6 +228,17 @@ public class FittingToolComponentTest extends AbstractComponentGUITest {
                 .run();
     }
 
+    @Test
+    public void spike() {
+        String expected = "$HOME/.vao/pippo";
+        String original = "/home/olaurino/.vao/pippo";
+        String actual = original.replaceAll("(/home/.*?/|/Users/.*?/)", "\\$HOME/");
+        assertEquals(expected, actual);
+        original = "/Users/olaurino/.vao/pippo";
+        actual = original.replaceAll("(/home/.*?/|/Users/.*?/)", "\\$HOME/");
+        assertEquals(expected, actual);
+    }
+
     private Window openWindow() {
         window.getMenuBar()
                 .getMenu("Tools")

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/FittingToolComponentTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/FittingToolComponentTest.java
@@ -24,20 +24,27 @@ import cfa.vo.iris.sed.SedlibSedManager;
 import cfa.vo.iris.test.unit.TestUtils;
 import cfa.vo.sherpa.models.*;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import cfa.vo.sherpa.optimization.OptimizationMethod;
 import cfa.vo.sherpa.stats.Statistic;
+import com.google.common.io.Files;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
 
+import org.junit.rules.TemporaryFolder;
 import org.uispec4j.ComboBox;
 import org.uispec4j.TextBox;
 import org.uispec4j.Tree;
 import org.uispec4j.Window;
 import org.uispec4j.interception.BasicHandler;
+import org.uispec4j.interception.FileChooserHandler;
 import org.uispec4j.interception.WindowInterceptor;
 
 public class FittingToolComponentTest extends AbstractComponentGUITest {
@@ -45,6 +52,9 @@ public class FittingToolComponentTest extends AbstractComponentGUITest {
     private FittingToolComponent comp = new FittingToolComponent();
     private String windowName;
     private SedlibSedManager sedManager;
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
 
     @Before
     public void setUp() throws Exception {
@@ -172,6 +182,24 @@ public class FittingToolComponentTest extends AbstractComponentGUITest {
         assertTrue(availableTree.contains("Preset Model Components/beta1d").isTrue());
         assertTrue(availableTree.contains("Preset Model Components/powerlaw").isTrue());
         assertTrue(availableTree.contains("Preset Model Components/brokenpowerlaw").isTrue());
+    }
+
+    @Test
+    public void testSaveText() throws Exception {
+        ExtSed sed = sedManager.newSed("TestSed");
+        addFit(sed);
+        Window mainFit = openWindow();
+
+        File outputFile = tempFolder.newFile("output.fit");
+
+        WindowInterceptor
+                .init(mainFit.getMenuBar().getMenu("File").getSubMenu("Save Text...").triggerClick())
+                .process(FileChooserHandler.init().select(outputFile.getAbsolutePath()))
+                .run()
+        ;
+
+        String expected = TestUtils.readFile(getClass(), "fit.output");
+        assertEquals(expected, Files.toString(outputFile, Charset.defaultCharset()));
     }
 
     private Window openWindow() {

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/FittingToolComponentTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/FittingToolComponentTest.java
@@ -39,12 +39,10 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 
 import org.junit.rules.TemporaryFolder;
-import org.uispec4j.ComboBox;
-import org.uispec4j.TextBox;
-import org.uispec4j.Tree;
-import org.uispec4j.Window;
+import org.uispec4j.*;
 import org.uispec4j.interception.BasicHandler;
 import org.uispec4j.interception.FileChooserHandler;
+import org.uispec4j.interception.WindowHandler;
 import org.uispec4j.interception.WindowInterceptor;
 
 public class FittingToolComponentTest extends AbstractComponentGUITest {
@@ -200,6 +198,34 @@ public class FittingToolComponentTest extends AbstractComponentGUITest {
 
         String expected = TestUtils.readFile(getClass(), "fit.output");
         assertEquals(expected, Files.toString(outputFile, Charset.defaultCharset()));
+    }
+
+    @Test
+    public void testSaveTextNonExistentFile() throws Exception {
+        ExtSed sed = sedManager.newSed("TestSed");
+        addFit(sed);
+        Window mainFit = openWindow();
+
+        final WindowInterceptor wi = WindowInterceptor
+                .init(mainFit.getMenuBar().getMenu("File").getSubMenu("Save Text...").triggerClick())
+                .process(FileChooserHandler.init().select("/foo/bar/baz"));
+
+        WindowInterceptor
+                .init(new Trigger() {
+                    @Override
+                    public void run() throws Exception {
+                        wi.run();
+                    }
+                })
+                .process(new WindowHandler() {
+                    @Override
+                    public Trigger process(Window window) throws Exception {
+                        window.titleEquals("Error").check();
+                        window.getTextBox("Optionpane.label").textContains("No such file or directory").check();
+                        return window.getButton().triggerClick();
+                    }
+                })
+                .run();
     }
 
     private Window openWindow() {

--- a/iris-visualizer/src/test/resources/cfa/vo/iris/fitting/fit.output
+++ b/iris-visualizer/src/test/resources/cfa/vo/iris/fitting/fit.output
@@ -1,0 +1,28 @@
+Iris Fitting Tool - Fit Summary
+SED ID: MySed
+
+Model Expression: m1+m2
+Components:
+	polynomial.m1
+		                     m1.c0 = 0.100000
+		                     m1.c1 = 0.200000
+		                     m1.c2 = 0.000000
+		                     m1.c3 = 0.000000
+		                     m1.c4 = 0.000000
+		                     m1.c5 = 0.000000
+		                 m1.offset = 0.000000
+	powlaw1d.m2
+		                    m2.ref = 5000.000000
+		                   m2.ampl = 0.020000
+		                  m2.gamma = 0.010000
+
+Fit Results:
+		       Final Fit Statistic = 0.123400
+		         Reduced Statistic = 0.432100
+		     Probability (Q-value) = 0.135700
+		        Degrees of Freedom = 30
+		               Data Points = 430
+		      Function Evaluations = 731
+
+		                 Optimizer = LevenbergMarquardt
+		 Statistic (Cost function) = LeastSquares

--- a/iris-visualizer/src/test/resources/cfa/vo/iris/fitting/fit.output
+++ b/iris-visualizer/src/test/resources/cfa/vo/iris/fitting/fit.output
@@ -4,22 +4,22 @@ SED ID: MySed (Segments: 3)
 Model Expression: m1+m2
 Components:
 	polynomial.m1
-		                     m1.c0 = 0.100000
-		                     m1.c1 = 0.200000
-		                     m1.c2 = 0.000000
-		                     m1.c3 = 0.000000
-		                     m1.c4 = 0.000000
-		                     m1.c5 = 0.000000
-		                 m1.offset = 0.000000
+		                     m1.c0 =  1.00000E-01
+		                     m1.c1 =  2.00000E-01
+		                     m1.c2 =  0.00000E+00 Frozen
+		                     m1.c3 =  0.00000E+00 Frozen
+		                     m1.c4 =  0.00000E+00 Frozen
+		                     m1.c5 =  0.00000E+00 Frozen
+		                 m1.offset =  0.00000E+00 Frozen
 	powlaw1d.m2
-		                    m2.ref = 5000.000000
-		                   m2.ampl = 0.020000
-		                  m2.gamma = 0.010000
+		                    m2.ref =  5.00000E+03 Frozen
+		                   m2.ampl =  2.00000E-02
+		                  m2.gamma =  1.00000E-02
 
 Fit Results:
-		       Final Fit Statistic = 0.123400
-		         Reduced Statistic = 0.432100
-		     Probability (Q-value) = 0.135700
+		       Final Fit Statistic =  1.23400E-01
+		         Reduced Statistic =  4.32100E-01
+		     Probability (Q-value) =  1.35700E-01
 		        Degrees of Freedom = 30
 		               Data Points = 430
 		      Function Evaluations = 731

--- a/iris-visualizer/src/test/resources/cfa/vo/iris/fitting/fit.output
+++ b/iris-visualizer/src/test/resources/cfa/vo/iris/fitting/fit.output
@@ -26,3 +26,8 @@ Fit Results:
 
 		                 Optimizer = LevenbergMarquardt
 		 Statistic (Cost function) = LeastSquares
+
+Confidence Limits at 1.60 sigma (96.30%):
+                   m1.c0: (-1.00000E-01,  1.00000E-01)
+                   m1.c1: (-2.00000E-01,  2.00000E-01)
+                   m2.c2: (-3.00000E-01,  3.00000E-01)

--- a/iris-visualizer/src/test/resources/cfa/vo/iris/fitting/fit.output
+++ b/iris-visualizer/src/test/resources/cfa/vo/iris/fitting/fit.output
@@ -1,5 +1,5 @@
 Iris Fitting Tool - Fit Summary
-SED ID: MySed
+SED ID: MySed (Segments: 3)
 
 Model Expression: m1+m2
 Components:

--- a/iris-visualizer/src/test/resources/cfa/vo/iris/fitting/fit.output
+++ b/iris-visualizer/src/test/resources/cfa/vo/iris/fitting/fit.output
@@ -1,8 +1,12 @@
 Iris Fitting Tool - Fit Summary
 SED ID: MySed (Segments: 3)
 
-Model Expression: m1+m2
+Model Expression: m1+m2+m3
 Components:
+	tablemodel.m3
+		                     m3.p1 =  1.00000E-01 Frozen
+		                     m3.p2 =  2.00000E-01
+		                     m3.p3 =  3.00000E-01
 	polynomial.m1
 		                     m1.c0 =  1.00000E-01
 		                     m1.c1 =  2.00000E-01
@@ -31,3 +35,6 @@ Confidence Limits at 1.60 sigma (96.30%):
                    m1.c0: (-1.00000E-01,  1.00000E-01)
                    m1.c1: (-2.00000E-01,  2.00000E-01)
                    m2.c2: (-3.00000E-01,  3.00000E-01)
+
+User Models:
+		function.m3: (file: file://somewhere/on/disk, function: somefunc)

--- a/iris-visualizer/src/test/resources/cfa/vo/iris/visualizer/fit.output
+++ b/iris-visualizer/src/test/resources/cfa/vo/iris/visualizer/fit.output
@@ -1,0 +1,26 @@
+Iris Fitting Tool - Fit Summary
+SED ID: TestSed (Segments: 0)
+
+Model Expression: m
+Components:
+	polynomial.m
+		                      m.c0 =  1.00000E+00
+		                      m.c1 =  0.00000E+00
+		                      m.c2 =  0.00000E+00 Frozen
+		                      m.c3 =  0.00000E+00 Frozen
+		                      m.c4 =  0.00000E+00 Frozen
+		                      m.c5 =  0.00000E+00 Frozen
+		                  m.offset =  0.00000E+00 Frozen
+
+Fit Results:
+		       Final Fit Statistic =         NULL
+		         Reduced Statistic =         NULL
+		     Probability (Q-value) =         NULL
+		        Degrees of Freedom = null
+		               Data Points = null
+		      Function Evaluations = null
+
+		                 Optimizer = LevenbergMarquardt
+		 Statistic (Cost function) = LeastSquares
+
+User Models:

--- a/iris/src/test/java/cfa/vo/iris/fitting/FittingFunctionalIT.java
+++ b/iris/src/test/java/cfa/vo/iris/fitting/FittingFunctionalIT.java
@@ -11,15 +11,19 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.uispec4j.*;
 import org.uispec4j.assertion.UISpecAssert;
+import org.uispec4j.interception.FileChooserHandler;
 import org.uispec4j.interception.PopupMenuInterceptor;
 import org.uispec4j.interception.WindowHandler;
 import org.uispec4j.interception.WindowInterceptor;
 
+import java.io.File;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+
+import static org.junit.Assert.assertEquals;
 
 public class FittingFunctionalIT extends AbstractUISpecTest {
     @Rule
@@ -70,6 +74,20 @@ public class FittingFunctionalIT extends AbstractUISpecTest {
         setupModelExpression();
         fit();
         fitCustomModel();
+        saveText();
+    }
+
+    private void saveText() throws Exception {
+        File outputFile = tempFolder.newFile("output.fit");
+
+        WindowInterceptor
+                .init(fittingView.getMenuBar().getMenu("File").getSubMenu("Save Text...").triggerClick())
+                .process(FileChooserHandler.init().select(outputFile.getAbsolutePath()))
+                .run()
+        ;
+
+        String expected = TestUtils.readFile(getClass(), "fit.output");
+        assertEquals(expected, com.google.common.io.Files.toString(outputFile, Charset.defaultCharset()));
     }
 
     private void installModels() throws Exception {

--- a/iris/src/test/java/cfa/vo/iris/fitting/FittingFunctionalIT.java
+++ b/iris/src/test/java/cfa/vo/iris/fitting/FittingFunctionalIT.java
@@ -87,7 +87,10 @@ public class FittingFunctionalIT extends AbstractUISpecTest {
         ;
 
         String expected = TestUtils.readFile(getClass(), "fit.output");
-        assertEquals(expected, com.google.common.io.Files.toString(outputFile, Charset.defaultCharset()));
+        String actual = com.google.common.io.Files.toString(outputFile, Charset.defaultCharset());
+        actual = actual.replaceAll("(/home/.*?/|/Users/.*?/)", "\\$HOME/");
+
+        assertEquals(expected, actual);
     }
 
     private void installModels() throws Exception {

--- a/iris/src/test/resources/cfa/vo/iris/fitting/fit.output
+++ b/iris/src/test/resources/cfa/vo/iris/fitting/fit.output
@@ -1,0 +1,34 @@
+Iris Fitting Tool - Fit Summary
+SED ID: Sed (Segments: 1)
+
+Model Expression: m6 + m7 + m8
+Components:
+	tablemodel.m6
+		                   m6.ampl =  1.00000E-38
+	usermodel.m7
+		                    m7.ref =  5.00000E+03 Frozen
+		                   m7.ampl =  1.00000E-38
+		                  m7.index = -4.08735E-01
+	template.m8
+		                    m8.idx = -3.75000E-01
+		                  m8.refer =  5.00000E+03
+
+Fit Results:
+		       Final Fit Statistic =  2.01188E+20
+		         Reduced Statistic =  5.61977E+17
+		     Probability (Q-value) =  0.00000E+00
+		        Degrees of Freedom = 358
+		               Data Points = 363
+		      Function Evaluations = 48
+
+		                 Optimizer = LevenbergMarquardt
+		 Statistic (Cost function) = Chi2
+
+Confidence Limits at 1.64 sigma (90.00%):
+                 m5.ampl: (-8.48169E-18,  6.44529E-18)
+                m5.index: (-7.27584E-06,          NAN)
+
+User Models:
+		tablemodel.m6: (file: /home/olaurino/.vao/iris/analysis/custom_models/tables/test_table, function: None)
+		usermodel.m7: (file: /home/olaurino/.vao/iris/analysis/custom_models/functions/test_function, function: mypowlaw)
+		template.m8: (file: /home/olaurino/.vao/iris/analysis/custom_models/templates/test_template, function: None)

--- a/iris/src/test/resources/cfa/vo/iris/fitting/fit.output
+++ b/iris/src/test/resources/cfa/vo/iris/fitting/fit.output
@@ -29,6 +29,6 @@ Confidence Limits at 1.64 sigma (90.00%):
                 m5.index: (-7.27584E-06,          NAN)
 
 User Models:
-		tablemodel.m6: (file: /home/olaurino/.vao/iris/analysis/custom_models/tables/test_table, function: None)
-		usermodel.m7: (file: /home/olaurino/.vao/iris/analysis/custom_models/functions/test_function, function: mypowlaw)
-		template.m8: (file: /home/olaurino/.vao/iris/analysis/custom_models/templates/test_template, function: None)
+		tablemodel.m6: (file: $HOME/.vao/iris/analysis/custom_models/tables/test_table, function: None)
+		usermodel.m7: (file: $HOME/.vao/iris/analysis/custom_models/functions/test_function, function: mypowlaw)
+		template.m8: (file: $HOME/.vao/iris/analysis/custom_models/templates/test_template, function: None)

--- a/samp-factory/src/main/java/cfa/vo/sherpa/models/DefaultModel.java
+++ b/samp-factory/src/main/java/cfa/vo/sherpa/models/DefaultModel.java
@@ -144,14 +144,21 @@ public class DefaultModel implements Model {
 
         builder.append("\t").append(model.getName()).append("\n");
         for (Parameter p : model.getPars()) {
-            builder.append(formatDouble(p.getName(), p.getVal()));
+            appendParamToString(p, builder);
         }
 
         return builder.toString();
     }
 
-    private static String formatDouble(String name, Double value) {
-        return String.format("\t\t%26s = %f\n", name, value);
+    private static void appendParamToString(Parameter p, StringBuilder builder) {
+        String name = p.getName();
+        Double value = p.getVal();
+        String frozen = p.getFrozen() == 1 ? " Frozen" : "";
+
+        builder
+                .append(String.format("\t\t%26s = %12.5E%s",name, value, frozen))
+                .append("\n");
+        ;
     }
 
     private static String findId(String name) {

--- a/samp-factory/src/main/java/cfa/vo/sherpa/models/DefaultModel.java
+++ b/samp-factory/src/main/java/cfa/vo/sherpa/models/DefaultModel.java
@@ -132,8 +132,10 @@ public class DefaultModel implements Model {
                 .append("Components:\n");
 
 
-        for (Model m : model.getParts()) {
-            builder.append(toString(m));
+        if (model.getParts() != null) {
+            for (Model m : model.getParts()) {
+                builder.append(toString(m));
+            }
         }
 
         return builder.toString();

--- a/samp-factory/src/main/java/cfa/vo/sherpa/models/DefaultModel.java
+++ b/samp-factory/src/main/java/cfa/vo/sherpa/models/DefaultModel.java
@@ -125,6 +125,35 @@ public class DefaultModel implements Model {
         return findId(m.getName());
     }
 
+    public static String toString(CompositeModel model) {
+        StringBuilder builder = new StringBuilder();
+
+        builder.append("Model Expression: ").append(model.getName()).append("\n")
+                .append("Components:\n");
+
+
+        for (Model m : model.getParts()) {
+            builder.append(toString(m));
+        }
+
+        return builder.toString();
+    }
+
+    private static String toString(Model model) {
+        StringBuilder builder = new StringBuilder();
+
+        builder.append("\t").append(model.getName()).append("\n");
+        for (Parameter p : model.getPars()) {
+            builder.append(formatDouble(p.getName(), p.getVal()));
+        }
+
+        return builder.toString();
+    }
+
+    private static String formatDouble(String name, Double value) {
+        return String.format("\t\t%26s = %f\n", name, value);
+    }
+
     private static String findId(String name) {
         String [] tokens = StringUtils.split(name, ".");
         if (tokens.length > 1) {


### PR DESCRIPTION
I will issue smaller PRs against the iris-dev-45 branch. That can't be a PR just yet because it doesn't have a diff with sprint-9.

# Description
This PR addresses part of chandracxc/iris-dev#45 by allowing users to save fit results in human readable text files. In particular, it fulfills req 2.2.b.1.

The only, small improvement I would like to make (pending review) is to add a timestamp when the file is saved, although we should really have a timestamp for fits.

This implementation has several improvements over the Iris 2.1 code. It includes data about the user models, as well as information regarding the optimizer and the cost function, which were missing in the old implementation.

Also, after an iteration with @jbudynk we decided to include all models in the output, without making a distinction between active and inactive components.