### PR TITLE
iris-dev#51,52,58 Sorting and Extraction in the Metadata Browser

### DIFF
--- a/iris-common/src/main/java/cfa/vo/iris/sed/stil/SegmentStarTable.java
+++ b/iris-common/src/main/java/cfa/vo/iris/sed/stil/SegmentStarTable.java
@@ -178,6 +178,10 @@ public class SegmentStarTable extends RandomStarTable {
         }
     }
     
+    public Segment getSegment() {
+        return segment;
+    }
+    
     /**
      * Sets the spectral axis units for this star table, which updates all spectral
      * valued columns in the table. As this may also alter the flux axis units,

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/masks/RowSubsetMask.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/masks/RowSubsetMask.java
@@ -15,7 +15,6 @@
  */
 package cfa.vo.iris.visualizer.masks;
 
-import java.util.Arrays;
 import java.util.BitSet;
 
 import cfa.vo.iris.visualizer.stil.tables.IrisStarTable;
@@ -66,7 +65,7 @@ public class RowSubsetMask implements Mask {
     @Override
     public void clearMasks(int[] rows) {
         for (int i : rows) {
-            if (i > table.getSegmentMetadataTable().getRowCount()) continue;
+            if (i > table.getBaseTable().getRowCount()) continue;
             mask.clear(i);
         }
     }
@@ -78,7 +77,7 @@ public class RowSubsetMask implements Mask {
     @Override
     public void applyMasks(int[] rows) {
         for (int i : rows) {
-            if (i > table.getSegmentMetadataTable().getRowCount()) continue;
+            if (i > table.getBaseTable().getRowCount()) continue;
             mask.set(i);
         }
     }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.form
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.form
@@ -14,6 +14,9 @@
               <Properties>
                 <Property name="text" type="java.lang.String" value="Extract to New SED"/>
               </Properties>
+              <Events>
+                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="extractToSedMenuItemActionPerformed"/>
+              </Events>
             </MenuItem>
             <MenuItem class="javax.swing.JMenuItem" name="broadcastToSampMenuItem">
               <Properties>

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.form
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.form
@@ -151,7 +151,7 @@
       </Properties>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="2" gridY="1" gridWidth="2" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="5" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="13" weightX="0.1" weightY="0.0"/>
+          <GridBagConstraints gridX="2" gridY="1" gridWidth="3" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="5" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="13" weightX="0.1" weightY="0.0"/>
         </Constraint>
       </Constraints>
     </Component>
@@ -165,7 +165,7 @@
       </Properties>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="4" gridY="1" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="5" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="17" weightX="0.0" weightY="0.0"/>
+          <GridBagConstraints gridX="5" gridY="1" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="5" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="17" weightX="0.0" weightY="0.0"/>
         </Constraint>
       </Constraints>
     </Component>
@@ -183,7 +183,7 @@
       </Events>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="4" gridY="2" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="5" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="17" weightX="0.0" weightY="0.0"/>
+          <GridBagConstraints gridX="5" gridY="2" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="5" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="17" weightX="0.0" weightY="0.0"/>
         </Constraint>
       </Constraints>
     </Component>
@@ -201,6 +201,20 @@
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
           <GridBagConstraints gridX="0" gridY="2" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="5" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="13" weightX="0.0" weightY="0.0"/>
+        </Constraint>
+      </Constraints>
+    </Component>
+    <Component class="javax.swing.JButton" name="extractButton">
+      <Properties>
+        <Property name="text" type="java.lang.String" value="Extract"/>
+        <Property name="toolTipText" type="java.lang.String" value="Extract selection to new SED"/>
+      </Properties>
+      <Events>
+        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="extractButtonActionPerformed"/>
+      </Events>
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+          <GridBagConstraints gridX="3" gridY="2" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="16" weightX="0.0" weightY="0.0"/>
         </Constraint>
       </Constraints>
     </Component>
@@ -253,7 +267,7 @@
       </Events>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="5" gridY="2" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="5" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="17" weightX="0.0" weightY="0.0"/>
+          <GridBagConstraints gridX="6" gridY="2" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="5" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="17" weightX="0.0" weightY="0.0"/>
         </Constraint>
       </Constraints>
     </Component>
@@ -271,7 +285,7 @@
       </Events>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="6" gridY="2" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="5" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="17" weightX="0.0" weightY="0.0"/>
+          <GridBagConstraints gridX="7" gridY="2" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="5" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="17" weightX="0.0" weightY="0.0"/>
         </Constraint>
       </Constraints>
     </Component>
@@ -287,7 +301,7 @@
       </Properties>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="0" gridY="0" gridWidth="7" gridHeight="1" fill="1" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="1.0" weightY="1.0"/>
+          <GridBagConstraints gridX="0" gridY="0" gridWidth="8" gridHeight="1" fill="1" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="1.0" weightY="1.0"/>
         </Constraint>
       </Constraints>
 

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.form
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.form
@@ -385,6 +385,9 @@
                         <Property name="columnInfoMatcher" type="cfa.vo.iris.visualizer.stil.tables.ColumnInfoMatcher" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
                           <Connection code="new SegmentColumnInfoMatcher()" type="code"/>
                         </Property>
+                        <Property name="sortBySpecValues" type="boolean" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+                          <Connection code="true" type="code"/>
+                        </Property>
                       </Properties>
                       <BindingProperties>
                         <BindingProperty name="selectedStarTables" source="Form" sourcePath="${selectedStarTables}" target="plotterStarJTable" targetPath="selectedStarTables" updateStrategy="0" immediately="false"/>
@@ -428,12 +431,14 @@
                         <Property name="columnInfoMatcher" type="cfa.vo.iris.visualizer.stil.tables.ColumnInfoMatcher" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
                           <Connection code="new UtypeColumnInfoMatcher()" type="code"/>
                         </Property>
+                        <Property name="sortBySpecValues" type="boolean" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+                          <Connection code="false" type="code"/>
+                        </Property>
                         <Property name="usePlotterDataTables" type="boolean" value="false"/>
                         <Property name="utypeAsNames" type="boolean" value="true"/>
                       </Properties>
                       <BindingProperties>
                         <BindingProperty name="selectedStarTables" source="Form" sourcePath="${selectedStarTables}" target="pointStarJTable" targetPath="selectedStarTables" updateStrategy="0" immediately="false"/>
-                        <BindingProperty name="selectionModel" source="plotterStarJTable" sourcePath="${selectionModel}" target="pointStarJTable" targetPath="selectionModel" updateStrategy="0" immediately="false"/>
                       </BindingProperties>
                     </Component>
                   </SubComponents>

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.java
@@ -295,6 +295,7 @@ public class MetadataBrowserMainView extends javax.swing.JInternalFrame {
         selectPointsButton = new javax.swing.JButton();
         applyMaskButton = new javax.swing.JButton();
         selectAllButton = new javax.swing.JButton();
+        extractButton = new javax.swing.JButton();
         clearSelectionButton = new javax.swing.JButton();
         invertSelectionButton = new javax.swing.JButton();
         clearMaskButton = new javax.swing.JButton();
@@ -345,7 +346,7 @@ public class MetadataBrowserMainView extends javax.swing.JInternalFrame {
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 2;
         gridBagConstraints.gridy = 1;
-        gridBagConstraints.gridwidth = 2;
+        gridBagConstraints.gridwidth = 3;
         gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.EAST;
         gridBagConstraints.weightx = 0.1;
@@ -356,7 +357,7 @@ public class MetadataBrowserMainView extends javax.swing.JInternalFrame {
         selectPointsButton.setText("Select Points");
         selectPointsButton.setToolTipText("Select points matching the filter expression");
         gridBagConstraints = new java.awt.GridBagConstraints();
-        gridBagConstraints.gridx = 4;
+        gridBagConstraints.gridx = 5;
         gridBagConstraints.gridy = 1;
         gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
@@ -373,7 +374,7 @@ public class MetadataBrowserMainView extends javax.swing.JInternalFrame {
             }
         });
         gridBagConstraints = new java.awt.GridBagConstraints();
-        gridBagConstraints.gridx = 4;
+        gridBagConstraints.gridx = 5;
         gridBagConstraints.gridy = 2;
         gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
@@ -395,6 +396,20 @@ public class MetadataBrowserMainView extends javax.swing.JInternalFrame {
         gridBagConstraints.anchor = java.awt.GridBagConstraints.EAST;
         gridBagConstraints.insets = new java.awt.Insets(5, 0, 0, 0);
         getContentPane().add(selectAllButton, gridBagConstraints);
+
+        extractButton.setText("Extract");
+        extractButton.setToolTipText("Extract selection to new SED");
+        extractButton.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                extractButtonActionPerformed(evt);
+            }
+        });
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 3;
+        gridBagConstraints.gridy = 2;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.SOUTHWEST;
+        getContentPane().add(extractButton, gridBagConstraints);
 
         clearSelectionButton.setFont(new java.awt.Font("DejaVu Sans", 0, 12)); // NOI18N
         clearSelectionButton.setText("Clear Selection");
@@ -439,7 +454,7 @@ public class MetadataBrowserMainView extends javax.swing.JInternalFrame {
             }
         });
         gridBagConstraints = new java.awt.GridBagConstraints();
-        gridBagConstraints.gridx = 5;
+        gridBagConstraints.gridx = 6;
         gridBagConstraints.gridy = 2;
         gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
@@ -456,7 +471,7 @@ public class MetadataBrowserMainView extends javax.swing.JInternalFrame {
             }
         });
         gridBagConstraints = new java.awt.GridBagConstraints();
-        gridBagConstraints.gridx = 6;
+        gridBagConstraints.gridx = 7;
         gridBagConstraints.gridy = 2;
         gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
@@ -570,7 +585,7 @@ public class MetadataBrowserMainView extends javax.swing.JInternalFrame {
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 0;
-        gridBagConstraints.gridwidth = 7;
+        gridBagConstraints.gridwidth = 8;
         gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
         gridBagConstraints.weightx = 1.0;
         gridBagConstraints.weighty = 1.0;
@@ -734,6 +749,10 @@ public class MetadataBrowserMainView extends javax.swing.JInternalFrame {
         extractSelectionToSed();
     }//GEN-LAST:event_extractToSedMenuItemActionPerformed
 
+    private void extractButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_extractButtonActionPerformed
+        extractSelectionToSed();
+    }//GEN-LAST:event_extractButtonActionPerformed
+
     private void selectAllButtonActionPerformed(
             java.awt.event.ActionEvent evt) {// GEN-FIRST:event_selectAllButtonActionPerformed
         JTable table = getSelectedJTable();
@@ -776,6 +795,7 @@ public class MetadataBrowserMainView extends javax.swing.JInternalFrame {
     private javax.swing.JSplitPane dataPane;
     private javax.swing.JTabbedPane dataTabsPane;
     private javax.swing.JMenu editMenu;
+    private javax.swing.JButton extractButton;
     private javax.swing.JMenuItem extractToSedMenuItem;
     private javax.swing.JMenu fileMenu;
     private javax.swing.JTextField filterExpressionField;

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.java
@@ -16,7 +16,6 @@
 package cfa.vo.iris.visualizer.metadata;
 
 import java.awt.Component;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.swing.JLabel;
@@ -41,9 +40,6 @@ import cfa.vo.iris.visualizer.stil.IrisStarJTable.RowSelection;
 import cfa.vo.iris.visualizer.stil.tables.IrisStarTable;
 import cfa.vo.iris.visualizer.stil.tables.SegmentColumnInfoMatcher;
 import cfa.vo.iris.visualizer.stil.tables.UtypeColumnInfoMatcher;
-import cfa.vo.sedlib.common.SedInconsistentException;
-import cfa.vo.sedlib.common.SedNoDataException;
-
 import java.util.LinkedList;
 import java.util.List;
 import uk.ac.starlink.table.StarTable;
@@ -188,22 +184,9 @@ public class MetadataBrowserMainView extends javax.swing.JInternalFrame {
             return;
         }
         
-        // Extract selected rows to new Segments
-        SegmentExtractor extractor = new SegmentExtractor(selectedStarTables, selectedRows);
-        ExtSed newSed = new ExtSed(selectedSed.getId());
-        
-        // Build a new SED
-        try {
-            newSed.addSegment(extractor.getSegments());
-        } catch (SedInconsistentException | SedNoDataException e) {
-            logger.log(Level.SEVERE, "Could not extract segments from SED", e);
-            JOptionPane.showMessageDialog(this, "ERROR:" + e.getMessage(), 
-                    null, JOptionPane.ERROR_MESSAGE);
-            throw new RuntimeException(e);
-        }
-        
-//        ws.getSedManager().add(newSed);
-        JOptionPane.showMessageDialog(this, "Added new SED to workspace. ID: " + newSed.getId());
+        logger.info(String.format("Extracting %s points from Sed.", selectedRows.length));
+        preferences.createNewWorkspaceSed(selectedStarTables, selectedRows);
+        JOptionPane.showMessageDialog(this, "Added new Filter SED to workspace.");
     }
     
     /*

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.java
@@ -110,7 +110,10 @@ public class MetadataBrowserMainView extends javax.swing.JInternalFrame {
     
     /**
      * Specifies a star table (by index) and a row to be added to the selected plotter/
-     * data table tabs' row selections.
+     * data table tabs' row selections. Note that irow is the row in the Base Table of the
+     * IrisStarTable - not of the masked star table! Any callers specifying rows based
+     * on the IrisStarTable must use .getBaseTableRow in IrisStarTable to map the masked
+     * row index back to the base table row index before calling this method.
      * 
      * @param starTableIndex - index of the star table in the selectedTables list.
      * @param irow - row to be selected in the star table.

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.java
@@ -16,10 +16,12 @@
 package cfa.vo.iris.visualizer.metadata;
 
 import java.awt.Component;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.swing.JLabel;
 import javax.swing.JList;
+import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
@@ -39,6 +41,8 @@ import cfa.vo.iris.visualizer.stil.IrisStarJTable.RowSelection;
 import cfa.vo.iris.visualizer.stil.tables.IrisStarTable;
 import cfa.vo.iris.visualizer.stil.tables.SegmentColumnInfoMatcher;
 import cfa.vo.iris.visualizer.stil.tables.UtypeColumnInfoMatcher;
+import cfa.vo.sedlib.common.SedInconsistentException;
+import cfa.vo.sedlib.common.SedNoDataException;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -163,7 +167,43 @@ public class MetadataBrowserMainView extends javax.swing.JInternalFrame {
         }
         setSelectedStarTables(newTables);
     }
-    
+
+    /**
+     * Extracts the selected rows in the Metadata browser to a new SED, then adds the SED to the
+     * SedManager through the Iris Workspace.
+     * 
+     */
+    private void extractSelectionToSed() {
+        
+        // Do nothing if no SED is selected
+        if (selectedSed == null) {
+            JOptionPane.showMessageDialog(this, "No SED in browser. Please load an SED.");
+            return;
+        }
+        
+        // Do nothing if there are no rows selected
+        int[] selectedRows = plotterStarJTable.getSelectedRows();
+        if (selectedRows == null || selectedRows.length == 0) {
+            JOptionPane.showMessageDialog(this, "No rows selected to extract. Please select rows.");
+            return;
+        }
+        
+        // Extract selected rows to new Segments
+        SegmentExtractor extractor = new SegmentExtractor(selectedStarTables, selectedRows);
+        ExtSed newSed = new ExtSed(selectedSed.getId());
+        
+        // Build a new SED
+        try {
+            newSed.addSegment(extractor.getSegments());
+        } catch (SedInconsistentException | SedNoDataException e) {
+            logger.log(Level.SEVERE, "Could not extract segments from SED", e);
+            JOptionPane.showMessageDialog(this, "ERROR:" + e.getMessage(), 
+                    null, JOptionPane.ERROR_MESSAGE);
+            throw new RuntimeException(e);
+        }
+        
+        JOptionPane.showMessageDialog(this, "Adding new SED to workspace.");
+    }
     
     /*
      * getters and setters
@@ -549,6 +589,11 @@ public class MetadataBrowserMainView extends javax.swing.JInternalFrame {
         fileMenu.setName("Extract"); // NOI18N
 
         extractToSedMenuItem.setText("Extract to New SED");
+        extractToSedMenuItem.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                extractToSedMenuItemActionPerformed(evt);
+            }
+        });
         fileMenu.add(extractToSedMenuItem);
 
         broadcastToSampMenuItem.setText("Broadcast to SAMP");
@@ -693,6 +738,10 @@ public class MetadataBrowserMainView extends javax.swing.JInternalFrame {
         IrisStarTable.clearAllMasks(sedStarTables);
         VisualizerChangeEvent.getInstance().fire(selectedSed, VisualizerCommand.REDRAW);
     }//GEN-LAST:event_clearAllButtonActionPerformed
+
+    private void extractToSedMenuItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_extractToSedMenuItemActionPerformed
+        extractSelectionToSed();
+    }//GEN-LAST:event_extractToSedMenuItemActionPerformed
 
     private void selectAllButtonActionPerformed(
             java.awt.event.ActionEvent evt) {// GEN-FIRST:event_selectAllButtonActionPerformed

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.java
@@ -177,15 +177,22 @@ public class MetadataBrowserMainView extends javax.swing.JInternalFrame {
             return;
         }
         
+        // Cannot extract from segment tab
+        IrisStarJTable jtable = getSelectedIrisJTable();
+        if (jtable == null) {
+            JOptionPane.showMessageDialog(this, "Select either Data or Point Metadata tab.");
+            return;
+        }
+        
         // Do nothing if there are no rows selected
-        int[] selectedRows = plotterStarJTable.getSelectedRows();
-        if (selectedRows == null || selectedRows.length == 0) {
+        RowSelection selectedRows = jtable.getRowSelection();
+        if (selectedRows == null || selectedRows.originalRows.length == 0) {
             JOptionPane.showMessageDialog(this, "No rows selected to extract. Please select rows.");
             return;
         }
         
-        logger.info(String.format("Extracting %s points from Sed.", selectedRows.length));
-        preferences.createNewWorkspaceSed(selectedStarTables, selectedRows);
+        logger.info(String.format("Extracting %s points from Sed.", selectedRows.originalRows.length));
+        preferences.createNewWorkspaceSed(selectedRows);
         JOptionPane.showMessageDialog(this, "Added new Filter SED to workspace.");
     }
     

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.java
@@ -202,7 +202,8 @@ public class MetadataBrowserMainView extends javax.swing.JInternalFrame {
             throw new RuntimeException(e);
         }
         
-        JOptionPane.showMessageDialog(this, "Adding new SED to workspace.");
+//        ws.getSedManager().add(newSed);
+        JOptionPane.showMessageDialog(this, "Added new SED to workspace. ID: " + newSed.getId());
     }
     
     /*

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/SegmentExtractor.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/SegmentExtractor.java
@@ -19,13 +19,15 @@ public class SegmentExtractor {
     
     private final int[][]  selectedRows;
     private final IrisStarTable[] selectedTables;
+    private final ExtSed sed;
     
     /**
      * @param tables - List of IrisStarTables, in order
      * @param selection - Array of selected ine in the tables, if they were stacked on top of 
      *                  each other.
+     * @param newSed - new Sed to add segments to.
      */
-    public SegmentExtractor(IrisStarTable[] tables, int[][] selection) {
+    public SegmentExtractor(IrisStarTable[] tables, int[][] selection, ExtSed newSed) {
         
         if (tables == null || selection == null) {
             throw new IllegalArgumentException("Neither tables nor selection can be null");
@@ -37,6 +39,7 @@ public class SegmentExtractor {
         
         this.selectedTables = tables;
         this.selectedRows = selection;
+        this.sed = newSed;
     }
     
 
@@ -44,9 +47,7 @@ public class SegmentExtractor {
     /**
      * Process and create a list of Segments with subsets of points.
      */
-    public ExtSed constructSed() throws SedInconsistentException, SedNoDataException {
-        
-        ExtSed sed = new ExtSed("FilterSed", false);
+    public void constructSed() throws SedInconsistentException, SedNoDataException {
 
         // Iterate over each row in the selection, and make a new segment as
         // necessary.
@@ -57,15 +58,13 @@ public class SegmentExtractor {
             Segment newSegment = processTable(table, rows);
             
             if (newSegment != null) {
-                sed.addSegment(newSegment);
+                sed.addSegment(newSegment, sed.getNumberOfSegments());
             }
         }
         
         // TODO: Investigate which fields need to be checked and adjusted in the
         // new sed. Then either uncomment this or set them elsewhere.
         // sed.checkChar();
-        
-        return sed;
     }
     
     private Segment processTable(IrisStarTable table, int[] rows) {

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/SegmentExtractor.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/SegmentExtractor.java
@@ -74,7 +74,7 @@ public class SegmentExtractor {
         // Mark the index of the end of this table in the selection
         long end = table.getRowCount() + tableStart;
         
-        Segment oldSegment = table.getPlotterTable().getSegment();
+        Segment oldSegment = table.getPlotterDataTable().getSegment();
         List<Point> oldPoints = oldSegment.getData().getPoint();
         List<Point> newPoints = new ArrayList<>();
         

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/SegmentExtractor.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/SegmentExtractor.java
@@ -1,0 +1,127 @@
+package cfa.vo.iris.visualizer.metadata;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
+import cfa.vo.iris.visualizer.stil.tables.IrisStarTable;
+import cfa.vo.sedlib.ArrayOfPoint;
+import cfa.vo.sedlib.Characterization;
+import cfa.vo.sedlib.CoordSys;
+import cfa.vo.sedlib.Curation;
+import cfa.vo.sedlib.DataID;
+import cfa.vo.sedlib.DerivedData;
+import cfa.vo.sedlib.Point;
+import cfa.vo.sedlib.Segment;
+import cfa.vo.sedlib.Target;
+import cfa.vo.sedlib.TextParam;
+
+/**
+ * Used to extract a list of segments from a list of IrisStarTables and selected
+ * indicies in those StarTables.
+ *
+ */
+public class SegmentExtractor {
+    
+    private List<IrisStarTable> tables;
+    private int[] selection;
+    
+    // Current position in iterating over the selection list
+    private int index;
+    
+    /**
+     * @param tables - List of IrisStarTables, in order
+     * @param selection - Array of selected indicies in the tables, if they were stacked on top of 
+     *                  each other.
+     */
+    public SegmentExtractor(List<IrisStarTable> tables, int[] selection) {
+        
+        if (tables == null) {
+            throw new IllegalArgumentException("Tables cannot be null");
+        }
+        if (selection == null) {
+            throw new IllegalArgumentException("List of points cannot be null");
+        }
+        
+        this.index = 0;
+        this.tables = tables;
+        this.selection = selection;
+        Arrays.sort(selection);
+    }
+    
+    /**
+     * Process and create a list of Segments with subsets of points.
+     */
+    public List<Segment> getSegments() {
+        // Iterate over each row in the selection, and make a new segment as
+        // necessary.
+        
+        List<Segment> newSegments = new LinkedList<>();
+        
+        // Current starting index of the table in our list of tables
+        int tableStart = 0;
+        for (IrisStarTable table : tables) {
+            newSegments.add(processTable(tableStart, table));
+            tableStart = tableStart + (int) table.getRowCount();
+        }
+        
+        return newSegments;
+    }
+    
+    private Segment processTable(int tableStart, IrisStarTable table) {
+        
+        // Mark the index of the end of this table in the selection
+        long end = table.getRowCount() + tableStart;
+        
+        Segment oldSegment = table.getPlotterTable().getSegment();
+        List<Point> oldPoints = oldSegment.getData().getPoint();
+        List<Point> newPoints = new ArrayList<>();
+        
+        while (index < selection.length && selection[index] < end) {
+            newPoints.add(oldPoints.get(selection[index] - tableStart));
+            index++;
+        }
+        
+        Segment newSegment = copySegmentMetadata(oldSegment, newPoints);
+        return newSegment;
+    }
+    
+    /**
+     * Copies everything except for the point data into a new segment. ArrayOfPoints
+     * may be huge, so this is more efficient than cloning.
+     * 
+     */
+    private Segment copySegmentMetadata(Segment oldSegment, List<Point> newPoints) {
+        
+        Segment segment = new Segment();
+        
+        if (oldSegment.isSetTarget())
+            segment.setTarget((Target) oldSegment.getTarget().clone());
+        if (oldSegment.isSetChar())
+            segment.setChar((Characterization) oldSegment.getChar().clone());
+        if (oldSegment.isSetCoordSys())
+            segment.setCoordSys((CoordSys)oldSegment.getCoordSys().clone());
+        if (oldSegment.isSetCuration())
+            segment.setCuration((Curation)oldSegment.getCuration().clone());
+        if (oldSegment.isSetDataID())
+            segment.setDataID((DataID)oldSegment.getDataID().clone());
+        if (oldSegment.isSetDerived())
+            segment.setDerived((DerivedData)oldSegment.createDerived().clone());
+        if (oldSegment.isSetType())
+            segment.setType((TextParam)oldSegment.getType().clone());
+        if (oldSegment.isSetTimeSI())
+            segment.setTimeSI((TextParam)oldSegment.getTimeSI().clone());
+        if (oldSegment.isSetSpectralSI())
+            segment.setSpectralSI((TextParam)oldSegment.getSpectralSI().clone());
+        if (oldSegment.isSetFluxSI())
+            segment.setFluxSI((TextParam)oldSegment.getFluxSI().clone());
+        
+        ArrayOfPoint newData = new ArrayOfPoint();
+        newData.setPoint(newPoints);
+        segment.setData(newData);
+        
+        return segment;
+    }
+
+}

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/SegmentExtractor.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/SegmentExtractor.java
@@ -63,6 +63,10 @@ public class SegmentExtractor {
             tableStart = tableStart + (int) table.getRowCount();
         }
         
+        // TODO: Investigate which fields need to be checked and adjusted in the new sed.
+        // Then either uncomment this or set them elsewhere.
+        //sed.checkChar();
+        
         return sed;
     }
     

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/SegmentExtractor.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/SegmentExtractor.java
@@ -69,7 +69,9 @@ public class SegmentExtractor {
     private Segment processTable(int tableStart, IrisStarTable table) {
         
         // Mark the index of the end of this table in the selection
-        long end = table.getRowCount() + tableStart;
+        // Recall that masks shorten the rowCount of IrisStarTables, so to be
+        // consistent with masking we rely on the SegmentStarTable for indicies.
+        long end = table.getPlotterDataTable().getRowCount() + tableStart;
         
         Segment oldSegment = table.getPlotterDataTable().getSegment();
         List<Point> oldPoints = oldSegment.getData().getPoint();
@@ -81,6 +83,7 @@ public class SegmentExtractor {
             index++;
         }
         
+        // If no rows were selected from this table then we don't add it to the Sed
         if (newPoints.size() == 0) {
             return null;
         }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/SegmentExtractor.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/SegmentExtractor.java
@@ -1,7 +1,6 @@
 package cfa.vo.iris.visualizer.metadata;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import cfa.vo.iris.sed.ExtSed;
@@ -13,92 +12,85 @@ import cfa.vo.sedlib.common.SedNoDataException;
 
 /**
  * Used to extract a list of segments from a list of IrisStarTables and selected
- * indicies in those StarTables.
+ * indexes in those StarTables.
  *
  */
 public class SegmentExtractor {
     
-    private final List<IrisStarTable> tables;
-    private final int[] selection;
-    
-    // Current position in iterating over the selection list
-    private int index;
+    private final int[][]  selectedRows;
+    private final IrisStarTable[] selectedTables;
     
     /**
      * @param tables - List of IrisStarTables, in order
-     * @param selection - Array of selected indicies in the tables, if they were stacked on top of 
+     * @param selection - Array of selected ine in the tables, if they were stacked on top of 
      *                  each other.
      */
-    public SegmentExtractor(List<IrisStarTable> tables, int[] selection) {
+    public SegmentExtractor(IrisStarTable[] tables, int[][] selection) {
         
-        if (tables == null) {
-            throw new IllegalArgumentException("Tables cannot be null");
-        }
-        if (selection == null) {
-            throw new IllegalArgumentException("List of points cannot be null");
+        if (tables == null || selection == null) {
+            throw new IllegalArgumentException("Neither tables nor selection can be null");
         }
         
-        this.index = 0;
-        this.tables = tables;
-        this.selection = selection;
-        Arrays.sort(selection);
+        if (tables.length != selection.length) {
+            throw new IllegalArgumentException("Arrays must have equal length");
+        }
+        
+        this.selectedTables = tables;
+        this.selectedRows = selection;
     }
+    
+
     
     /**
      * Process and create a list of Segments with subsets of points.
      */
     public ExtSed constructSed() throws SedInconsistentException, SedNoDataException {
         
+        ExtSed sed = new ExtSed("FilterSed", false);
+
         // Iterate over each row in the selection, and make a new segment as
         // necessary.
-        ExtSed sed = new ExtSed("FilterSed", false);
-        
-        // Current starting index of the table in our list of tables
-        int tableStart = 0;
-        for (IrisStarTable table : tables) {
-            Segment newSegment = processTable(tableStart, table);
+        for (int i=0; i<selectedTables.length; i++) {
+            int[] rows = selectedRows[i];
+            IrisStarTable table = selectedTables[i];
+            
+            Segment newSegment = processTable(table, rows);
+            
             if (newSegment != null) {
                 sed.addSegment(newSegment);
             }
-            tableStart = tableStart + (int) table.getRowCount();
         }
         
-        // TODO: Investigate which fields need to be checked and adjusted in the new sed.
-        // Then either uncomment this or set them elsewhere.
-        //sed.checkChar();
+        // TODO: Investigate which fields need to be checked and adjusted in the
+        // new sed. Then either uncomment this or set them elsewhere.
+        // sed.checkChar();
         
         return sed;
     }
     
-    private Segment processTable(int tableStart, IrisStarTable table) {
+    private Segment processTable(IrisStarTable table, int[] rows) {
         
-        // Mark the index of the end of this table in the selection
-        // Recall that masks shorten the rowCount of IrisStarTables, so to be
-        // consistent with masking we rely on the SegmentStarTable for indicies.
-        long end = table.getPlotterDataTable().getRowCount() + tableStart;
-        
-        Segment oldSegment = table.getPlotterDataTable().getSegment();
-        List<Point> oldPoints = oldSegment.getData().getPoint();
-        List<Point> newPoints = new ArrayList<>();
-        
-        // The index in the star table is the selection index minus the start index
-        while (index < selection.length && selection[index] < end) {
-            newPoints.add(oldPoints.get(selection[index] - tableStart));
-            index++;
-        }
-        
-        // If no rows were selected from this table then we don't add it to the Sed
-        if (newPoints.size() == 0) {
+        // If there are no selected rows skip this segment
+        if (rows.length == 0) {
             return null;
         }
         
-        // Clone the old segment
-        Segment newSegment = (Segment) oldSegment.clone();
+        Segment originalSegment = table.getPlotterDataTable().getSegment();
+        List<Point> oldPoints = originalSegment.getData().getPoint();
+        List<Point> newPoints = new ArrayList<>(rows.length);
         
-        // Overwrite with new data
+        // Add selected datapoints to the new points list
+        for (int i : rows) {
+            newPoints.add(oldPoints.get(i));
+        }
+        
+        // Clone the old segment
+        Segment newSegment = (Segment) originalSegment.clone();
+        
+        // Replace point data
         newSegment.getData().setPoint(newPoints);
         
-        // Ask nicely if the system will clean up old data
+        // Ask nicely for the system to clean up old data
         System.gc();
         
         return newSegment;

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotPointSelectionListener.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotPointSelectionListener.java
@@ -29,6 +29,10 @@ public class PlotPointSelectionListener extends StilPlotterPointSelectionListene
     @Override
     public void handleSelection(int starTableIndex, int irow, PointSelectionEvent evt) {
         MetadataBrowserMainView mbView = this.getPlotterView().getMetadataBrowserView();
+        
+        // The plotter irow does not take into account masks, so we map it to the row in the
+        // base table before passing it to the metadata browser.
+        irow = mbView.getSelectedTables().get(starTableIndex).getBaseTableRow(irow);
         mbView.addRowToSelection(starTableIndex, irow);
     }
     

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedModel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedModel.java
@@ -117,12 +117,15 @@ public class SedModel {
         
         // If the segment is already in the map remake the star table
         if (segmentPreferences.containsKey(me)) {
-            segmentPreferences.get(me).setInSource(convertSegment(seg));
+            SegmentModel mod = segmentPreferences.get(me);
+            
+            // Need to preserve table name on reserialization
+            mod.setInSource(convertSegment(seg, mod.getInSource().getName()));
             return;
         }
         
         // Ensure that the layer has a unique identifier in the list of segments
-        SegmentModel layer = new SegmentModel(convertSegment(seg));
+        SegmentModel layer = new SegmentModel(convertSegment(seg, null));
         int count = 0;
         String id = layer.getSuffix();
         while (!isUniqueLayerSuffix(id)) {
@@ -145,12 +148,14 @@ public class SedModel {
         segmentPreferences.put(me, layer);
     }
     
-    private IrisStarTable convertSegment(Segment seg) {
+    private IrisStarTable convertSegment(Segment seg, String name) {
         // Convert segments with more than 3000 points asynchronously.
         if (seg.getLength() > 3000) {
-            return adapter.convertSegmentAsync(seg);
+            return adapter.convertSegmentAsync(seg, name);
         }
-        return adapter.convertSegment(seg);
+        IrisStarTable table = adapter.convertSegment(seg, name);
+        
+        return table;
     }
     
     /**

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerComponentPreferences.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerComponentPreferences.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 
 import cfa.vo.iris.IWorkspace;
 import cfa.vo.iris.events.MultipleSegmentEvent;
@@ -190,17 +189,21 @@ public class VisualizerComponentPreferences {
      */
     public ExtSed createNewWorkspaceSed(RowSelection selection) throws SedInconsistentException, SedNoDataException {
         
+        final ExtSed sed = (ExtSed) ws.getSedManager().newSed("FilterSed");
+        
         // Extract selected rows to new Segments
         final SegmentExtractor extractor = 
-                new SegmentExtractor(selection.selectedTables, selection.selectedRows);
+                new SegmentExtractor(selection.selectedTables, selection.selectedRows, sed);
         
-        try {
-            ExtSed newSed = extractor.constructSed();
-            ws.getSedManager().add(newSed);
-            return newSed;
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        visualizerExecutor.submit(new Callable<ExtSed>() {
+            @Override
+            public ExtSed call() throws Exception {
+                extractor.constructSed();
+                return null;
+            }
+        });
+        
+        return sed;
     }
 
     /**

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerComponentPreferences.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerComponentPreferences.java
@@ -38,7 +38,7 @@ import cfa.vo.iris.visualizer.plotter.MouseListenerManager;
 import cfa.vo.iris.visualizer.metadata.SegmentExtractor;
 import cfa.vo.iris.visualizer.plotter.PlotPreferences;
 import cfa.vo.iris.visualizer.plotter.SegmentModel;
-import cfa.vo.iris.visualizer.stil.tables.IrisStarTable;
+import cfa.vo.iris.visualizer.stil.IrisStarJTable.RowSelection;
 import cfa.vo.iris.visualizer.stil.tables.IrisStarTableAdapter;
 import cfa.vo.sedlib.Segment;
 
@@ -178,14 +178,15 @@ public class VisualizerComponentPreferences {
      * from the selected set of StarTables, then asynchronously pass it back to the 
      * SedManager and let the SedListener do the work of notifying/processing the 
      * new ExtSed back into the VisualizerComponent.
-     * @param tables
+     * 
      * @param selection
      * @return
      */
-    public void createNewWorkspaceSed(List<IrisStarTable> tables, int[] selection) {
+    public void createNewWorkspaceSed(RowSelection selection) {
         
         // Extract selected rows to new Segments
-        final SegmentExtractor extractor = new SegmentExtractor(tables, selection);
+        final SegmentExtractor extractor = 
+                new SegmentExtractor(selection.selectedTables, selection.selectedRows);
         
         visualizerExecutor.submit(new Callable<ExtSed>() {
             @SuppressWarnings("unchecked")

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/IrisStarJTable.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/IrisStarJTable.java
@@ -164,7 +164,7 @@ public class IrisStarJTable extends StarJTable {
             setUtypeColumnNames();
         }
     }
-    
+
     public List<IrisStarTable> getSelectedStarTables() {
         return selectedStarTables;
     }
@@ -265,6 +265,7 @@ public class IrisStarJTable extends StarJTable {
     }
     
     private void sortBySpectralValue(boolean showIndex) {
+        
         // Do nothing is we have no data
         if (getStarTable().getRowCount() <= 0) return;
         
@@ -282,9 +283,10 @@ public class IrisStarJTable extends StarJTable {
             TableRowSorter<?> sorter = (TableRowSorter<?>) getRowSorter();
             sorter.setSortKeys(Arrays.asList(new SortKey(col, SortOrder.ASCENDING)));
             sorter.sort();
+            
         } catch (IOException ex) {
             // Ignore these
-            logger.log(Level.WARNING, "Could not read spectral value column", ex);;
+            logger.log(Level.WARNING, "Could not read spectral value column", ex);
         }
     }
     
@@ -354,6 +356,7 @@ public class IrisStarJTable extends StarJTable {
         public final int[] originalRows;
         
         private RowSelection(List<IrisStarTable> tables, int[] rows) {
+            
             this.selectedRows = new int[tables.size()][];
             Arrays.fill(selectedRows, new int[0]);
             

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/IrisStarJTable.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/IrisStarJTable.java
@@ -356,7 +356,6 @@ public class IrisStarJTable extends StarJTable {
         public final int[] originalRows;
         
         private RowSelection(List<IrisStarTable> tables, int[] rows) {
-            
             this.selectedRows = new int[tables.size()][];
             Arrays.fill(selectedRows, new int[0]);
             

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/IrisStarJTable.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/IrisStarJTable.java
@@ -75,6 +75,8 @@ public class IrisStarJTable extends StarJTable {
         // By default we use use the plotter data, as it is generally available first
         columnInfoMatcher = new SegmentColumnInfoMatcher();
         usePlotterDataTables = true;
+        
+        // Tables support sorting
         setAutoCreateRowSorter(true);
     }
     
@@ -95,9 +97,7 @@ public class IrisStarJTable extends StarJTable {
      * @param selectedStarTables
      */
     public void setSelectedStarTables(List<IrisStarTable> selectedStarTables) {
-        if (selectedStarTables == null) {
-            return;
-        }
+        if (selectedStarTables == null) return;
         
         // Include the index column for non-null/non-empty star tables.
         boolean showIndex = (selectedStarTables.size() > 0);
@@ -116,7 +116,7 @@ public class IrisStarJTable extends StarJTable {
         this.setStarTable(new StackedStarTable(dataTables, columnInfoMatcher), showIndex);
         IrisStarJTable.configureColumnWidths(this, 200, 20);
         
-        // If usePlotterDataTables we resort by spectral value
+        // If specified we re-sort by spectral values
         if (sortBySpecValues) {
             sortBySpectralValue(showIndex);
         }
@@ -233,6 +233,9 @@ public class IrisStarJTable extends StarJTable {
     }
     
     private void sortBySpectralValue(boolean showIndex) {
+        // Do nothing is we have no data
+        if (getStarTable().getRowCount() <= 0) return;
+        
         try {
             ColumnIdentifier id = new ColumnIdentifier(getStarTable());
             int col = id.getColumnIndex(Column.Spectral_Value.name());
@@ -248,7 +251,9 @@ public class IrisStarJTable extends StarJTable {
             sorter.setSortKeys(Arrays.asList(new RowSorter.SortKey(col, SortOrder.ASCENDING)));
             sorter.sort();
         } catch (IOException ex) {
-            logger.log(Level.SEVERE, "Could not read spectral value column", ex);;
+            // Ignore these
+            ex.printStackTrace();
+            logger.log(Level.WARNING, "Could not read spectral value column", ex);;
         }
     }
     

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/StilPlotter.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/StilPlotter.java
@@ -245,6 +245,7 @@ public class StilPlotter extends JPanel {
     public void hideErrorBars() {
         
     }
+
     public StilPlotter setVisualizerPreferences(VisualizerComponentPreferences prefs) {
         this.preferences = prefs;
         return this;

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/StilPlotter.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/StilPlotter.java
@@ -245,7 +245,6 @@ public class StilPlotter extends JPanel {
     public void hideErrorBars() {
         
     }
-    
     public StilPlotter setVisualizerPreferences(VisualizerComponentPreferences prefs) {
         this.preferences = prefs;
         return this;

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/IrisStarTable.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/IrisStarTable.java
@@ -18,6 +18,7 @@ package cfa.vo.iris.visualizer.stil.tables;
 
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.BitSet;
 import java.util.List;
 import java.util.concurrent.Future;

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/IrisStarTable.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/IrisStarTable.java
@@ -18,7 +18,6 @@ package cfa.vo.iris.visualizer.stil.tables;
 
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.BitSet;
 import java.util.List;
 import java.util.concurrent.Future;

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainViewTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainViewTest.java
@@ -448,6 +448,13 @@ public class MetadataBrowserMainViewTest extends AbstractComponentGUITest {
             }
         }).run();
         
+        invokeWithRetry(50, 100, new Runnable() {
+            @Override
+            public void run() {
+                assertNotEquals(sed, mbView.selectedSed);
+            }
+        });
+        
         // 3 Seds in workspace
         assertEquals(3, sedManager.getSeds().size());
         

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainViewTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainViewTest.java
@@ -31,13 +31,14 @@ import cfa.vo.iris.IrisComponent;
 import cfa.vo.iris.sed.ExtSed;
 import cfa.vo.iris.sed.SedlibSedManager;
 import cfa.vo.iris.test.unit.AbstractComponentGUITest;
-import cfa.vo.iris.test.unit.TestUtils;
 import cfa.vo.iris.visualizer.VisualizerComponent;
 import cfa.vo.iris.visualizer.plotter.PlotterView;
 import cfa.vo.iris.visualizer.stil.tables.IrisStarTable;
 import cfa.vo.sedlib.Segment;
 import cfa.vo.iris.visualizer.plotter.SegmentModel;
 import cfa.vo.sedlib.TextParam;
+import cfa.vo.sedlib.io.SedFormat;
+import cfa.vo.testdata.TestData;
 
 import static org.junit.Assert.*;
 

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainViewTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainViewTest.java
@@ -370,7 +370,7 @@ public class MetadataBrowserMainViewTest extends AbstractComponentGUITest {
         sed.getSegment(0).createTarget();
         sed.getSegment(0).getTarget().setName(new TextParam("target1"));
         sed.getSegment(1).createTarget();
-        sed.getSegment(1).getTarget().setName(new TextParam("target1"));
+        sed.getSegment(1).getTarget().setName(new TextParam("target2"));
         
         sedManager.add(sed);
         
@@ -408,7 +408,7 @@ public class MetadataBrowserMainViewTest extends AbstractComponentGUITest {
             public Trigger process(Window warning) throws Exception {
                 // Check warning message
                 assertTrue(StringUtils.contains(warning.getTextBox("OptionPane.label").getText(), 
-                             "Added new SED"));
+                             "Added new Filter SED"));
                 return Trigger.DO_NOTHING;
             }
         }).run();
@@ -432,10 +432,10 @@ public class MetadataBrowserMainViewTest extends AbstractComponentGUITest {
         });
         
         // Select all segments
-        starTableList.selectIndices(0,1);
+        starTableList.selectIndices(1,0);
         
         // Select first rows from both segments
-        plotterTable.selectRows(0,3);
+        plotterTable.selectRows(3,0);
         
         // Should throw a success message
         makeExtractWindowInterceptor().process(new WindowHandler() {
@@ -443,7 +443,7 @@ public class MetadataBrowserMainViewTest extends AbstractComponentGUITest {
             public Trigger process(Window warning) throws Exception {
                 // Check warning message
                 assertTrue(StringUtils.contains(warning.getTextBox("OptionPane.label").getText(), 
-                             "Added new SED"));
+                             "Added new Filter SED"));
                 return Trigger.DO_NOTHING;
             }
         }).run();

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainViewTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainViewTest.java
@@ -17,7 +17,6 @@
 package cfa.vo.iris.visualizer.metadata;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.builder.ReflectionToStringBuilder;
 import org.junit.Before;
 import org.junit.Test;
 import org.uispec4j.ListBox;
@@ -34,9 +33,6 @@ import cfa.vo.iris.visualizer.VisualizerComponent;
 import cfa.vo.iris.visualizer.plotter.PlotterView;
 import cfa.vo.iris.visualizer.stil.tables.IrisStarTable;
 import cfa.vo.sedlib.Segment;
-import cfa.vo.sedlib.io.SedFormat;
-import cfa.vo.testdata.TestData;
-
 import static org.junit.Assert.*;
 
 import java.util.BitSet;
@@ -253,22 +249,21 @@ public class MetadataBrowserMainViewTest extends AbstractComponentGUITest {
         plotterTable.addRowToSelection(0);
         plotterTable.addRowToSelection(1);
         
-        // dataTable should have the same selected rows
-        dataTable.rowsAreSelected(0,1).check();
+        // dataTable row selection is independent
+        dataTable.rowsAreSelected().check();
         
         // Select some rows the the dataTable
         dataTable.selectRow(2);
         dataTable.addRowToSelection(0);
         
-        // Plotter data table should have same rows selected
-        plotterTable.rowsAreSelected(2,0).check();
+        // Plotter data table should still have same rows selected
+        plotterTable.rowsAreSelected(0,1).check();
         
         // Click select all button
         mbWindow.getButton("Select All").click();
         
         // Everything should be selected, nothing in the segment tab
         plotterTable.rowsAreSelected(0,1,2).check();
-        dataTable.rowsAreSelected(0,1,2).check();
         segmentTable.rowsAreSelected(0).check();
         
         // Clear selections
@@ -276,7 +271,6 @@ public class MetadataBrowserMainViewTest extends AbstractComponentGUITest {
         
         // Verify selections are empty
         plotterTable.selectionIsEmpty().check();
-        dataTable.selectionIsEmpty().check();
         
         // select 0th index in tables
         plotterTable.selectRow(0);
@@ -286,10 +280,7 @@ public class MetadataBrowserMainViewTest extends AbstractComponentGUITest {
         
         // verify inversion
         plotterTable.rowsAreSelected(1,2).check();
-        dataTable.rowsAreSelected(1,2).check();
-        
         assertFalse(plotterTable.rowIsSelected(0).isTrue());
-        assertFalse(dataTable.rowIsSelected(0).isTrue());
         
         // Set to segment tab
         mbWindow.getButton("Clear Selection").click();
@@ -358,18 +349,13 @@ public class MetadataBrowserMainViewTest extends AbstractComponentGUITest {
         assertEquals("0E0", plView.getXcoord());
         assertEquals("0E0", plView.getYcoord());
         
-        final ExtSed sed = sedManager.newSed("test1");
-        sedManager.select(sed);
-        
-        double[] x1 = new double[] {100};
-        double[] y1 = new double[] {1};
-        final Segment seg1 = createSampleSegment(x1, y1);
+        final ExtSed sed = new ExtSed("test1");
+        final Segment seg1 = createSampleSegment(new double[] {100}, new double[] {1});
         sed.addSegment(seg1);
-        
-        double[] x2 = new double[] {200};
-        double[] y2 = new double[] {2};
-        final Segment seg2 = createSampleSegment(x2, y2);
+        final Segment seg2 = createSampleSegment(new double[] {200}, new double[] {2});
         sed.addSegment(seg2);
+        
+        sedManager.add(sed);
         
         invokeWithRetry(50, 100, new Runnable() {
             @Override
@@ -389,7 +375,7 @@ public class MetadataBrowserMainViewTest extends AbstractComponentGUITest {
             @Override
             public void run() {
                 // first row should be selected, still just one star table
-                dataTable.rowIsSelected(0).check();
+                plotterTable.rowsAreSelected(0).check();
                 assertEquals(1, mbView.getSelectedStarTables().size());
             }
         });
@@ -400,8 +386,7 @@ public class MetadataBrowserMainViewTest extends AbstractComponentGUITest {
         invokeWithRetry(50, 100, new Runnable() {
             @Override
             public void run() {
-                // Both rows should be selected, ditto both star tables
-                dataTable.rowsAreSelected(0, 1);
+                plotterTable.rowsAreSelected(1).check();
                 assertEquals(2, mbView.getSelectedStarTables().size());
             }
         });

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainViewTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainViewTest.java
@@ -22,7 +22,10 @@ import org.junit.Test;
 import org.uispec4j.ListBox;
 import org.uispec4j.Panel;
 import org.uispec4j.Table;
+import org.uispec4j.Trigger;
 import org.uispec4j.Window;
+import org.uispec4j.interception.WindowHandler;
+import org.uispec4j.interception.WindowInterceptor;
 
 import cfa.vo.iris.IrisComponent;
 import cfa.vo.iris.sed.ExtSed;
@@ -33,8 +36,8 @@ import cfa.vo.iris.visualizer.VisualizerComponent;
 import cfa.vo.iris.visualizer.plotter.PlotterView;
 import cfa.vo.iris.visualizer.stil.tables.IrisStarTable;
 import cfa.vo.sedlib.Segment;
-import cfa.vo.sedlib.io.SedFormat;
-import cfa.vo.testdata.TestData;
+import cfa.vo.iris.visualizer.plotter.SegmentModel;
+import cfa.vo.sedlib.TextParam;
 
 import static org.junit.Assert.*;
 
@@ -342,6 +345,144 @@ public class MetadataBrowserMainViewTest extends AbstractComponentGUITest {
             public void run() {
                 IrisStarTable table = mbView.selectedStarTables.get(0);
                 assertEquals(masked, table.getMasked());
+            }
+        });
+    }
+    
+    public void testExtractPoints() throws Exception {
+        
+        // Should throw a warning message for no SED
+        makeExtractWindowInterceptor().process(new WindowHandler() {
+            @Override
+            public Trigger process(Window warning) throws Exception {
+                // Check warning message
+                assertEquals(warning.getTextBox("OptionPane.label").getText(), 
+                             "No SED in browser. Please load an SED.");
+                return Trigger.DO_NOTHING;
+            }
+        }).run();
+        
+        final ExtSed sed = new ExtSed("sed");
+        sed.addSegment(createSampleSegment());
+        sed.addSegment(createSampleSegment(new double[] {1}, new double[] {2}));
+        
+        // Set target names
+        sed.getSegment(0).createTarget();
+        sed.getSegment(0).getTarget().setName(new TextParam("target1"));
+        sed.getSegment(1).createTarget();
+        sed.getSegment(1).getTarget().setName(new TextParam("target1"));
+        
+        sedManager.add(sed);
+        
+        // verify selected sed
+        invokeWithRetry(50, 100, new Runnable() {
+            @Override
+            public void run() {
+                assertEquals(mbView.getTitle(), mbWindow.getTitle());
+                assertEquals(sed, mbView.selectedSed);
+                assertEquals(2, mbView.sedStarTables.size());
+                assertEquals(2, starTableList.getSize());
+                assertEquals(3, plotterTable.getRowCount());
+                assertEquals(3, dataTable.getRowCount());
+                assertEquals(2, segmentTable.getRowCount());
+            }
+        });
+        
+        // Should throw a warning message for no rows selected
+        makeExtractWindowInterceptor().process(new WindowHandler() {
+            @Override
+            public Trigger process(Window warning) throws Exception {
+                // Check warning message
+                assertEquals(warning.getTextBox("OptionPane.label").getText(), 
+                             "No rows selected to extract. Please select rows.");
+                return Trigger.DO_NOTHING;
+            }
+        }).run();
+        
+        // Select two rows from first segment
+        plotterTable.selectRows(0,1);
+        
+        // Should throw a success message
+        makeExtractWindowInterceptor().process(new WindowHandler() {
+            @Override
+            public Trigger process(Window warning) throws Exception {
+                // Check warning message
+                assertTrue(StringUtils.contains(warning.getTextBox("OptionPane.label").getText(), 
+                             "Added new SED"));
+                return Trigger.DO_NOTHING;
+            }
+        }).run();
+        
+        // Should now be two SEDs in the workspace
+        assertEquals(2, sedManager.getSeds().size());
+        
+        // Get the new SED
+        ExtSed newSed = sedManager.getSelected();
+        assertEquals(1, newSed.getNumberOfSegments());
+        assertEquals(2, newSed.getSegment(0).getLength());
+        
+        // Select the first SED with two segments
+        sedManager.select(sed);
+        invokeWithRetry(50, 100, new Runnable() {
+            @Override
+            public void run() {
+                assertEquals(mbView.getTitle(), mbWindow.getTitle());
+                assertEquals(sed, mbView.selectedSed);
+            }
+        });
+        
+        // Select all segments
+        starTableList.selectIndices(0,1);
+        
+        // Select first rows from both segments
+        plotterTable.selectRows(0,3);
+        
+        // Should throw a success message
+        makeExtractWindowInterceptor().process(new WindowHandler() {
+            @Override
+            public Trigger process(Window warning) throws Exception {
+                // Check warning message
+                assertTrue(StringUtils.contains(warning.getTextBox("OptionPane.label").getText(), 
+                             "Added new SED"));
+                return Trigger.DO_NOTHING;
+            }
+        }).run();
+        
+        // 3 Seds in workspace
+        assertEquals(3, sedManager.getSeds().size());
+        
+        // Get the new SED
+        newSed = sedManager.getSelected();
+        assertEquals(2, newSed.getNumberOfSegments());
+        assertEquals(1, newSed.getSegment(0).getLength());
+        assertEquals(1, newSed.getSegment(1).getLength());
+        
+        // Verify IrisStarTables are all the same
+        SegmentModel oldLayer = mbView.preferences.getSedPreferences(sed)
+                .getSegmentPreferences(sed.getSegment(0));
+        SegmentModel newLayer = mbView.preferences.getSedPreferences(newSed)
+                .getSegmentPreferences(newSed.getSegment(0));
+        assertEquals(oldLayer.getSuffix(), newLayer.getSuffix());
+        assertEquals(oldLayer.getInSource().getName(), newLayer.getInSource().getName());
+        assertEquals(oldLayer.getInSource().getParameters().size(), newLayer.getInSource().getParameters().size());
+        starTableList.contains(newLayer.getSuffix()).check();
+        
+        oldLayer = mbView.preferences.getSedPreferences(sed)
+                .getSegmentPreferences(sed.getSegment(1));
+        newLayer = mbView.preferences.getSedPreferences(newSed)
+                .getSegmentPreferences(newSed.getSegment(1));
+        assertEquals(oldLayer.getSuffix(), newLayer.getSuffix());
+        assertEquals(oldLayer.getInSource().getName(), newLayer.getInSource().getName());
+        assertEquals(oldLayer.getInSource().getParameters().size(), newLayer.getInSource().getParameters().size());
+        starTableList.contains(newLayer.getSuffix()).check();
+    }
+    
+    
+    private WindowInterceptor makeExtractWindowInterceptor() {
+        return WindowInterceptor.init(new Trigger() {
+            @Override
+            public void run() throws Exception {
+                mbWindow.getMenuBar().getMenu("File").getSubMenu("Extract to New SED").click();
             }
         });
     }

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainViewTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainViewTest.java
@@ -33,6 +33,9 @@ import cfa.vo.iris.visualizer.VisualizerComponent;
 import cfa.vo.iris.visualizer.plotter.PlotterView;
 import cfa.vo.iris.visualizer.stil.tables.IrisStarTable;
 import cfa.vo.sedlib.Segment;
+import cfa.vo.sedlib.io.SedFormat;
+import cfa.vo.testdata.TestData;
+
 import static org.junit.Assert.*;
 
 import java.util.BitSet;
@@ -298,8 +301,7 @@ public class MetadataBrowserMainViewTest extends AbstractComponentGUITest {
     
     @Test
     public void testMetadataBrowserMasking() throws Exception {
-        final ExtSed sed = new ExtSed("");//ExtSed.read(TestData.class.getResource("3c273.vot").openStream(), SedFormat.VOT);
-        sed.addSegment(TestUtils.createSampleSegment());
+        final ExtSed sed = ExtSed.read(TestData.class.getResource("3c273.vot").openStream(), SedFormat.VOT);
         sedManager.add(sed);
         
         invokeWithRetry(20, 100, new Runnable() {
@@ -309,14 +311,14 @@ public class MetadataBrowserMainViewTest extends AbstractComponentGUITest {
                 assertEquals(sed, mbView.selectedSed);
                 assertEquals(1, mbView.sedStarTables.size());
                 assertEquals(1, starTableList.getSize());
-                assertEquals(3, plotterTable.getRowCount());
+                assertEquals(455, plotterTable.getRowCount());
             }
         });
         
         // Apply a mask on the first and last rows
         final BitSet masked = new BitSet();
         masked.set(0);
-        masked.set(2);
+        masked.set(454);
         
         dataPanel.getTabGroup().selectTab("Data");
         plotterTable.selectRows(0, 2);
@@ -340,6 +342,56 @@ public class MetadataBrowserMainViewTest extends AbstractComponentGUITest {
             public void run() {
                 IrisStarTable table = mbView.selectedStarTables.get(0);
                 assertEquals(masked, table.getMasked());
+            }
+        });
+    }
+    
+    @Test
+    public void testMetadataBrowserMultipleSegmentMasking() throws Exception {
+        final ExtSed sed = new ExtSed("test");
+        final BitSet masked = new BitSet();
+        
+        // Spectral Values should be {1, 1, 2, 2, 3, 3} due to spectral sorting.
+        sed.addSegment(createSampleSegment());
+        sed.addSegment(createSampleSegment());
+        sedManager.add(sed);
+        
+        invokeWithRetry(50, 100, new Runnable() {
+            @Override
+            public void run() {
+                starTableList.selectIndices(0,1);
+                assertEquals(mbView.getTitle(), mbWindow.getTitle());
+                assertEquals(sed, mbView.selectedSed);
+                assertEquals(2, mbView.sedStarTables.size());
+                assertEquals(2, starTableList.getSize());
+                assertEquals(6, plotterTable.getRowCount());
+            }
+        });
+        
+        plotterTable.selectAllRows();
+        mbWindow.getButton("Apply Mask").click();
+        
+        // Both tables should have all rows masked
+        masked.set(0, 3);
+        invokeWithRetry(20, 100, new Runnable() {
+            @Override
+            public void run() {
+                for (IrisStarTable table : mbView.selectedStarTables)
+                    assertEquals(masked, table.getMasked());
+            }
+        });
+        
+        // Remove masks from first rows in each table (recall the table is sorted)
+        plotterTable.selectRows(0,1);
+        mbWindow.getButton("Remove Masks").click();
+        
+        // Masks should be cleared from first rows
+        masked.clear(0);
+        invokeWithRetry(20, 100, new Runnable() {
+            @Override
+            public void run() {
+                for (IrisStarTable table : mbView.selectedStarTables)
+                    assertEquals(masked, table.getMasked());
             }
         });
     }

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainViewTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainViewTest.java
@@ -325,7 +325,8 @@ public class MetadataBrowserMainViewTest extends AbstractComponentGUITest {
         masked.set(454);
         
         dataPanel.getTabGroup().selectTab("Data");
-        plotterTable.selectRows(0, 2);
+        mbView.addRowToSelection(0, 0);
+        mbView.addRowToSelection(0, 454);
         mbWindow.getButton("Mask Points").click();
         
         invokeWithRetry(20, 100, new Runnable() {
@@ -518,7 +519,7 @@ public class MetadataBrowserMainViewTest extends AbstractComponentGUITest {
         });
         
         plotterTable.selectAllRows();
-        mbWindow.getButton("Apply Mask").click();
+        mbWindow.getButton("Mask Points").click();
         
         // Both tables should have all rows masked
         masked.set(0, 3);
@@ -532,7 +533,7 @@ public class MetadataBrowserMainViewTest extends AbstractComponentGUITest {
         
         // Remove masks from first rows in each table (recall the table is sorted)
         plotterTable.selectRows(0,1);
-        mbWindow.getButton("Remove Masks").click();
+        mbWindow.getButton("Unmask Points").click();
         
         // Masks should be cleared from first rows
         masked.clear(0);

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/metadata/SegmentExtractorTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/metadata/SegmentExtractorTest.java
@@ -2,10 +2,6 @@ package cfa.vo.iris.visualizer.metadata;
 
 import static org.junit.Assert.*;
 
-import java.util.LinkedList;
-import java.util.List;
-
-import org.apache.commons.lang.builder.EqualsBuilder;
 import org.junit.Test;
 
 import cfa.vo.iris.sed.ExtSed;
@@ -25,10 +21,10 @@ public class SegmentExtractorTest {
         
         // Simple segment, three rows selected
         Segment seg1 = TestUtils.createSampleSegment();
-        int[] selection = new int[] {0,1,2};
+        int[][] selection = new int[][] {{0,1,2}};
         
-        List<IrisStarTable> tables = new LinkedList<>();
-        tables.add(adapter.convertSegment(seg1));
+        IrisStarTable[] tables = new IrisStarTable[1];
+        tables[0] = adapter.convertSegment(seg1);
         
         SegmentExtractor extractor = new SegmentExtractor(tables, selection);
         
@@ -45,10 +41,10 @@ public class SegmentExtractorTest {
     public void testSingleSegmentExtractionSomeRows() throws Exception {
         
         Segment seg1 = TestUtils.createSampleSegment();
-        int[] selection = new int[] {1};
-        
-        List<IrisStarTable> tables = new LinkedList<>();
-        tables.add(adapter.convertSegment(seg1));
+        int[][] selection = new int[][] {{1}};
+
+        IrisStarTable[] tables = new IrisStarTable[1];
+        tables[0] = adapter.convertSegment(seg1);
         
         SegmentExtractor extractor = new SegmentExtractor(tables, selection);
         
@@ -69,11 +65,11 @@ public class SegmentExtractorTest {
         // Two segments, all rows selected
         Segment seg1 = TestUtils.createSampleSegment();
         Segment seg2 = TestUtils.createSampleSegment(new double[] {100,200,300}, new double[] {100,200,300});
-        int[] selection = new int[] {0,1,2,3,4,5};
+        int[][] selection = new int[][] {{0,1,2},{0,1,2}};
         
-        List<IrisStarTable> tables = new LinkedList<>();
-        tables.add(adapter.convertSegment(seg1));
-        tables.add(adapter.convertSegment(seg2));
+        IrisStarTable[] tables = new IrisStarTable[2];
+        tables[0] = adapter.convertSegment(seg1);
+        tables[1] = adapter.convertSegment(seg2);
         
         SegmentExtractor extractor = new SegmentExtractor(tables, selection);
         ExtSed sed = extractor.constructSed();
@@ -90,11 +86,11 @@ public class SegmentExtractorTest {
         // Two segments, no rows selected from first, last 2 from second
         Segment seg1 = TestUtils.createSampleSegment();
         Segment seg2 = TestUtils.createSampleSegment(new double[] {100,200,300}, new double[] {100,200,300});
-        int[] selection = new int[] {4,5};
+        int[][] selection = new int[][] {{},{1,2}};
         
-        List<IrisStarTable> tables = new LinkedList<>();
-        tables.add(adapter.convertSegment(seg1));
-        tables.add(adapter.convertSegment(seg2));
+        IrisStarTable[] tables = new IrisStarTable[2];
+        tables[0] = adapter.convertSegment(seg1);
+        tables[1] = adapter.convertSegment(seg2);
         
         SegmentExtractor extractor = new SegmentExtractor(tables, selection);
         ExtSed sed = extractor.constructSed();
@@ -112,11 +108,11 @@ public class SegmentExtractorTest {
         
         seg1.createTarget();
         seg1.getTarget().setName(new TextParam("Some Star"));
+
+        IrisStarTable[] tables = new IrisStarTable[1];
+        tables[0] = adapter.convertSegment(seg1);
         
-        List<IrisStarTable> tables = new LinkedList<>();
-        tables.add(adapter.convertSegment(seg1));
-        
-        SegmentExtractor extractor = new SegmentExtractor(tables, new int[] {0});
+        SegmentExtractor extractor = new SegmentExtractor(tables, new int[][] {{0}});
         Segment clone = extractor.constructSed().getSegment(0);
         
         assertEquals(clone.getCuration().getDate(), seg1.getCuration().getDate());

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/metadata/SegmentExtractorTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/metadata/SegmentExtractorTest.java
@@ -26,9 +26,9 @@ public class SegmentExtractorTest {
         IrisStarTable[] tables = new IrisStarTable[1];
         tables[0] = adapter.convertSegment(seg1);
         
-        SegmentExtractor extractor = new SegmentExtractor(tables, selection);
-        
-        ExtSed sed = extractor.constructSed();
+        ExtSed sed = new ExtSed("FilterSed");
+        SegmentExtractor extractor = new SegmentExtractor(tables, selection, sed);
+        extractor.constructSed();
         
         // One segment that is identical to the original should be extracted
         assertEquals(1, sed.getNumberOfSegments());
@@ -46,9 +46,9 @@ public class SegmentExtractorTest {
         IrisStarTable[] tables = new IrisStarTable[1];
         tables[0] = adapter.convertSegment(seg1);
         
-        SegmentExtractor extractor = new SegmentExtractor(tables, selection);
-        
-        ExtSed sed = extractor.constructSed();
+        ExtSed sed = new ExtSed("FilterSed");
+        SegmentExtractor extractor = new SegmentExtractor(tables, selection, sed);
+        extractor.constructSed();
         
         // One segment should be extracted
         assertEquals(1, sed.getNumberOfSegments());
@@ -71,8 +71,12 @@ public class SegmentExtractorTest {
         tables[0] = adapter.convertSegment(seg1);
         tables[1] = adapter.convertSegment(seg2);
         
-        SegmentExtractor extractor = new SegmentExtractor(tables, selection);
-        ExtSed sed = extractor.constructSed();
+        tables[0].setName("test");
+        tables[1].setName("test");
+        
+        ExtSed sed = new ExtSed("FilterSed");
+        SegmentExtractor extractor = new SegmentExtractor(tables, selection, sed);
+        extractor.constructSed();
         
         // Verify 2 segments are equal
         assertEquals(2, sed.getNumberOfSegments());
@@ -92,8 +96,9 @@ public class SegmentExtractorTest {
         tables[0] = adapter.convertSegment(seg1);
         tables[1] = adapter.convertSegment(seg2);
         
-        SegmentExtractor extractor = new SegmentExtractor(tables, selection);
-        ExtSed sed = extractor.constructSed();
+        ExtSed sed = new ExtSed("FilterSed");
+        SegmentExtractor extractor = new SegmentExtractor(tables, selection, sed);
+        extractor.constructSed();
         
         // Verify 2 segments are equal
         assertEquals(1, sed.getNumberOfSegments());
@@ -111,9 +116,12 @@ public class SegmentExtractorTest {
 
         IrisStarTable[] tables = new IrisStarTable[1];
         tables[0] = adapter.convertSegment(seg1);
+
         
-        SegmentExtractor extractor = new SegmentExtractor(tables, new int[][] {{0}});
-        Segment clone = extractor.constructSed().getSegment(0);
+        ExtSed sed = new ExtSed("FilterSed");
+        SegmentExtractor extractor = new SegmentExtractor(tables, new int[][] {{0}}, sed);
+        extractor.constructSed();
+        Segment clone = sed.getSegment(0);
         
         assertEquals(clone.getCuration().getDate(), seg1.getCuration().getDate());
         assertEquals(clone.getTarget().getName(), seg1.getTarget().getName());

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/metadata/SegmentExtractorTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/metadata/SegmentExtractorTest.java
@@ -1,0 +1,125 @@
+package cfa.vo.iris.visualizer.metadata;
+
+import static org.junit.Assert.*;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import org.junit.Test;
+
+import cfa.vo.iris.test.unit.TestUtils;
+import cfa.vo.iris.visualizer.stil.tables.IrisStarTable;
+import cfa.vo.iris.visualizer.stil.tables.IrisStarTableAdapter;
+import cfa.vo.sedlib.DateParam;
+import cfa.vo.sedlib.Segment;
+import cfa.vo.sedlib.TextParam;
+
+public class SegmentExtractorTest {
+    
+    IrisStarTableAdapter adapter = new IrisStarTableAdapter(null);
+    
+    @Test
+    public void testSingleSegmentExtractionAllRows() throws Exception {
+        
+        // Simple segment, three rows selected
+        Segment seg1 = TestUtils.createSampleSegment();
+        int[] selection = new int[] {0,1,2};
+        
+        List<IrisStarTable> tables = new LinkedList<>();
+        tables.add(adapter.convertSegment(seg1));
+        
+        SegmentExtractor extractor = new SegmentExtractor(tables, selection);
+        
+        List<Segment> newSegment = extractor.getSegments();
+        
+        // One segment that is identical to the original should be extracted
+        assertEquals(1, newSegment.size());
+        Segment newSeg = newSegment.get(0);
+        assertEquals(newSeg, seg1);
+        
+    }
+    
+    @Test
+    public void testSingleSegmentExtractionSomeRows() throws Exception {
+        
+        Segment seg1 = TestUtils.createSampleSegment();
+        int[] selection = new int[] {1};
+        
+        List<IrisStarTable> tables = new LinkedList<>();
+        tables.add(adapter.convertSegment(seg1));
+        
+        SegmentExtractor extractor = new SegmentExtractor(tables, selection);
+        
+        List<Segment> newSegment = extractor.getSegments();
+        
+        // One segment should be extracted
+        assertEquals(1, newSegment.size());
+        
+        // Segment should have one point that is equal to 1st point in original segment
+        Segment newSeg = newSegment.get(0);
+        assertEquals(1, newSeg.getData().getLength());
+        assertEquals(seg1.getData().getPoint().get(1), newSeg.getData().getPoint().get(0));
+    }
+    
+    @Test
+    public void testMultipleSegmentExtractionAllRows() throws Exception {
+        
+        // Two segments, all rows selected
+        Segment seg1 = TestUtils.createSampleSegment();
+        Segment seg2 = TestUtils.createSampleSegment(new double[] {100,200,300}, new double[] {100,200,300});
+        int[] selection = new int[] {0,1,2,3,4,5};
+        
+        List<IrisStarTable> tables = new LinkedList<>();
+        tables.add(adapter.convertSegment(seg1));
+        tables.add(adapter.convertSegment(seg2));
+        
+        SegmentExtractor extractor = new SegmentExtractor(tables, selection);
+        List<Segment> newSegments = extractor.getSegments();
+        
+        // Verify 2 segments are equal
+        assertEquals(2, newSegments.size());
+        assertEquals(newSegments.get(0), seg1);
+        assertEquals(newSegments.get(1), seg2);
+    }
+    
+    @Test
+    public void testMultipleSegmentExtractionSomeRows() throws Exception {
+        
+        // Two segments, no rows selected from first, last 2 from second
+        Segment seg1 = TestUtils.createSampleSegment();
+        Segment seg2 = TestUtils.createSampleSegment(new double[] {100,200,300}, new double[] {100,200,300});
+        int[] selection = new int[] {4,5};
+        
+        List<IrisStarTable> tables = new LinkedList<>();
+        tables.add(adapter.convertSegment(seg1));
+        tables.add(adapter.convertSegment(seg2));
+        
+        SegmentExtractor extractor = new SegmentExtractor(tables, selection);
+        List<Segment> newSegments = extractor.getSegments();
+        
+        // Verify 2 segments are equal
+        assertEquals(2, newSegments.size());
+        assertEquals(0, newSegments.get(0).getData().getLength());
+        assertEquals(2, newSegments.get(1).getData().getLength());
+    }
+    
+    @Test
+    public void verifyCloning() throws Exception {
+        Segment seg1 = TestUtils.createSampleSegment();
+        seg1.createCuration();
+        seg1.getCuration().setDate(new DateParam("04042014"));
+        
+        seg1.createTarget();
+        seg1.getTarget().setName(new TextParam("Some Star"));
+        
+        List<IrisStarTable> tables = new LinkedList<>();
+        tables.add(adapter.convertSegment(seg1));
+        
+        SegmentExtractor extractor = new SegmentExtractor(tables, new int[] {0});
+        Segment clone = extractor.getSegments().get(0);
+        
+        assertEquals(clone.getCuration().getDate(), seg1.getCuration().getDate());
+        assertEquals(clone.getTarget().getName(), seg1.getTarget().getName());
+    }
+
+}

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/metadata/SegmentExtractorTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/metadata/SegmentExtractorTest.java
@@ -5,8 +5,10 @@ import static org.junit.Assert.*;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.apache.commons.lang.builder.EqualsBuilder;
 import org.junit.Test;
 
+import cfa.vo.iris.sed.ExtSed;
 import cfa.vo.iris.test.unit.TestUtils;
 import cfa.vo.iris.visualizer.stil.tables.IrisStarTable;
 import cfa.vo.iris.visualizer.stil.tables.IrisStarTableAdapter;
@@ -30,11 +32,11 @@ public class SegmentExtractorTest {
         
         SegmentExtractor extractor = new SegmentExtractor(tables, selection);
         
-        List<Segment> newSegment = extractor.getSegments();
+        ExtSed sed = extractor.constructSed();
         
         // One segment that is identical to the original should be extracted
-        assertEquals(1, newSegment.size());
-        Segment newSeg = newSegment.get(0);
+        assertEquals(1, sed.getNumberOfSegments());
+        Segment newSeg = sed.getSegment(0);
         assertEquals(newSeg, seg1);
         
     }
@@ -50,13 +52,13 @@ public class SegmentExtractorTest {
         
         SegmentExtractor extractor = new SegmentExtractor(tables, selection);
         
-        List<Segment> newSegment = extractor.getSegments();
+        ExtSed sed = extractor.constructSed();
         
         // One segment should be extracted
-        assertEquals(1, newSegment.size());
+        assertEquals(1, sed.getNumberOfSegments());
         
         // Segment should have one point that is equal to 1st point in original segment
-        Segment newSeg = newSegment.get(0);
+        Segment newSeg = sed.getSegment(0);
         assertEquals(1, newSeg.getData().getLength());
         assertEquals(seg1.getData().getPoint().get(1), newSeg.getData().getPoint().get(0));
     }
@@ -74,12 +76,12 @@ public class SegmentExtractorTest {
         tables.add(adapter.convertSegment(seg2));
         
         SegmentExtractor extractor = new SegmentExtractor(tables, selection);
-        List<Segment> newSegments = extractor.getSegments();
+        ExtSed sed = extractor.constructSed();
         
         // Verify 2 segments are equal
-        assertEquals(2, newSegments.size());
-        assertEquals(newSegments.get(0), seg1);
-        assertEquals(newSegments.get(1), seg2);
+        assertEquals(2, sed.getNumberOfSegments());
+        assertEquals(sed.getSegment(0), seg1);
+        assertEquals(sed.getSegment(1), seg2);
     }
     
     @Test
@@ -95,12 +97,11 @@ public class SegmentExtractorTest {
         tables.add(adapter.convertSegment(seg2));
         
         SegmentExtractor extractor = new SegmentExtractor(tables, selection);
-        List<Segment> newSegments = extractor.getSegments();
+        ExtSed sed = extractor.constructSed();
         
         // Verify 2 segments are equal
-        assertEquals(2, newSegments.size());
-        assertEquals(0, newSegments.get(0).getData().getLength());
-        assertEquals(2, newSegments.get(1).getData().getLength());
+        assertEquals(1, sed.getNumberOfSegments());
+        assertEquals(2, sed.getSegment(0).getData().getLength());
     }
     
     @Test
@@ -116,10 +117,9 @@ public class SegmentExtractorTest {
         tables.add(adapter.convertSegment(seg1));
         
         SegmentExtractor extractor = new SegmentExtractor(tables, new int[] {0});
-        Segment clone = extractor.getSegments().get(0);
+        Segment clone = extractor.constructSed().getSegment(0);
         
         assertEquals(clone.getCuration().getDate(), seg1.getCuration().getDate());
         assertEquals(clone.getTarget().getName(), seg1.getTarget().getName());
     }
-
 }

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/preferences/SedPreferencesTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/preferences/SedPreferencesTest.java
@@ -121,4 +121,24 @@ public class SedPreferencesTest {
         prefs.refresh();
         assertEquals("my segment 2", prefs.getSegmentPreferences(seg3).getSuffix());
     }
+    
+    @Test
+    public void testAddMultipleSegments() throws Exception {
+        
+        final ExtSed sed = new ExtSed("sed");
+        sed.addSegment(createSampleSegment());
+        sed.addSegment(createSampleSegment(new double[] {1}, new double[] {2}));
+        
+        // Set target names to same name
+        sed.getSegment(0).createTarget();
+        sed.getSegment(0).getTarget().setName(new TextParam("target1"));
+        sed.getSegment(1).createTarget();
+        sed.getSegment(1).getTarget().setName(new TextParam("target1"));
+        
+        IrisStarTableAdapter adapter = new IrisStarTableAdapter(null);
+        SedModel prefs = new SedModel(sed, adapter);
+        
+        assertEquals("target1", prefs.getSegmentPreferences(sed.getSegment(0)).getSuffix());
+        assertEquals("target1 1", prefs.getSegmentPreferences(sed.getSegment(1)).getSuffix());
+    }
 }

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/IrisStarJTableTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/IrisStarJTableTest.java
@@ -21,6 +21,8 @@ import java.awt.event.MouseEvent;
 import java.util.Arrays;
 import java.util.List;
 
+import javax.swing.RowSorter;
+import javax.swing.SortOrder;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableColumnModel;
 
@@ -245,5 +247,35 @@ public class IrisStarJTableTest {
         RowSelection selection = table.getRowSelection();
         ArrayUtils.assertEquals(new int[] {0}, selection.selectedRows[0]);
         ArrayUtils.assertEquals(new int[] {0}, selection.selectedRows[1]);
+    }
+    
+    @Test
+    public void testSortingPreservationOnReset() throws Exception {
+        IrisStarJTable table = new IrisStarJTable();
+        table.setSortBySpecValues(true);
+        table.setUsePlotterDataTables(true);
+        
+        IrisStarTable segTable1 = adapter.convertSegment(TestUtils.createSampleSegment(
+                new double[] {1,2,3}, new double[] {4,5,6}));
+        IrisStarTable segTable2 = adapter.convertSegment(TestUtils.createSampleSegment(
+                new double[] {100,200,300}, new double[] {10,11,12}));
+        
+        table.setSelectedStarTables(Arrays.asList(segTable1));
+        
+        // Min spec value first by default
+        assertEquals(1.0, table.getValueAt(0, 2));
+        
+        // Sort by Ascending flux values
+        table.getRowSorter().setSortKeys(Arrays.asList(new RowSorter.SortKey(3, SortOrder.DESCENDING)));
+        assertEquals(3.0, table.getValueAt(0, 2));
+        
+        // Adding the new table should preserve sort order
+        table.setSelectedStarTables(Arrays.asList(segTable1, segTable2));
+        assertEquals(300.0, table.getValueAt(0, 2));
+        
+        // Applying a mask and adding a column should preserve sort order
+        segTable2.applyMasks(new int[] {0});
+        table.setSelectedStarTables(Arrays.asList(segTable1, segTable2));
+        assertEquals(300.0, table.getValueAt(0, 3));
     }
 }

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/IrisStarJTableTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/IrisStarJTableTest.java
@@ -160,4 +160,31 @@ public class IrisStarJTableTest {
         ArrayUtils.assertEquals(new int[] {}, sel.selectedRows[0]);
         ArrayUtils.assertEquals(new int[] {2}, sel.selectedRows[1]);
     }
+    
+    @Test
+    public void testSorting() throws Exception {
+        IrisStarJTable table = new IrisStarJTable();
+        table.setSortBySpecValues(true);
+        
+        IrisStarTable segTable = adapter.convertSegment(TestUtils.createSampleSegment(
+                        new double[] {5,4,3,2,1}, 
+                        new double[] {6,7,8,9,10}));
+        
+        table.setSelectedStarTables(Arrays.asList(segTable));
+        
+        // Rows selection should map correctly back to model, so selecting last three in the
+        // table should be first three in model
+        table.addRowSelectionInterval(2, 4);
+        ArrayUtils.assertEquals(new int[] {0,1,2}, table.getSelectedRows(true));
+        
+        table.clearSelection();
+        
+        // Values should be in ascending order
+        assertEquals(1.0, table.getValueAt(0, 2));
+        assertEquals(5.0, table.getValueAt(4, 2));
+        
+        // Try adding the 0th (model) index to the selection, should select the last row.
+        table.selectRowIndex(0,0);
+        ArrayUtils.assertEquals(new int[] {4}, table.getSelectedRows(false));
+    }
 }

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/IrisStarJTableTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/IrisStarJTableTest.java
@@ -110,7 +110,7 @@ public class IrisStarJTableTest {
         // Select 0th index in second star table
         table.clearSelection();
         table.selectRowIndex(1, 0);
-        ArrayUtils.assertEquals(new int[] {4}, table.getSelectedRows());
+        ArrayUtils.assertEquals(new int[] {3}, table.getSelectedRows());
         
         // Mask all but first rows in both tables
         table.clearSelection();
@@ -165,9 +165,10 @@ public class IrisStarJTableTest {
     public void testSorting() throws Exception {
         IrisStarJTable table = new IrisStarJTable();
         table.setSortBySpecValues(true);
+        table.setUsePlotterDataTables(true);
         
         IrisStarTable segTable = adapter.convertSegment(TestUtils.createSampleSegment(
-                        new double[] {5,4,3,2,1}, 
+                        new double[] {5,4,3,2,1},
                         new double[] {6,7,8,9,10}));
         
         table.setSelectedStarTables(Arrays.asList(segTable));
@@ -186,5 +187,63 @@ public class IrisStarJTableTest {
         // Try adding the 0th (model) index to the selection, should select the last row.
         table.selectRowIndex(0,0);
         ArrayUtils.assertEquals(new int[] {4}, table.getSelectedRows(false));
+        
+        // mask value 5, row 0
+        segTable.applyMasks(new int[] {0});
+        
+        // Add new StarTable, small valued
+        IrisStarTable segTable1 = adapter.convertSegment(TestUtils.createSampleSegment(
+                new double[] {.1,.2},
+                new double[] {1000,2000}));
+        
+        // Reset the table
+        table.setSelectedStarTables(Arrays.asList(segTable, segTable1));
+        
+        // Values should still be in ascending order (also now a masked column)
+        assertEquals(.1, table.getValueAt(0, 3));
+        assertEquals(5.0, table.getValueAt(6, 3));
+        assertEquals(true, table.getValueAt(6, 1));
+        
+        // Select 2nd row from 2nd star table
+        table.selectRowIndex(1,1);
+        
+        // Should be row 1, or row 6 in the model
+        ArrayUtils.assertEquals(new int[] {1}, table.getSelectedRows(false));
+        ArrayUtils.assertEquals(new int[] {6}, table.getSelectedRows(true));
+        
+        // Add first row from the 1st star table (has value 4 since the 1st row is masked)
+        table.selectRowIndex(0,0);
+        
+        // Should be row 1, or row 6 in the model
+        ArrayUtils.assertEquals(new int[] {1,6}, table.getSelectedRows(false));
+        ArrayUtils.assertEquals(new int[] {0,6}, table.getSelectedRows(true));
+    }
+    
+    @Test
+    public void testSortingWithMasks() throws Exception {
+        IrisStarJTable table = new IrisStarJTable();
+        table.setSortBySpecValues(true);
+        table.setUsePlotterDataTables(true);
+        
+        IrisStarTable segTable1 = adapter.convertSegment(TestUtils.createSampleSegment());
+        IrisStarTable segTable2 = adapter.convertSegment(TestUtils.createSampleSegment());
+        
+        // All rows are masked
+        segTable1.applyMasks(new int[] {0,1,2});
+        segTable2.applyMasks(new int[] {0,1,2});
+        
+        // Select first rows from each table
+        table.setSelectedStarTables(Arrays.asList(segTable1, segTable2));
+        table.selectRowIndex(0, 0);
+        table.selectRowIndex(1, 0);
+        
+        // Check selection values
+        ArrayUtils.assertEquals(new int[] {0, 1}, table.getSelectedRows(false));
+        ArrayUtils.assertEquals(new int[] {0, 3}, table.getSelectedRows(true));
+        
+        // Verify RowSelection matches expected values
+        RowSelection selection = table.getRowSelection();
+        ArrayUtils.assertEquals(new int[] {0}, selection.selectedRows[0]);
+        ArrayUtils.assertEquals(new int[] {0}, selection.selectedRows[1]);
     }
 }

--- a/iris/src/main/java/cfa/vo/iris/ConsistencyChecker.java
+++ b/iris/src/main/java/cfa/vo/iris/ConsistencyChecker.java
@@ -74,7 +74,7 @@ public class ConsistencyChecker implements IrisComponent {
 
         if (npoints == 1) {
             NarrowOptionPane.showMessageDialog(workspace.getRootFrame(),
-                    "The SED: " + sed.getId() + " has only one point in it. Some functions (e.g. Visualization and Fitting) will be disabled for this SED until new points are added.",
+                    "The SED: " + sed.getId() + " has only one point in it. Some functions (e.g. Fitting) will be disabled for this SED until new points are added.",
                     "WARNING",
                     NarrowOptionPane.WARNING_MESSAGE);
         }


### PR DESCRIPTION
Supersedes https://github.com/ChandraCXC/iris/pull/283 and https://github.com/ChandraCXC/iris/pull/279

Closes

https://github.com/ChandraCXC/iris-dev/issues/58
https://github.com/ChandraCXC/iris-dev/issues/52
https://github.com/ChandraCXC/iris-dev/issues/51

Changes to support sorting on column values in the metadata browser, as well as extracting the current selection in the metadata browser to a new SED.

Builds on the RowSelection model in the IrisStarJTable class to give outside callers clean access to the underlying StarTables and rows, without having to deal with row sorting or ordering of the tables. The plotter data table in the metadata browser is sorted by spectral value by default. Order and selection is currently reset with the metadata browser, so applying masks will reset to default ordering and clear the selection. We have tasks in our backlog to address those issues at a later time.

SED extraction is handled by a separate class, and the new SED is asynchronously added to the the workspace by the visualizer preferences class. Existing infrastructure handles serializing/selected the new SED in the workspace.