### PR TITLE
iris-dev#100 Fix Tooltip in Metadata Browser

### DIFF
--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.form
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.form
@@ -391,7 +391,6 @@
               <SubComponents>
                 <Container class="javax.swing.JScrollPane" name="plotterMetadataScrollPane">
                   <Properties>
-                    <Property name="toolTipText" type="java.lang.String" value=""/>
                     <Property name="verticalScrollBarPolicy" type="int" value="22"/>
                   </Properties>
 

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.java
@@ -523,7 +523,6 @@ public class MetadataBrowserMainView extends javax.swing.JInternalFrame {
         dataTabsPane.setMinimumSize(new java.awt.Dimension(0, 0));
         dataTabsPane.setName("dataTabsPane"); // NOI18N
 
-        plotterMetadataScrollPane.setToolTipText("");
         plotterMetadataScrollPane.setVerticalScrollBarPolicy(javax.swing.ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
 
         plotterStarJTable.setColumnInfoMatcher(new SegmentColumnInfoMatcher());

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/IrisStarJTable.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/IrisStarJTable.java
@@ -302,6 +302,13 @@ public class IrisStarJTable extends StarJTable {
         public String getToolTipText(MouseEvent evt) {
             Point p = evt.getPoint();
             int index = columnModel.getColumnIndexAtX(p.x);
+            
+            // Tool tip texts might not always be directly over the column's location, apparently.
+            // Don't show anything if the point is off the table's header.
+            if (index < 0) {
+                return null;
+            }
+            
             String tt = printColumnInfo((StarTableColumn) columnModel.getColumn(index));
             return tt;
         }


### PR DESCRIPTION
Resolves https://github.com/ChandraCXC/iris-dev/issues/100

This is unrelated to https://github.com/ChandraCXC/iris-dev/issues/101.

Basically just had a stray empty string in the tooltip setting for one of the metadata browser panels. Also added a check to make sure we don't ask for the -1 indexed column in the startable - which can happen if the header doesn't fill the entire frame.