### PR TITLE
Fix issue with AB magnitudes not being converted correctly.

### DIFF
--- a/iris-common/src/main/java/cfa/vo/iris/sed/stil/SegmentColumn.java
+++ b/iris-common/src/main/java/cfa/vo/iris/sed/stil/SegmentColumn.java
@@ -158,7 +158,11 @@ public abstract class SegmentColumn extends ColumnData
         Spectral_Error_Low("X axis low error values", "iris.spec.value.error.low", Double.class),
         Flux_Error("Y axis error values", "iris.flux.value.error", Double.class),
         Flux_Error_High("Y axis error values", "iris.flux.value.error.high", Double.class),
-        FLux_Error_Low("Y axis low error values", "iris.flux.value.error.low", Double.class);
+        Flux_Error_Low("Y axis low error values", "iris.flux.value.error.low", Double.class),
+        Original_Flux_Error("Original Y axis error values", "iris.flux.value.original.error", Double.class),
+        Original_Flux_Error_Hi("Original Y axis upper error values", "iris.flux.value.original.error.high", Double.class),
+        Original_Flux_Error_Low("Original Y axis low error values", "iris.flux.value.original.error.low", Double.class);
+        
         
         public String description;
         public String utype;

--- a/iris-common/src/main/java/cfa/vo/iris/sed/stil/SegmentStarTable.java
+++ b/iris-common/src/main/java/cfa/vo/iris/sed/stil/SegmentStarTable.java
@@ -57,6 +57,7 @@ public class SegmentStarTable extends RandomStarTable {
     private Segment segment;
     private XUnit specUnits;
     private YUnit fluxUnits;
+    private YUnit originalFluxUnits;
     private final long rows;
 
     // Columns for name and filtered state
@@ -70,6 +71,9 @@ public class SegmentStarTable extends RandomStarTable {
     private double[] specValues;
     private double[] fluxValues;
     private double[] originalFluxValues;
+    private double[] originalFluxErrValues;
+    private double[] originalFluxErrValuesHi;
+    private double[] originalFluxErrValuesLo;
     private double[] specErrValues;
     private double[] specErrValuesLo;
     private double[] specErrValuesHi;
@@ -88,6 +92,7 @@ public class SegmentStarTable extends RandomStarTable {
         this.segment = segment;
         this.specUnits = units.newXUnits(segment.getSpectralAxisUnits());
         this.fluxUnits = units.newYUnits(segment.getFluxAxisUnits());
+        this.originalFluxUnits = units.newYUnits(segment.getFluxAxisUnits());
         this.columns = new TreeSet<SegmentColumn>();
         
         // Name column will always be first
@@ -116,6 +121,9 @@ public class SegmentStarTable extends RandomStarTable {
         setSpecValues(segment.getSpectralAxisValues());
         setFluxValues(segment.getFluxAxisValues());
         setOriginalFluxValues(segment.getFluxAxisValues()); // Copies data so these aren't the same
+        setOriginalFluxErrValues((double[]) getDataFromSegment(Utypes.SEG_DATA_FLUXAXIS_ACC_STATERR));
+        setOriginalFluxErrValuesHi((double[]) getDataFromSegment(Utypes.SEG_DATA_FLUXAXIS_ACC_STATERRHIGH));
+        setOriginalFluxErrValuesLo((double[]) getDataFromSegment(Utypes.SEG_DATA_FLUXAXIS_ACC_STATERRLOW));
         
         // Try to add flux error values
         setFluxErrValues((double[]) getDataFromSegment(Utypes.SEG_DATA_FLUXAXIS_ACC_STATERR));
@@ -221,12 +229,18 @@ public class SegmentStarTable extends RandomStarTable {
     public void setFluxUnits(YUnit newUnit) throws UnitsException {
         if (specValues == null) return;
         
+        // copy values from original arrays
+        double[] errs = originalFluxErrValues;
+        double[] fluxes = originalFluxValues;
+        double[] errsHi = originalFluxErrValuesHi;
+        double[] errsLo = originalFluxErrValuesLo;
+        
         // Convert units
-        setFluxValues(units.convertY(fluxValues, specValues, fluxUnits, specUnits, newUnit));
-        setOriginalFluxValues(units.convertY(originalFluxValues, specValues, fluxUnits, specUnits, newUnit));
-        setFluxErrValues(units.convertY(fluxErrValues, specValues, fluxUnits, specUnits, newUnit));
-        setFluxErrValuesLo(units.convertY(fluxErrValuesLo, specValues, fluxUnits, specUnits, newUnit));
-        setFluxErrValuesHi(units.convertY(fluxErrValuesLo, specValues, fluxUnits, specUnits, newUnit));
+        
+        setFluxValues(units.convertY(fluxes, specValues, originalFluxUnits, specUnits, newUnit));
+        setFluxErrValues(units.convertErrors(errs, fluxes, specValues, originalFluxUnits, specUnits, newUnit));
+        setFluxErrValuesLo(units.convertErrors(errsLo, fluxes, specValues, originalFluxUnits, specUnits, newUnit));
+        setFluxErrValuesHi(units.convertErrors(errsHi, fluxes, specValues, originalFluxUnits, specUnits, newUnit));
         
         fluxUnits = newUnit;
         
@@ -286,6 +300,30 @@ public class SegmentStarTable extends RandomStarTable {
     public void setOriginalFluxValues(double[] originalFluxValues) {
         this.originalFluxValues = originalFluxValues;
         updateColumnValues(fluxValues, Column.Original_Flux_Value);
+    }
+    
+    public double[] getOriginalFluxErrValues() {
+        return originalFluxErrValuesHi;
+    }
+
+    public void setOriginalFluxErrValues(double[] originalFluxErrValues) {
+        this.originalFluxErrValues = originalFluxErrValues;
+    }
+    
+    public double[] getOriginalFluxErrValuesHi() {
+        return originalFluxErrValuesHi;
+    }
+
+    public void setOriginalFluxErrValuesHi(double[] originalFluxErrValuesHi) {
+        this.originalFluxErrValuesHi = originalFluxErrValuesHi;
+    }
+    
+    public double[] getOriginalFluxErrValuesLo() {
+        return originalFluxErrValuesLo;
+    }
+
+    public void setOriginalFluxErrValuesLo(double[] originalFluxErrValuesLo) {
+        this.originalFluxErrValuesLo = originalFluxErrValuesLo;
     }
 
     public double[] getSpecErrValues() {

--- a/iris-common/src/main/java/cfa/vo/iris/units/spv/YUnits.java
+++ b/iris-common/src/main/java/cfa/vo/iris/units/spv/YUnits.java
@@ -891,7 +891,7 @@ public class YUnits extends Units implements YUnit, Serializable {
             public double convertTo(double f, double w, double d1, double d2) {
                 double arg = Constant.H * Constant.C * f / w;
                 if (arg > 0.0)
-                    return (-1.085736 * Math.log (arg) + STZERO);
+                    return (-2.5 * Math.log10(arg) + STZERO);
                 else
                     return Double.NaN;
             }
@@ -1037,7 +1037,7 @@ public class YUnits extends Units implements YUnit, Serializable {
         // Errors in magnitude must be added to the data magnitude to get
         // the lower error bar in flux, and subtracted to get the upper. We do only
         // one here.
-
+        
         // we first compute where are the end points of the error bars.
         double[] errorBarEndValue = new double[e.length];
         for (int i = 0; i < errorBarEndValue.length; i++) {

--- a/iris-common/src/main/java/cfa/vo/iris/units/spv/YUnits.java
+++ b/iris-common/src/main/java/cfa/vo/iris/units/spv/YUnits.java
@@ -859,7 +859,7 @@ public class YUnits extends Units implements YUnit, Serializable {
             public double convertTo(double f, double w, double d1, double d2) {
                 double arg = Constant.H * f * w;
                 if (arg > 0.0) {
-                    return (-1.085736 * Math.log (arg) + ABZERO);
+                    return (-2.5 * Math.log10(arg) + ABZERO);
                 } else {
                     return Double.NaN;
                 }

--- a/iris-common/src/test/java/cfa/vo/iris/sed/stil/SegmentStarTableTest.java
+++ b/iris-common/src/test/java/cfa/vo/iris/sed/stil/SegmentStarTableTest.java
@@ -91,7 +91,7 @@ public class SegmentStarTableTest {
         
         assertEquals('\u03BC' + "m", table.getColumnInfo(id.getColumnIndex(Column.Spectral_Value.name())).getUnitString());
         assertEquals("erg/s/cm2/Angstrom", table.getColumnInfo(id.getColumnIndex(Column.Flux_Value.name())).getUnitString());
-        assertEquals("erg/s/cm2/Angstrom", table.getColumnInfo(id.getColumnIndex(Column.Original_Flux_Value.name())).getUnitString());
+        assertEquals("Jy", table.getColumnInfo(id.getColumnIndex(Column.Original_Flux_Value.name())).getUnitString()); // shouldn't change
         assertEquals("erg/s/cm2/Angstrom", table.getColumnInfo(id.getColumnIndex(Column.Flux_Error.name())).getUnitString());
     }
     
@@ -173,6 +173,8 @@ public class SegmentStarTableTest {
         // switch back and forth correctly
         
         // ABMAG back to erg/s/cm2/Hz
+        // f_nu(erg/s/cm2/Hz) = 10**(-0.4 (m_ab + 48.6))
+        // f_nu_err(erg/s/cm2/Hz) = 10**(-0.4 (m_ab + m_ab_err + 48.6)) - f_nu
         table.setFluxUnits(new YUnits("erg/s/cm**2/Hz"));
         for (int i=0; i < table.getFluxValues().length; i++) {
             assertEquals(y[i], table.getFluxValues()[i], 0.000001);

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SegmentModel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SegmentModel.java
@@ -136,9 +136,9 @@ public class SegmentModel {
             prefs.put(X_ERR_HI + suffix, Column.Spectral_Error_High.name());
             prefs.put(X_ERR_LO + suffix, Column.Spectral_Error_Low.name());
         }
-        if (shouldAddErrorColumn(Column.FLux_Error_Low, id)) {
+        if (shouldAddErrorColumn(Column.Flux_Error_Low, id)) {
             prefs.put(Y_ERR_HI + suffix, Column.Flux_Error_High.name());
-            prefs.put(Y_ERR_LO + suffix, Column.FLux_Error_Low.name());
+            prefs.put(Y_ERR_LO + suffix, Column.Flux_Error_Low.name());
         }
         
         prefs.put(TYPE + suffix, LayerType.xyerror.name());


### PR DESCRIPTION
Addresses ChandraCXC/iris-dev#72

This PR fixes an issue where conversions between magnitudes and flux/flux densities were not done correctly.

First, the wrong units conversion method was being used in [`SegmentStarTable::setFluxUnits()`](https://github.com/ChandraCXC/iris/blob/master/iris-common/src/main/java/cfa/vo/iris/sed/stil/SegmentStarTable.java#L221). Before, it was using `UnitsManager::convertY()`. Now, it uses `UnitsManager::convertErrors()` for the flux errors which has a special cases for converting errors to/from magnitude units (in the Specview units code).

Next, Specview's `YUnits` conversion method for AB magnitudes wasn't perfect. This has been fixed in line [862](https://github.com/ChandraCXC/iris/blob/iris-dev-72-magnitudes-conversion/iris-common/src/main/java/cfa/vo/iris/units/spv/YUnits.java#L862). This is what was causing the flux values to change when the user converts back and forth between ABMAG and another unit multiple times.

Converting errors between magnitude and flux/flux density units, however, is more tricky. Even doing calculations by hand, I haven't figured out how to convert the errors back and forth between mags and flux. So as a solution, this PR stores *all* the original flux values and errors, along with the original units, and always starts from here when converting between units. I am not happy with this solution, as this takes up more space. However, now we could have a method to reset the SED back to it's original state without any issues.

TODOs:
   - make sure the OriginalFlux column in the MB shows the original units.