### PR TITLE
Plot fitted model

### DIFF
--- a/iris-common/src/main/java/cfa/vo/iris/sed/stil/SegmentColumn.java
+++ b/iris-common/src/main/java/cfa/vo/iris/sed/stil/SegmentColumn.java
@@ -165,7 +165,6 @@ public abstract class SegmentColumn extends ColumnData
         Model_Values("Evaluated values from fit model", "iris.fit.values", Double.class),
         Residuals("Observed - Expected", "iris.fit.residuals", Double.class),
         Ratios("abs(Observerd - Expected)/Expected", "iris.fit.ratios", Double.class);
-
         
         public String description;
         public String utype;

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.form
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.form
@@ -132,12 +132,12 @@
                 <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="mntmCoplotActionPerformed"/>
               </Events>
             </MenuItem>
-            <MenuItem class="javax.swing.JCheckBoxMenuItem" name="mntmPlotModel">
+            <MenuItem class="javax.swing.JCheckBoxMenuItem" name="mntmShowModel">
               <Properties>
-                <Property name="text" type="java.lang.String" value="Plot model"/>
+                <Property name="text" type="java.lang.String" value="Show model"/>
               </Properties>
               <Events>
-                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="mntmPlotModelActionPerformed"/>
+                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="mntmShowModelActionPerformed"/>
               </Events>
             </MenuItem>
           </SubComponents>

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.form
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.form
@@ -132,12 +132,12 @@
                 <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="mntmCoplotActionPerformed"/>
               </Events>
             </MenuItem>
-            <MenuItem class="javax.swing.JCheckBoxMenuItem" name="jCheckBoxMenuItem1">
+            <MenuItem class="javax.swing.JCheckBoxMenuItem" name="mntmPlotModel">
               <Properties>
-                <Property name="text" type="java.lang.String" value="jCheckBoxMenuItem1"/>
+                <Property name="text" type="java.lang.String" value="Plot model"/>
               </Properties>
               <Events>
-                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jCheckBoxMenuItem1ActionPerformed"/>
+                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="mntmPlotModelActionPerformed"/>
               </Events>
             </MenuItem>
           </SubComponents>

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.form
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.form
@@ -132,6 +132,15 @@
                 <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="mntmCoplotActionPerformed"/>
               </Events>
             </MenuItem>
+            <MenuItem class="javax.swing.JCheckBoxMenuItem" name="jCheckBoxMenuItem1">
+              <Properties>
+                <Property name="selected" type="boolean" value="true"/>
+                <Property name="text" type="java.lang.String" value="jCheckBoxMenuItem1"/>
+              </Properties>
+              <Events>
+                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jCheckBoxMenuItem1ActionPerformed"/>
+              </Events>
+            </MenuItem>
           </SubComponents>
         </Menu>
         <Menu class="javax.swing.JMenu" name="mnHelp">

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.form
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.form
@@ -134,7 +134,6 @@
             </MenuItem>
             <MenuItem class="javax.swing.JCheckBoxMenuItem" name="jCheckBoxMenuItem1">
               <Properties>
-                <Property name="selected" type="boolean" value="true"/>
                 <Property name="text" type="java.lang.String" value="jCheckBoxMenuItem1"/>
               </Properties>
               <Events>

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.form
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.form
@@ -132,14 +132,6 @@
                 <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="mntmCoplotActionPerformed"/>
               </Events>
             </MenuItem>
-            <MenuItem class="javax.swing.JCheckBoxMenuItem" name="mntmShowModel">
-              <Properties>
-                <Property name="text" type="java.lang.String" value="Show model"/>
-              </Properties>
-              <Events>
-                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="mntmShowModelActionPerformed"/>
-              </Events>
-            </MenuItem>
           </SubComponents>
         </Menu>
         <Menu class="javax.swing.JMenu" name="mnHelp">

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
@@ -256,7 +256,6 @@ public class PlotterView extends JInternalFrame {
         mntmAutoFixed = new javax.swing.JCheckBoxMenuItem();
         mntmGridOnOff = new javax.swing.JCheckBoxMenuItem();
         mntmCoplot = new javax.swing.JMenuItem();
-        mntmShowModel = new javax.swing.JCheckBoxMenuItem();
         mnHelp = new javax.swing.JMenu();
         mntmPlotterNavigationHelp = new javax.swing.JMenuItem();
 
@@ -605,14 +604,6 @@ public class PlotterView extends JInternalFrame {
         });
         mnView.add(mntmCoplot);
 
-        mntmShowModel.setText("Show model");
-        mntmShowModel.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                mntmShowModelActionPerformed(evt);
-            }
-        });
-        mnView.add(mntmShowModel);
-
         menuBar.add(mnView);
 
         mnHelp.setText("Help");
@@ -695,29 +686,6 @@ public class PlotterView extends JInternalFrame {
         plotter.dataPan(SwingConstants.WEST);
     }//GEN-LAST:event_rightActionPerformed
 
-    private void mntmShowModelActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_mntmShowModelActionPerformed
-        
-        // Plot a model
-        // TODO: This is a dummy model; it's just a line plot of the first segment
-        // in the current SED. We need to replace this with the fitted model
-        ExtSed sed = plotter.getDataModel().getSelectedSeds().get(0);
-        SedModel model = plotter.getDataModel().getSedModel(sed);
-        
-        if (mntmShowModel.isSelected()) {
-            try {
-                model.getDataTables().get(0).getPlotterDataTable().setModelValues(sed.getSegment(0).getFluxAxisValues());
-                FunctionModel functionModel = new FunctionModel(model);
-                plotter.getDataModel().getSedModel(plotter.getDataModel().getSelectedSeds().get(0)).setFunctionModel(functionModel);
-                plotter.resetPlot(false, false);
-            } catch (SedNoDataException ex) {
-                Logger.getLogger(PlotterView.class.getName()).log(Level.SEVERE, null, ex);
-            }
-        } else {
-            plotter.getDataModel().getSedModel(plotter.getDataModel().getSelectedSeds().get(0)).setFunctionModel(null);
-            plotter.resetPlot(false, false);
-        }
-    }//GEN-LAST:event_mntmShowModelActionPerformed
-
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JPanel bottomButtonsPanel;
     private javax.swing.JButton btnReset;
@@ -744,7 +712,6 @@ public class PlotterView extends JInternalFrame {
     private javax.swing.JMenuItem mntmPlotterNavigationHelp;
     private javax.swing.JMenuItem mntmProperties;
     private javax.swing.JMenuItem mntmSave;
-    private javax.swing.JCheckBoxMenuItem mntmShowModel;
     private javax.swing.JMenuItem mntmSomething;
     private javax.swing.JRadioButtonMenuItem mntmXlog;
     private javax.swing.JRadioButtonMenuItem mntmYlog;

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
@@ -602,7 +602,6 @@ public class PlotterView extends JInternalFrame {
         });
         mnView.add(mntmCoplot);
 
-        jCheckBoxMenuItem1.setSelected(true);
         jCheckBoxMenuItem1.setText("jCheckBoxMenuItem1");
         jCheckBoxMenuItem1.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
@@ -700,13 +699,17 @@ public class PlotterView extends JInternalFrame {
             // TODO: right now, it just overplots a flattened-version of the SED to
             // play around with. This should be updated to show the currently
             // selected SED's model, if it exists.
-            
-            ExtSed sed = preferences.getDataModel().getSelectedSeds().get(0);
-            String xunits = preferences.getDataModel().getSedModel(sed).getXUnits();
-            String yunits = preferences.getDataModel().getSedModel(sed).getYUnits();
 
-            SegmentStarTable model = new SegmentStarTable(ExtSed.flatten(sed, xunits, yunits).getSegment(0), title);
-            plotter.plot_model(model);
+            if (jCheckBoxMenuItem1.isSelected()) {
+                ExtSed sed = preferences.getDataModel().getSelectedSeds().get(0);
+                String xunits = preferences.getDataModel().getSedModel(sed).getXUnits();
+                String yunits = preferences.getDataModel().getSedModel(sed).getYUnits();
+
+                SegmentStarTable model = new SegmentStarTable(ExtSed.flatten(sed, xunits, yunits).getSegment(0), title);
+                plotter.plot_model(model);
+            } else {
+                plotter.remove_model();
+            }
         } catch (SedException | UnitsException ex) {
             Logger.getLogger(PlotterView.class.getName()).log(Level.SEVERE, null, ex);
         }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
@@ -706,7 +706,7 @@ public class PlotterView extends JInternalFrame {
                 String yunits = preferences.getDataModel().getSedModel(sed).getYUnits();
 
                 SegmentStarTable model = new SegmentStarTable(ExtSed.flatten(sed, xunits, yunits).getSegment(0), title);
-                plotter.plot_model(model);
+                plotter.plotModel(model);
             } else {
                 plotter.remove_model();
             }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
@@ -18,14 +18,19 @@ package cfa.vo.iris.visualizer.plotter;
 import cfa.vo.iris.IWorkspace;
 import cfa.vo.iris.IrisApplication;
 import cfa.vo.iris.gui.GUIUtils;
+import cfa.vo.iris.sed.ExtSed;
+import cfa.vo.iris.sed.stil.SegmentStarTable;
+import cfa.vo.iris.units.UnitsException;
 import cfa.vo.iris.visualizer.metadata.MetadataBrowserMainView;
 import cfa.vo.iris.visualizer.plotter.PlotPreferences.PlotType;
 import cfa.vo.iris.visualizer.preferences.CoPlotManagementWindow;
 import cfa.vo.iris.visualizer.preferences.VisualizerComponentPreferences;
 import cfa.vo.iris.visualizer.preferences.VisualizerDataModel;
+import cfa.vo.sedlib.common.SedException;
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.JFrame;
 import javax.swing.JInternalFrame;
@@ -248,6 +253,7 @@ public class PlotterView extends JInternalFrame {
         mntmAutoFixed = new javax.swing.JCheckBoxMenuItem();
         mntmGridOnOff = new javax.swing.JCheckBoxMenuItem();
         mntmCoplot = new javax.swing.JMenuItem();
+        jCheckBoxMenuItem1 = new javax.swing.JCheckBoxMenuItem();
         mnHelp = new javax.swing.JMenu();
         mntmPlotterNavigationHelp = new javax.swing.JMenuItem();
 
@@ -596,6 +602,15 @@ public class PlotterView extends JInternalFrame {
         });
         mnView.add(mntmCoplot);
 
+        jCheckBoxMenuItem1.setSelected(true);
+        jCheckBoxMenuItem1.setText("jCheckBoxMenuItem1");
+        jCheckBoxMenuItem1.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jCheckBoxMenuItem1ActionPerformed(evt);
+            }
+        });
+        mnView.add(jCheckBoxMenuItem1);
+
         menuBar.add(mnView);
 
         mnHelp.setText("Help");
@@ -678,6 +693,26 @@ public class PlotterView extends JInternalFrame {
         plotter.dataPan(SwingConstants.WEST);
     }//GEN-LAST:event_rightActionPerformed
 
+    private void jCheckBoxMenuItem1ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jCheckBoxMenuItem1ActionPerformed
+        try {
+            // show model
+            
+            // TODO: right now, it just overplots a flattened-version of the SED to
+            // play around with. This should be updated to show the currently
+            // selected SED's model, if it exists.
+            
+            ExtSed sed = preferences.getDataModel().getSelectedSeds().get(0);
+            String xunits = preferences.getDataModel().getSedModel(sed).getXUnits();
+            String yunits = preferences.getDataModel().getSedModel(sed).getYUnits();
+
+            SegmentStarTable model = new SegmentStarTable(ExtSed.flatten(sed, xunits, yunits).getSegment(0), title);
+            plotter.plot_model(model);
+        } catch (SedException | UnitsException ex) {
+            Logger.getLogger(PlotterView.class.getName()).log(Level.SEVERE, null, ex);
+        }
+        
+    }//GEN-LAST:event_jCheckBoxMenuItem1ActionPerformed
+
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JPanel bottomButtonsPanel;
     private javax.swing.JButton btnReset;
@@ -685,6 +720,7 @@ public class PlotterView extends JInternalFrame {
     private javax.swing.JPanel buttonPanel;
     private cfa.vo.iris.visualizer.plotter.JButtonArrow down;
     private javax.swing.JSpinner fluxOrDensity;
+    private javax.swing.JCheckBoxMenuItem jCheckBoxMenuItem1;
     private cfa.vo.iris.visualizer.plotter.JButtonArrow left;
     private javax.swing.JMenuBar menuBar;
     private javax.swing.JButton metadataButton;

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
@@ -253,7 +253,7 @@ public class PlotterView extends JInternalFrame {
         mntmAutoFixed = new javax.swing.JCheckBoxMenuItem();
         mntmGridOnOff = new javax.swing.JCheckBoxMenuItem();
         mntmCoplot = new javax.swing.JMenuItem();
-        jCheckBoxMenuItem1 = new javax.swing.JCheckBoxMenuItem();
+        mntmPlotModel = new javax.swing.JCheckBoxMenuItem();
         mnHelp = new javax.swing.JMenu();
         mntmPlotterNavigationHelp = new javax.swing.JMenuItem();
 
@@ -602,13 +602,13 @@ public class PlotterView extends JInternalFrame {
         });
         mnView.add(mntmCoplot);
 
-        jCheckBoxMenuItem1.setText("jCheckBoxMenuItem1");
-        jCheckBoxMenuItem1.addActionListener(new java.awt.event.ActionListener() {
+        mntmPlotModel.setText("Plot model");
+        mntmPlotModel.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
-                jCheckBoxMenuItem1ActionPerformed(evt);
+                mntmPlotModelActionPerformed(evt);
             }
         });
-        mnView.add(jCheckBoxMenuItem1);
+        mnView.add(mntmPlotModel);
 
         menuBar.add(mnView);
 
@@ -692,15 +692,16 @@ public class PlotterView extends JInternalFrame {
         plotter.dataPan(SwingConstants.WEST);
     }//GEN-LAST:event_rightActionPerformed
 
-    private void jCheckBoxMenuItem1ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jCheckBoxMenuItem1ActionPerformed
+    private void mntmPlotModelActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_mntmPlotModelActionPerformed
+
         try {
             // show model
             
             // TODO: right now, it just overplots a flattened-version of the SED to
-            // play around with. This should be updated to show the currently
-            // selected SED's model, if it exists.
+            // play around with. This should be updated to either show or hide
+            // the model; the function model should already be in the preferneces
 
-            if (jCheckBoxMenuItem1.isSelected()) {
+            if (mntmPlotModel.isSelected()) {
                 ExtSed sed = preferences.getDataModel().getSelectedSeds().get(0);
                 String xunits = preferences.getDataModel().getSedModel(sed).getXUnits();
                 String yunits = preferences.getDataModel().getSedModel(sed).getYUnits();
@@ -714,7 +715,7 @@ public class PlotterView extends JInternalFrame {
             Logger.getLogger(PlotterView.class.getName()).log(Level.SEVERE, null, ex);
         }
         
-    }//GEN-LAST:event_jCheckBoxMenuItem1ActionPerformed
+    }//GEN-LAST:event_mntmPlotModelActionPerformed
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JPanel bottomButtonsPanel;
@@ -723,7 +724,6 @@ public class PlotterView extends JInternalFrame {
     private javax.swing.JPanel buttonPanel;
     private cfa.vo.iris.visualizer.plotter.JButtonArrow down;
     private javax.swing.JSpinner fluxOrDensity;
-    private javax.swing.JCheckBoxMenuItem jCheckBoxMenuItem1;
     private cfa.vo.iris.visualizer.plotter.JButtonArrow left;
     private javax.swing.JMenuBar menuBar;
     private javax.swing.JButton metadataButton;
@@ -740,6 +740,7 @@ public class PlotterView extends JInternalFrame {
     private javax.swing.JRadioButtonMenuItem mntmLinear;
     private javax.swing.JRadioButtonMenuItem mntmLog;
     private javax.swing.JMenuItem mntmOpen;
+    private javax.swing.JCheckBoxMenuItem mntmPlotModel;
     private javax.swing.JMenuItem mntmPlotterNavigationHelp;
     private javax.swing.JMenuItem mntmProperties;
     private javax.swing.JMenuItem mntmSave;

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
@@ -24,9 +24,12 @@ import cfa.vo.iris.units.UnitsException;
 import cfa.vo.iris.visualizer.metadata.MetadataBrowserMainView;
 import cfa.vo.iris.visualizer.plotter.PlotPreferences.PlotType;
 import cfa.vo.iris.visualizer.preferences.CoPlotManagementWindow;
+import cfa.vo.iris.visualizer.preferences.FunctionModel;
+import cfa.vo.iris.visualizer.preferences.SedModel;
 import cfa.vo.iris.visualizer.preferences.VisualizerComponentPreferences;
 import cfa.vo.iris.visualizer.preferences.VisualizerDataModel;
 import cfa.vo.sedlib.common.SedException;
+import cfa.vo.sedlib.common.SedNoDataException;
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -253,7 +256,7 @@ public class PlotterView extends JInternalFrame {
         mntmAutoFixed = new javax.swing.JCheckBoxMenuItem();
         mntmGridOnOff = new javax.swing.JCheckBoxMenuItem();
         mntmCoplot = new javax.swing.JMenuItem();
-        mntmPlotModel = new javax.swing.JCheckBoxMenuItem();
+        mntmShowModel = new javax.swing.JCheckBoxMenuItem();
         mnHelp = new javax.swing.JMenu();
         mntmPlotterNavigationHelp = new javax.swing.JMenuItem();
 
@@ -602,13 +605,13 @@ public class PlotterView extends JInternalFrame {
         });
         mnView.add(mntmCoplot);
 
-        mntmPlotModel.setText("Plot model");
-        mntmPlotModel.addActionListener(new java.awt.event.ActionListener() {
+        mntmShowModel.setText("Show model");
+        mntmShowModel.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
-                mntmPlotModelActionPerformed(evt);
+                mntmShowModelActionPerformed(evt);
             }
         });
-        mnView.add(mntmPlotModel);
+        mnView.add(mntmShowModel);
 
         menuBar.add(mnView);
 
@@ -692,30 +695,28 @@ public class PlotterView extends JInternalFrame {
         plotter.dataPan(SwingConstants.WEST);
     }//GEN-LAST:event_rightActionPerformed
 
-    private void mntmPlotModelActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_mntmPlotModelActionPerformed
-
-        try {
-            // show model
-            
-            // TODO: right now, it just overplots a flattened-version of the SED to
-            // play around with. This should be updated to either show or hide
-            // the model; the function model should already be in the preferneces
-
-            if (mntmPlotModel.isSelected()) {
-                ExtSed sed = preferences.getDataModel().getSelectedSeds().get(0);
-                String xunits = preferences.getDataModel().getSedModel(sed).getXUnits();
-                String yunits = preferences.getDataModel().getSedModel(sed).getYUnits();
-
-                SegmentStarTable model = new SegmentStarTable(ExtSed.flatten(sed, xunits, yunits).getSegment(0), title);
-                plotter.plotModel(model);
-            } else {
-                plotter.remove_model();
-            }
-        } catch (SedException | UnitsException ex) {
-            Logger.getLogger(PlotterView.class.getName()).log(Level.SEVERE, null, ex);
-        }
+    private void mntmShowModelActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_mntmShowModelActionPerformed
         
-    }//GEN-LAST:event_mntmPlotModelActionPerformed
+        // Plot a model
+        // TODO: This is a dummy model; it's just a line plot of the first segment
+        // in the current SED. We need to replace this with the fitted model
+        ExtSed sed = plotter.getDataModel().getSelectedSeds().get(0);
+        SedModel model = plotter.getDataModel().getSedModel(sed);
+        
+        if (mntmShowModel.isSelected()) {
+            try {
+                model.getDataTables().get(0).getPlotterDataTable().setModelValues(sed.getSegment(0).getFluxAxisValues());
+                FunctionModel functionModel = new FunctionModel(model);
+                plotter.getDataModel().getSedModel(plotter.getDataModel().getSelectedSeds().get(0)).setFunctionModel(functionModel);
+                plotter.resetPlot(false, false);
+            } catch (SedNoDataException ex) {
+                Logger.getLogger(PlotterView.class.getName()).log(Level.SEVERE, null, ex);
+            }
+        } else {
+            plotter.getDataModel().getSedModel(plotter.getDataModel().getSelectedSeds().get(0)).setFunctionModel(null);
+            plotter.resetPlot(false, false);
+        }
+    }//GEN-LAST:event_mntmShowModelActionPerformed
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JPanel bottomButtonsPanel;
@@ -740,10 +741,10 @@ public class PlotterView extends JInternalFrame {
     private javax.swing.JRadioButtonMenuItem mntmLinear;
     private javax.swing.JRadioButtonMenuItem mntmLog;
     private javax.swing.JMenuItem mntmOpen;
-    private javax.swing.JCheckBoxMenuItem mntmPlotModel;
     private javax.swing.JMenuItem mntmPlotterNavigationHelp;
     private javax.swing.JMenuItem mntmProperties;
     private javax.swing.JMenuItem mntmSave;
+    private javax.swing.JCheckBoxMenuItem mntmShowModel;
     private javax.swing.JMenuItem mntmSomething;
     private javax.swing.JRadioButtonMenuItem mntmXlog;
     private javax.swing.JRadioButtonMenuItem mntmYlog;

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/StilPlotter.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/StilPlotter.java
@@ -22,6 +22,7 @@ import cfa.vo.iris.sed.ExtSed;
 import cfa.vo.iris.sed.quantities.SPVYQuantity;
 import cfa.vo.iris.sed.stil.SegmentStarTable;
 import cfa.vo.iris.visualizer.preferences.LayerModel;
+import cfa.vo.iris.visualizer.preferences.FunctionModel;
 import cfa.vo.iris.visualizer.preferences.VisualizerComponentPreferences;
 import cfa.vo.iris.visualizer.preferences.VisualizerDataModel;
 import uk.ac.starlink.ttools.plot2.geom.PlaneAspect;
@@ -271,10 +272,15 @@ public class StilPlotter extends JPanel {
 
     // TODO: update this when we have an interface defined for grabbing a
     // selected ExtSed's evaluated model
-    public void plot_model(SegmentStarTable table) {
+    /**
+     * Overplot a function on the plotter.
+     * @param table - a SegmentStarTable containing the X and Y values of the 
+     * function to plot
+     */
+    public void plotModel(SegmentStarTable table) {
         
-        // add evaluated model layer if model exists OR if model should be shown
-        EvaluatedModelLayer layer = new EvaluatedModelLayer(table);
+        // add function model layer if model exists OR if model should be shown
+        FunctionModel layer = new FunctionModel(table);
         if (layer.isShowModel()) {
             for (String key : layer.getPreferences().keySet()) {
                 env.setValue(key, layer.getPreferences().get(key));

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/StilPlotter.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/StilPlotter.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import uk.ac.starlink.task.Parameter;
 import uk.ac.starlink.ttools.plot2.Axis;
 
 public class StilPlotter extends JPanel {
@@ -283,6 +284,15 @@ public class StilPlotter extends JPanel {
         // overplot the model on top of the current display
         try {
             resetPlot(false, false, env);
+        } catch (Exception ex) {
+            Logger.getLogger(StilPlotter.class.getName()).log(Level.SEVERE, null, ex);
+        }
+    }
+    
+    public void remove_model() {
+        
+        try {
+            resetPlot(false, false);
         } catch (Exception ex) {
             Logger.getLogger(StilPlotter.class.getName()).log(Level.SEVERE, null, ex);
         }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/FunctionModel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/FunctionModel.java
@@ -21,10 +21,16 @@ import cfa.vo.iris.units.UnitsException;
 import cfa.vo.iris.units.spv.XUnits;
 import cfa.vo.iris.units.spv.YUnits;
 import cfa.vo.iris.visualizer.plotter.LayerType;
+import cfa.vo.sedlib.Segment;
+import cfa.vo.sedlib.common.SedInconsistentException;
+import cfa.vo.sedlib.common.SedNoDataException;
 import java.security.InvalidParameterException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
 import java.util.logging.Logger;
+import uk.ac.starlink.table.StarTable;
 
 /**
  *
@@ -65,6 +71,19 @@ public class FunctionModel {
     
     private boolean show; // show the evaluated model
     
+    public FunctionModel() {
+        this.color = "red";
+        this.thickness = 1;
+        this.show = false;
+        
+        try {
+            // add empty table
+            this.setInSource(new SegmentStarTable(new Segment()));
+        } catch (SedNoDataException | UnitsException | SedInconsistentException ex) {
+            Logger.getLogger(FunctionModel.class.getName()).log(Level.SEVERE, null, ex);
+        }
+    }
+    
     public FunctionModel(SegmentStarTable table) {
         if (table == null) {
             throw new InvalidParameterException("star table cannot be null");
@@ -77,6 +96,14 @@ public class FunctionModel {
         
         // Setting default values here
         this.show = true;
+    }
+    
+    public FunctionModel(List<SegmentStarTable> tables) {
+        for (StarTable st : tables) {
+            if (st == null) {
+                throw new InvalidParameterException("star tables cannot be null");
+            }
+        }
     }
     
     /**

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/FunctionModel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/FunctionModel.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2016 Chandra X-Ray Observatory.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cfa.vo.iris.visualizer.preferences;
+
+import cfa.vo.iris.sed.stil.SegmentColumn.Column;
+import cfa.vo.iris.sed.stil.SegmentStarTable;
+import cfa.vo.iris.units.UnitsException;
+import cfa.vo.iris.units.spv.XUnits;
+import cfa.vo.iris.units.spv.YUnits;
+import cfa.vo.iris.visualizer.plotter.LayerType;
+import java.security.InvalidParameterException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Logger;
+
+/**
+ *
+ * Evaluated model preferences. This describes the STIL preferences for plotting 
+ * an evaluated model.
+ */
+public class FunctionModel {
+
+    // see http://www.star.bris.ac.uk/~mbt/stilts/sun256/sun256.html#plot2plane
+    // for a list of all the configurable plot properties
+    
+    private static final Logger logger = Logger.getLogger(FunctionModel.class.getName());
+    
+    // Override-able Settings
+    public static final String TYPE = "layer";
+    public static final String IN = "in";
+    public static final String X_COL = "x";
+    public static final String Y_COL = "y";
+    public static final String COLOR = "color";
+    public static final String THICK = "thick";
+    public static final String DASH = "dash";
+    public static final String SIZE = "size";
+    
+    // for the plot legend
+    public static final String LEGEND_LABEL = "leglabel";
+    public static final String LEGEND_SEQUENCE = "legseq";
+    
+    private String suffix;
+    
+    private SegmentStarTable inSource;
+    private Integer size;
+    private String color;
+    private Double dash;
+    private Integer thickness;
+    
+    private String leglabel;
+    private String[] legseq;
+    
+    private boolean show; // show the evaluated model
+    
+    public FunctionModel(SegmentStarTable table) {
+        if (table == null) {
+            throw new InvalidParameterException("star table cannot be null");
+        }
+        
+        this.setInSource(table);
+        this.suffix = table.getName();
+        this.color = "red";
+        this.thickness = 1;
+        
+        // Setting default values here
+        this.show = true;
+    }
+    
+    /**
+     * Show or hide the evaluated model
+     * @param bool
+     */
+    public void setShowModel(boolean bool) {
+        this.show = bool;
+    }
+    
+    /**
+     * Returns whether the model should be shown or not
+     */
+    public boolean isShowModel() {
+        return this.show;
+    }
+
+    /**
+     * 
+     * @return a map of all preferences currently set for this layer.
+     */
+    public Map<String, Object> getPreferences() {
+        Map<String, Object> preferences = new HashMap<String, Object>();
+        
+        if (show) {
+            addMarkFields(suffix, preferences);
+        }
+        
+        // TODO: In the future, we may want to have shaded regions for model
+        // upper/lower limits.
+        
+        return preferences;
+    }
+    
+    private void addMarkFields(String suffix, Map<String, Object> prefs) {
+        prefs.put(TYPE + suffix, LayerType.line.name());
+        if (dash != null)
+            prefs.put(DASH + suffix, dash);
+        if (color != null)
+            prefs.put(COLOR + suffix, color);
+        if (thickness != null)
+            prefs.put(THICK + suffix, thickness);
+        
+        addCommonFields(suffix, prefs);
+
+    }
+    
+    private void addCommonFields(String suffix, Map<String, Object> prefs) {
+        prefs.put(IN + suffix, inSource);
+        prefs.put(X_COL + suffix, Column.Spectral_Value.name());
+        prefs.put(Y_COL + suffix, Column.Flux_Value.name());
+        
+        // for the legend. set the flux and error layer legened names
+        // to the same name
+        prefs.put(LEGEND_LABEL + suffix, getLabel());
+        
+        if (size != null)
+            prefs.put(SIZE + suffix, size);
+    }
+    
+    public String getXUnits() {
+        return inSource.getSpecUnits().toString();
+    }
+    
+    public void setXUnits(String xunits) throws UnitsException {
+        inSource.setSpecUnits(new XUnits(XUnits.getCorrectSpelling(xunits)));
+    }
+    
+    public String getYUnits() {
+        return inSource.getFluxUnits().toString();
+    }
+    
+    public void setYUnits(String yunits) throws UnitsException {
+        inSource.setFluxUnits(new YUnits(YUnits.getCorrectSpelling(yunits)));
+    }
+
+    public SegmentStarTable getInSource() {
+        return inSource;
+    }
+    
+    public FunctionModel setInSource(SegmentStarTable table) {
+        if (table == null) {
+            throw new InvalidParameterException("StarTable cannot be null!");
+        }
+        
+        this.inSource = table;
+        return this;
+    }
+    
+    public String getSuffix() {
+        return suffix;
+    }
+
+    public FunctionModel setSuffix(String suffix) {
+        this.suffix = suffix;
+        return this;
+    }
+
+    public int getSize() {
+        return size;
+    }
+
+    public FunctionModel setSize(int size) {
+        this.size = size;
+        return this;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+    public FunctionModel setColor(String color) {
+        this.color = color;
+        return this;
+    }
+    
+    public double getDash() {
+        return dash;
+    }
+
+    public FunctionModel setDash(double dash) {
+        this.dash = dash;
+        return this;
+    }
+    
+    public int getThickness() {
+        return thickness;
+    }
+
+    public FunctionModel setThickness(int thickness) {
+        this.thickness = thickness;
+        return this;
+    }
+    
+    public FunctionModel setLayerSequence(String[] layerSequence) {
+        this.legseq = layerSequence;
+        return this;
+    }
+    
+    public String[] getLayerSequence() {
+        return this.legseq;
+    }
+    
+    // the suffix is the layer suffix name from the SedPreferences
+    public FunctionModel setLabel(String label) {
+        this.leglabel = label;
+        return this;
+    }
+    
+    public String getLabel() {
+        return this.leglabel;
+    }    
+}

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/FunctionModel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/FunctionModel.java
@@ -33,8 +33,8 @@ import uk.ac.starlink.ttools.jel.ColumnIdentifier;
 public class FunctionModel {
     
     public static final String DEFAULT_FUNCTION_COLOR = "red";
-    public static final String RATIO = "ratio";
-    public static final String RESIDUAL = "residual";
+    public static final String RATIOS = "Ratios";
+    public static final String RESIDUALS = "Residuals";
     
     public static final String FUNCTION_SUFFIX = "_MODEL";
     
@@ -49,8 +49,78 @@ public class FunctionModel {
 
     public FunctionModel(SedModel sedModel) {
         
+        setSedModel(sedModel);
+
+    }
+    
+    /**
+     * Create a LayerModel for the evaluated function model associated with the
+     * SedModel.
+     * @return a LayerModel of the evaluated function
+     */
+    public LayerModel getFunctionLayerModel() {
+        
+        LayerModel layer = new LayerModel(sortedStackedStarTable);
+        layer.setShowErrorBars(false);
+        layer.setShowMarks(false);
+        layer.setShowLines(true);
+        layer.setLayerType(LayerType.line.name());
+        layer.setX(SegmentColumn.Column.Spectral_Value.name());
+        layer.setY(SegmentColumn.Column.Model_Values.name());
+        layer.setLineColor(getFunctionColor());
+        layer.setLineThickness(getFunctionThickness());
+        layer.setLineDash(getFunctionDash());
+        return layer;
+    }
+    
+    /**
+     * Create a LayerModel for plotting the residuals of the SedModel's fit. The
+     * residuals can be plotted as the "raw" residual (model - observed) or as 
+     * the ratio
+     * @param residualType - the type of residual to create: "Residuals" is the 
+     * (model - observed), and "Ratios" is the (model - observed)/model. 
+     * @return a LayerModel representing the residuals for the SedModel.
+     */
+    public LayerModel getResidualsLayerModel(String residualType) {
+        
+        LayerModel layer = new LayerModel(sortedStackedStarTable);
+        if (residualType.equals(RATIOS)) {
+            layer.setX(SegmentColumn.Column.Spectral_Value.name());
+            layer.setY(SegmentColumn.Column.Ratios.name());
+        } else if (residualType.equals(RESIDUALS)) {
+            layer.setX(SegmentColumn.Column.Spectral_Value.name());
+            layer.setY(SegmentColumn.Column.Residuals.name());
+        } else {
+            throw new IllegalArgumentException("Unrecognized residual type. "
+                    + "Must be \"ratio\" or \"residual\"");
+        }
+        
+        layer.setShowErrorBars(false);
+        layer.setShowMarks(true);
+        
+        return layer;
+    }
+    
+    /**
+     * Update the SedModel. This will also update the underlying sorted 
+     * StarTable that represents the function model. 
+     * @param sedModel 
+     */
+    public void setSedModel(SedModel sedModel) {
         this.sedModel = sedModel;
-        // concat IrisStarTable into StackedStarTable
+        
+        // update the sorted star table
+        updateSortedStarTable();
+    }
+    
+    public SedModel getSedModel() {
+        return this.sedModel;
+    }
+    
+    /**
+     * Update the sortedStarTable given the current SedModel
+     */
+    private void updateSortedStarTable() {
         StackedStarTable stackedTable = new StackedStarTable(sedModel.getDataTables(), new SegmentColumnInfoMatcher());
         stackedTable.setName(sedModel.getSedLayerModel().getSuffix());
         
@@ -68,54 +138,6 @@ public class FunctionModel {
         } catch (IOException ex) {
             Logger.getLogger(FunctionModel.class.getName()).log(Level.SEVERE, null, ex);
         }
-        
-    }
-    
-    public LayerModel getFunctionLayerModel() {
-        
-        LayerModel layer = new LayerModel(sortedStackedStarTable);
-        layer.setShowErrorBars(false);
-        layer.setShowMarks(false);
-        layer.setShowLines(true);
-        layer.setLayerType(LayerType.line.name());
-        layer.setX(SegmentColumn.Column.Spectral_Value.name());
-        layer.setY(SegmentColumn.Column.Model_Values.name());
-        layer.setLineColor(getFunctionColor());
-        layer.setLineThickness(getFunctionThickness());
-        layer.setLineDash(getFunctionDash());
-        return layer;
-    }
-    
-    public LayerModel getResidualsLayerModel(String residualType) {
-        
-        LayerModel layer = new LayerModel(sortedStackedStarTable);
-        if (residualType.equals(RATIO)) {
-            layer.setX(SegmentColumn.Column.Spectral_Value.name());
-            layer.setY(SegmentColumn.Column.Ratios.name());
-        } else if (residualType.equals(RESIDUAL)) {
-            layer.setX(SegmentColumn.Column.Spectral_Value.name());
-            layer.setY(SegmentColumn.Column.Residuals.name());
-        } else {
-            throw new IllegalArgumentException("Unrecognized residual type. "
-                    + "Must be \"ratio\" or \"residual\"");
-        }
-        
-        layer.setShowErrorBars(false);
-        layer.setShowMarks(true);
-        
-        return layer;
-    }
-    
-    public void setSedModel(SedModel sedModel) {
-        this.sedModel = sedModel;
-    }
-    
-    public SedModel getSedModel() {
-        return this.sedModel;
-    }
-    
-    public void setSortedStarTable(SortedStarTable table) {
-        this.sortedStackedStarTable = table;
     }
     
     public SortedStarTable getSortedStarTable() {

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/LayerModel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/LayerModel.java
@@ -31,6 +31,7 @@ import uk.ac.starlink.table.StarTable;
 import uk.ac.starlink.ttools.jel.ColumnIdentifier;
 
 import static cfa.vo.iris.visualizer.plotter.PlotPreferences.*;
+import java.util.List;
 
 public class LayerModel {
     
@@ -48,8 +49,12 @@ public class LayerModel {
     public static final String X_ERR_LO = "xerrlo";
     public static final String Y_ERR_LO = "yerrlo";
     public static final String COLOR = "color";
+    public static final String LINE_DASH = "dash";
+    public static final String LINE_COLOR = "color";
+    public static final String LINE_THICK = "thick";
     
     private static final String ERROR_SUFFIX = "_ERROR";
+    private static final String FUNCTION_SUFFIX = "_FUNCTION";
     
     // for the plot legend
     public static final String LEGEND_LABEL = "leglabel";
@@ -59,6 +64,9 @@ public class LayerModel {
     
     private boolean showErrorBars;
     private boolean showMarks;
+    private boolean showFunctions;
+    
+    private List<FunctionModel> functionModels;
     
     private StarTable inSource;
     
@@ -72,6 +80,9 @@ public class LayerModel {
     private String errorColor;
     private Double markColorWeight;
     private Double errorColorWeight;
+    private String lineColor;
+    private Integer lineThickness;
+    private Double lineDash;
     
     private String leglabel;
     private String[] legseq;
@@ -87,6 +98,8 @@ public class LayerModel {
         
         this.showErrorBars = true;
         this.showMarks = true;
+        this.showFunctions = true;
+        this.lineColor = "red"; // TODO: update if we show more than one model per SED. We won't always want this to be red.
     }
 
     /**
@@ -97,6 +110,7 @@ public class LayerModel {
         int layers = 0;
         if (showMarks) layers++;
         if (showErrorBars) layers++;
+        if (showFunctions) layers++;
         return layers;
     }
 
@@ -115,6 +129,11 @@ public class LayerModel {
         // for the base layer into the error bar layer.
         if (showErrorBars) {
             addErrorFields(suffix + ERROR_SUFFIX, preferences);
+        }
+        
+        // for plotting model functions
+        if (showFunctions) {
+            addFunctionFields(suffix + FUNCTION_SUFFIX, preferences);
         }
         
         return preferences;
@@ -168,6 +187,18 @@ public class LayerModel {
             prefs.put(COLOR + suffix, markColor);
         if (markColorWeight != null)
             prefs.put(markShading.name + suffix, markColorWeight);
+        
+        addCommonFields(suffix, prefs);
+    }
+    
+    private void addFunctionFields(String suffix, Map<String, Object> prefs) {
+        prefs.put(TYPE + suffix, LayerType.line.name());
+        if (lineDash != null)
+            prefs.put(LINE_DASH + suffix, lineDash);
+        if (lineColor != null)
+            prefs.put(LINE_COLOR + suffix, lineColor);
+        if (lineThickness != null)
+            prefs.put(LINE_THICK + suffix, lineThickness);
         
         addCommonFields(suffix, prefs);
     }
@@ -235,6 +266,14 @@ public class LayerModel {
     public LayerModel setShowMarks(boolean showMarks) {
         this.showMarks = showMarks;
         return this;
+    }
+    
+    public void setShowFunctions(boolean bool) {
+        this.showFunctions = bool;
+    }
+    
+    public boolean isShowFunctions() {
+        return this.showFunctions;
     }
 
     public ErrorBarType getErrorBarType() {
@@ -335,6 +374,33 @@ public class LayerModel {
     
     public String getLabel() {
         return this.leglabel;
+    }
+    
+    public String getLineColor() {
+        return lineColor;
+    }
+
+    public LayerModel setLineColor(String color) {
+        this.lineColor = color;
+        return this;
+    }
+    
+    public double getLineDash() {
+        return lineDash;
+    }
+
+    public LayerModel setLineDash(double dash) {
+        this.lineDash = dash;
+        return this;
+    }
+    
+    public int getLineThickness() {
+        return lineThickness;
+    }
+
+    public LayerModel setLineThickness(int thickness) {
+        this.lineThickness = thickness;
+        return this;
     }
 
     /*

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/LayerModel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/LayerModel.java
@@ -16,6 +16,7 @@
 
 package cfa.vo.iris.visualizer.preferences;
 
+import cfa.vo.iris.sed.stil.SegmentColumn;
 import java.io.IOException;
 import java.security.InvalidParameterException;
 import java.util.HashMap;
@@ -54,7 +55,6 @@ public class LayerModel {
     public static final String LINE_THICK = "thick";
     
     private static final String ERROR_SUFFIX = "_ERROR";
-    private static final String FUNCTION_SUFFIX = "_FUNCTION";
     
     // for the plot legend
     public static final String LEGEND_LABEL = "leglabel";
@@ -64,9 +64,11 @@ public class LayerModel {
     
     private boolean showErrorBars;
     private boolean showMarks;
-    private boolean showFunctions;
+    private boolean showLine; // for models/functions
     
-    private List<FunctionModel> functionModels;
+    private String xColName;
+    private String yColName;
+    private String layerType;
     
     private StarTable inSource;
     
@@ -96,10 +98,12 @@ public class LayerModel {
         this.setInSource(table);
         this.suffix = table.getName();
         
+        this.xColName = SegmentColumn.Column.Spectral_Value.name();
+        this.yColName = SegmentColumn.Column.Flux_Value.name();
+        
         this.showErrorBars = true;
         this.showMarks = true;
-        this.showFunctions = true;
-        this.lineColor = "red"; // TODO: update if we show more than one model per SED. We won't always want this to be red.
+        this.showLine = false;
     }
 
     /**
@@ -110,7 +114,6 @@ public class LayerModel {
         int layers = 0;
         if (showMarks) layers++;
         if (showErrorBars) layers++;
-        if (showFunctions) layers++;
         return layers;
     }
 
@@ -131,10 +134,13 @@ public class LayerModel {
             addErrorFields(suffix + ERROR_SUFFIX, preferences);
         }
         
-        // for plotting model functions
-        if (showFunctions) {
-            addFunctionFields(suffix + FUNCTION_SUFFIX, preferences);
+        if (showLine) {
+            addLineFields(suffix, preferences);
         }
+        
+        // if neither marks nor errors are shown, just add the common fields.
+        if (preferences.isEmpty())
+            addCommonFields(suffix, preferences);
         
         return preferences;
     }
@@ -191,22 +197,22 @@ public class LayerModel {
         addCommonFields(suffix, prefs);
     }
     
-    private void addFunctionFields(String suffix, Map<String, Object> prefs) {
+    private void addLineFields(String suffix, Map<String, Object> prefs) {
         prefs.put(TYPE + suffix, LayerType.line.name());
-        if (lineDash != null)
-            prefs.put(LINE_DASH + suffix, lineDash);
         if (lineColor != null)
             prefs.put(LINE_COLOR + suffix, lineColor);
+        if (markColorWeight != null)
+            prefs.put(LINE_DASH + suffix, lineDash);
         if (lineThickness != null)
-            prefs.put(LINE_THICK + suffix, lineThickness);
+            prefs.put(LINE_THICK, lineThickness);
         
         addCommonFields(suffix, prefs);
     }
     
     private void addCommonFields(String suffix, Map<String, Object> prefs) {
         prefs.put(IN + suffix, inSource);
-        prefs.put(X_COL + suffix, Column.Spectral_Value.name());
-        prefs.put(Y_COL + suffix, Column.Flux_Value.name());
+        prefs.put(X_COL + suffix, xColName);
+        prefs.put(Y_COL + suffix, yColName);
         
         // for the legend. set the flux and error layer legened names
         // to the same name
@@ -268,12 +274,22 @@ public class LayerModel {
         return this;
     }
     
-    public void setShowFunctions(boolean bool) {
-        this.showFunctions = bool;
+    public boolean getShowLines() {
+        return showLine;
     }
     
-    public boolean isShowFunctions() {
-        return this.showFunctions;
+    public LayerModel setShowLines(boolean showLine) {
+        this.showLine = showLine;
+        return this;
+    }
+    
+    public String getLayerType() {
+        return layerType;
+    }
+    
+    public LayerModel setLayerType(String type) {
+        this.layerType = type;
+        return this;
     }
 
     public ErrorBarType getErrorBarType() {
@@ -401,6 +417,22 @@ public class LayerModel {
     public LayerModel setLineThickness(int thickness) {
         this.lineThickness = thickness;
         return this;
+    }
+    
+    public void setX(String colName) {
+        this.xColName = colName;
+    }
+    
+    public String getX() {
+        return xColName;
+    }
+    
+    public void setY(String colName) {
+        this.yColName = colName;
+    }
+    
+    public String getY() {
+        return yColName;
     }
 
     /*

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/LayerModel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/LayerModel.java
@@ -139,8 +139,9 @@ public class LayerModel {
         }
         
         // if neither marks nor errors are shown, just add the common fields.
-        if (preferences.isEmpty())
+        if (preferences.isEmpty()) {
             addCommonFields(suffix, preferences);
+        }
         
         return preferences;
     }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedModel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedModel.java
@@ -16,6 +16,7 @@
 
 package cfa.vo.iris.visualizer.preferences;
 
+import cfa.vo.iris.fitting.FitConfiguration;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.LinkedList;
@@ -35,10 +36,9 @@ import cfa.vo.iris.visualizer.stil.tables.SegmentColumnInfoMatcher;
 import cfa.vo.iris.visualizer.stil.tables.StackedStarTable;
 import cfa.vo.sedlib.Segment;
 import cfa.vo.sedlib.common.SedNoDataException;
-import uk.ac.starlink.table.StarTable;
-
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import uk.ac.starlink.table.StarTable;
 
 /**
  * Maintains visualizer preferences for an SED currently in the 
@@ -57,6 +57,10 @@ public class SedModel {
     private String xunits;
     private String yunits;
     
+//    private Map<FitConfiguration, FunctionModel> evalModel;
+    private FunctionModel evalModel;
+    public final static String DefaultModelColor = "red";
+    
     public SedModel(ExtSed sed, IrisStarTableAdapter adapter) {
         this.sed = sed;
         this.adapter = adapter;
@@ -64,7 +68,8 @@ public class SedModel {
         
         this.starTableData = Collections.synchronizedMap(new IdentityHashMap<Segment, IrisStarTable>());
         this.tableLayerModels = Collections.synchronizedMap(new IdentityHashMap<Segment, LayerModel>());
-        
+//        this.evalModel = Collections.synchronizedMap(new IdentityHashMap<FitConfiguration, FunctionModel>()); // empty function model
+        this.evalModel = new FunctionModel();
         refresh();
     }
     
@@ -113,8 +118,8 @@ public class SedModel {
     }
     
     /**
-     * @return A list of all LayerModels for each Segment in this SED. List is in the same
-     * order as they appear in the SED.
+     * @return A list of all LayerModels for each Segment and FunctionModel in this SED. 
+     * List of Segment layers is in the same order as they appear in the SED.
      */
     public List<LayerModel> getLayerModels() {
         List<LayerModel> ret = new LinkedList<>();
@@ -124,6 +129,19 @@ public class SedModel {
                 ret.add(tableLayerModels.get(seg));
             }
         }
+        
+        
+//        for (int i = 0; i < evalModel.size(); i++) {
+//            if (evalModel.containsKey(i) != null) {
+//                ret.add(new LayerModel(evalModel.getInSource()));
+//            }
+//        }
+        
+        // add a funtion model layer if it exists
+        if (evalModel != null) {
+            ret.add(new LayerModel(evalModel.getInSource()));
+        }
+        
         return ret;
     }
     
@@ -223,6 +241,21 @@ public class SedModel {
         
         starTableData.remove(seg);
         return tableLayerModels.remove(seg) != null;
+    }
+    
+    /**
+     * Attaches an evaluated model to the Sed.
+     * @param model
+     */
+    public void setEvalModel(FunctionModel model) {
+        this.evalModel = model;
+    }
+    
+    /**
+     * Returns the evaluated model belonging to this ExtSed.
+     */
+    public FunctionModel getEvalModel() {
+        return this.evalModel;
     }
     
     /**

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedModel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedModel.java
@@ -57,9 +57,7 @@ public class SedModel {
     private String xunits;
     private String yunits;
     
-//    private Map<FitConfiguration, FunctionModel> evalModel;
     private FunctionModel evalModel;
-    public final static String DefaultModelColor = "red";
     
     public SedModel(ExtSed sed, IrisStarTableAdapter adapter) {
         this.sed = sed;
@@ -68,8 +66,6 @@ public class SedModel {
         
         this.starTableData = Collections.synchronizedMap(new IdentityHashMap<Segment, IrisStarTable>());
         this.tableLayerModels = Collections.synchronizedMap(new IdentityHashMap<Segment, LayerModel>());
-//        this.evalModel = Collections.synchronizedMap(new IdentityHashMap<FitConfiguration, FunctionModel>()); // empty function model
-        this.evalModel = new FunctionModel();
         refresh();
     }
     
@@ -118,7 +114,7 @@ public class SedModel {
     }
     
     /**
-     * @return A list of all LayerModels for each Segment and FunctionModel in this SED. 
+     * @return A list of all LayerModels for each Segment in this SED. 
      * List of Segment layers is in the same order as they appear in the SED.
      */
     public List<LayerModel> getLayerModels() {
@@ -128,18 +124,6 @@ public class SedModel {
             if (starTableData.containsKey(seg)) {
                 ret.add(tableLayerModels.get(seg));
             }
-        }
-        
-        
-//        for (int i = 0; i < evalModel.size(); i++) {
-//            if (evalModel.containsKey(i) != null) {
-//                ret.add(new LayerModel(evalModel.getInSource()));
-//            }
-//        }
-        
-        // add a funtion model layer if it exists
-        if (evalModel != null) {
-            ret.add(new LayerModel(evalModel.getInSource()));
         }
         
         return ret;
@@ -247,15 +231,15 @@ public class SedModel {
      * Attaches an evaluated model to the Sed.
      * @param model
      */
-    public void setEvalModel(FunctionModel model) {
+    public void setFunctionModel(FunctionModel model) {
         this.evalModel = model;
     }
     
     /**
      * Returns the evaluated model belonging to this ExtSed.
      */
-    public FunctionModel getEvalModel() {
-        return this.evalModel;
+    public FunctionModel getFunctionModel() {
+        return evalModel;
     }
     
     /**

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerDataModel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerDataModel.java
@@ -33,6 +33,7 @@ public class VisualizerDataModel {
     public static final String PROP_SELECTED_STARTABLES = "selectedStarTables";
     public static final String PROP_XUNITS = "xunits";
     public static final String PROP_YUNITS = "yunits";
+    public static final String PROP_FUNCTION_MODELS = "functionModels";
 
     private final PropertyChangeSupport pcs;
     private final VisualizerDataStore store;
@@ -62,6 +63,10 @@ public class VisualizerDataModel {
     // Yunits for StarTables
     private String yUnits = "";
     
+    // list of FunctionModels associated with selectedSeds. These tables will be overplotted
+    // as solid lines
+//    private List<FunctionModel> functionModels;
+    
     private boolean coplotted = false;
     
     public VisualizerDataModel(VisualizerComponentPreferences prefs) {
@@ -73,6 +78,7 @@ public class VisualizerDataModel {
         this.setLayerModels(new LinkedList<LayerModel>());
         this.setSedStarTables(new LinkedList<IrisStarTable>());
         this.setSelectedStarTables(new LinkedList<IrisStarTable>());
+//        this.setFunctionModels(new LinkedList<FunctionModel>());
     }
 
     public void addPropertyChangeListener(PropertyChangeListener listener) {
@@ -137,6 +143,9 @@ public class VisualizerDataModel {
         return this.coplotted;
     }
     
+    // TODO: should we allow SEDs to have multiple FunctionModels attached?
+    // If so, we should add a "getFunctionModelsForSed()" here.
+    
     /*
      * 
      * Getters and Setters
@@ -165,6 +174,7 @@ public class VisualizerDataModel {
         List<LayerModel> newSedModels = new LinkedList<>();
         List<IrisStarTable> newSedTables = new LinkedList<>();
         StringBuilder dataModelTitle = new StringBuilder();
+        //List<FunctionModel> newFunctionModel = new LinkedList<FunctionModel>();
         
         Iterator<ExtSed> it = selectedSeds.iterator();
         while (it.hasNext()) {
@@ -189,6 +199,9 @@ public class VisualizerDataModel {
             else {
                 newSedModels.addAll(sedModel.getLayerModels());
             }
+            // set a FunctionModel
+            // TODO: handle setting multiple function models
+            //newFunctionModel.add(sedModel.getEvalModel());
         }
         this.selectedSeds = ObservableCollections.observableList(selectedSeds);
         
@@ -200,6 +213,7 @@ public class VisualizerDataModel {
         this.setLayerModels(newSedModels);
         this.setSedStarTables(newSedTables);
         this.setDataModelTitle(dataModelTitle.toString());
+        //this.setFunctionModels(newFunctionModel);
         
         pcs.firePropertyChange(PROP_SELECTED_SEDS, oldSeds, selectedSeds);
     }
@@ -276,6 +290,16 @@ public class VisualizerDataModel {
         pcs.firePropertyChange(PROP_SELECTED_STARTABLES, oldStarTables, selectedStarTables);
     }
     
+//    public List<FunctionModel> getFunctionModels() {
+//        return functionModels;
+//    }
+//    
+//    public synchronized void setFunctionModels(List<FunctionModel> newFunctionModels) {
+//        List<FunctionModel> oldFunctionModels = functionModels;
+//        this.functionModels = ObservableCollections.observableList(newFunctionModels);
+//        pcs.firePropertyChange(PROP_FUNCTION_MODELS, oldFunctionModels, functionModels);
+//    }
+
     public void refresh() {
         // This is a total cop-out. Just clear all existing preferences and reset
         // with the new selected SED.
@@ -285,6 +309,7 @@ public class VisualizerDataModel {
         this.setLayerModels(new LinkedList<LayerModel>());
         this.setSedStarTables(new LinkedList<IrisStarTable>());
         this.setSelectedStarTables(new LinkedList<IrisStarTable>());
+//        this.setFunctionModels(new LinkedList<FunctionModel>());
         
         setSelectedSeds(oldSeds);
     }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerDataModel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerDataModel.java
@@ -202,6 +202,7 @@ public class VisualizerDataModel {
             // set a FunctionModel
             // TODO: handle setting multiple function models
             //newFunctionModel.add(sedModel.getEvalModel());
+            // should probably be an 'if' block ('if SED has FunctionModel')
         }
         this.selectedSeds = ObservableCollections.observableList(selectedSeds);
         

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/SortedStarTable.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/SortedStarTable.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2016 Smithsonian Astrophysical Observatory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cfa.vo.iris.visualizer.stil.tables;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import uk.ac.starlink.table.RowPermutedStarTable;
+import uk.ac.starlink.table.StarTable;
+
+/**
+ * SortedStarTable implementation borrowed from:
+ * http://www.star.bris.ac.uk/~mbt/stil/sun252/sortExample.html
+ * Supports sorting by either ascending or descending values
+ */
+@SuppressWarnings({"rawtypes", "unchecked"})
+public class SortedStarTable extends RowPermutedStarTable {
+
+    public SortedStarTable(StarTable baseTable, int sortCol, Boolean ascending) throws IOException {
+        super(baseTable);
+        
+        // BaseTable must provide Random access
+        if (!baseTable.isRandom()) {
+            throw new IllegalArgumentException("baseTable must provide random access");
+        }
+        
+        // Check that the column we are being asked to sort on has
+        // a defined sort order.
+        Class<?> clazz = baseTable.getColumnInfo( sortCol ).getContentClass();
+        if ( ! Comparable.class.isAssignableFrom( clazz ) ) {
+            throw new IllegalArgumentException( clazz + " not Comparable" );
+        }
+        
+        // Fill an array with objects which contain both the index of each
+        // row, and the object in the selected column in that row.
+        int nrow = (int) getRowCount();
+        RowKey[] keys = new RowKey[ nrow ];
+        for ( int irow = 0; irow < nrow; irow++ ) {
+            Object value = baseTable.getCell( irow, sortCol );
+            keys[ irow ] = new RowKey( (Comparable) value, irow, ascending );
+        }
+
+        // Sort the array on the values of the objects in the column;
+        // the row indices will get sorted into the right order too.
+        Arrays.sort( keys );
+
+        // Read out the values of the row indices into a permutation array.
+        long[] rowMap = new long[ nrow ];
+        for ( int irow = 0; irow < nrow; irow++ ) {
+            rowMap[ irow ] = keys[ irow ].index;
+        }
+
+        // Finally set the row permutation map of this table to the one
+        // we have just worked out.
+        setRowMap( rowMap );
+    }
+    
+    // Defines a class (just a structure really) which can hold 
+    // a row index and a value (from our selected column).
+    class RowKey implements Comparable { 
+        Comparable value;
+        int index;
+        Boolean ascending;
+        
+        RowKey( Comparable value, int index, Boolean ascending ) {
+            this.value = value;
+            this.index = index;
+            this.ascending = ascending;
+        }
+        
+        public int compareTo( Object o ) {
+            RowKey other = (RowKey) o;
+            int val = this.value.compareTo( other.value );
+            
+            // If ascending switch the comparison
+            return !ascending ? -1 * val : val;
+        }
+    }
+}

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/plotter/StilPlotterTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/plotter/StilPlotterTest.java
@@ -18,13 +18,17 @@ package cfa.vo.iris.visualizer.plotter;
 import cfa.vo.iris.visualizer.plotter.StilPlotter;
 import static org.junit.Assert.*;
 import cfa.vo.iris.sed.ExtSed;
+import cfa.vo.iris.sed.stil.SegmentColumn;
 import cfa.vo.iris.sed.stil.SegmentStarTable;
 import cfa.vo.iris.test.Ws;
 import cfa.vo.iris.visualizer.plotter.PlotPreferences.PlotType;
 import cfa.vo.iris.test.unit.TestUtils;
 import cfa.vo.iris.visualizer.plotter.PlotterView;
 import cfa.vo.iris.visualizer.preferences.FunctionModel;
+import cfa.vo.iris.visualizer.preferences.LayerModel;
+import cfa.vo.iris.visualizer.preferences.SedModel;
 import cfa.vo.iris.visualizer.preferences.VisualizerComponentPreferences;
+import cfa.vo.iris.visualizer.stil.tables.SortedStarTable;
 import cfa.vo.sedlib.Segment;
 import cfa.vo.sedlib.io.SedFormat;
 
@@ -41,7 +45,9 @@ import uk.ac.starlink.ttools.plot2.geom.PlaneSurfaceFactory.Profile;
 import uk.ac.starlink.ttools.plot2.task.PlotDisplay;
 import uk.ac.starlink.ttools.task.MapEnvironment;
 import cfa.vo.testdata.TestData;
+import java.util.List;
 import uk.ac.starlink.task.BooleanParameter;
+import uk.ac.starlink.ttools.jel.ColumnIdentifier;
 
 public class StilPlotterTest {
     
@@ -299,27 +305,41 @@ public class StilPlotterTest {
     @Test
     public void testPlotFunctionModel() throws Exception {
         
-        // create a SegmentStarTable that represents the evaluated model
-        SegmentStarTable evalModelTable = new SegmentStarTable(TestUtils.createSampleSegment());
-        String evalModelTableName = evalModelTable.getName();
+        // create a sed
+        Segment seg = TestUtils.createSampleSegment();
+        ExtSed sed = new ExtSed("my_sed", true);
+        sed.addSegment(seg);
         
-        preferences = new VisualizerComponentPreferences(ws);
-        StilPlotter plot = new StilPlotter(preferences);
+        StilPlotter plot = setUpTests(sed);
         
-        // plot the model
-        plot.plotModel(evalModelTable);
+        SedModel model = plot.getPreferences().getDataModel().getSedModel(sed);
+        model.getDataTables().get(0).getPlotterDataTable().setModelValues(seg.getFluxAxisValues());
+        FunctionModel functionModel = new FunctionModel(model);
+        
+        LayerModel layer = functionModel.getFunctionLayerModel();
+        String functionLayerName = layer.getSuffix();
+        
+        assertEquals("red", layer.getLineColor());
+        assertEquals("line", layer.getLayerType());
+        
+        // set the function model
+        plot.getDataModel().getSedModel(sed).setFunctionModel(functionModel);
+        
+        // replot
+        plot.resetPlot(false, false);
+        
         PlotDisplay<?, ?> display = plot.getPlotDisplay();
         
         // check that plot env is correctly set
         MapEnvironment env = plot.getEnv();
 
         // check color
-        StringParameter par = new StringParameter("color"+evalModelTableName);
+        StringParameter par = new StringParameter("color"+functionLayerName);
         env.acquireValue(par);
         assertEquals(par.objectValue(env), "red");
         
         // check that a line is plotted
-        par.setName("layer"+evalModelTableName);
+        par.setName("layer"+functionLayerName);
         env.acquireValue(par);
         assertEquals(par.objectValue(env), "line");
         
@@ -328,11 +348,9 @@ public class StilPlotterTest {
         layers_.setAccessible(true);
         PlotLayer[] layers = (PlotLayer[]) layers_.get(display);
         
-        // there should be one layer for the function/model
+        // there should be 3 layers for the function/model, flux, and errs
         assertTrue(!ArrayUtils.isEmpty(layers));
-        assertEquals(1, ArrayUtils.getLength(layers));
-        assertEquals(layers[0].getDataSpec().getSourceTable().getRowCount(), 
-                evalModelTable.getRowCount());
+        assertEquals(3, ArrayUtils.getLength(layers));
     }
     
     private StilPlotter setUpTests(ExtSed sed) throws Exception {

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/plotter/StilPlotterTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/plotter/StilPlotterTest.java
@@ -18,8 +18,10 @@ package cfa.vo.iris.visualizer.plotter;
 import cfa.vo.iris.visualizer.plotter.StilPlotter;
 import static org.junit.Assert.*;
 import cfa.vo.iris.sed.ExtSed;
+import cfa.vo.iris.sed.stil.SegmentStarTable;
 import cfa.vo.iris.test.Ws;
 import cfa.vo.iris.visualizer.plotter.PlotPreferences.PlotType;
+import cfa.vo.iris.test.unit.TestUtils;
 import cfa.vo.iris.visualizer.plotter.PlotterView;
 import cfa.vo.iris.visualizer.preferences.VisualizerComponentPreferences;
 import cfa.vo.sedlib.Segment;
@@ -292,6 +294,78 @@ public class StilPlotterTest {
         assertEquals(1, aspect.getYMax(), 0.01);
         assertEquals(1.0, aspect.getXMin(), 0.01);
         assertEquals(0, aspect.getYMin(), 0.01);
+    }
+    @Test
+    public void testPlotModel() throws Exception {
+        
+        // create a SegmentStarTable that represents the evaluated model
+        SegmentStarTable evalModelTable = new SegmentStarTable(TestUtils.createSampleSegment());
+        String evalModelTableName = evalModelTable.getName();
+        
+        preferences = new VisualizerComponentPreferences(ws);
+        StilPlotter plot = new StilPlotter(preferences);
+        
+        // plot the model
+        plot.plot_model(evalModelTable);
+        PlotDisplay<?, ?> display = plot.getPlotDisplay();
+        
+        // check that plot env is correctly set
+        MapEnvironment env = plot.getEnv();
+
+        // check color
+        StringParameter par = new StringParameter("color"+evalModelTableName);
+        env.acquireValue(par);
+        assertEquals(par.objectValue(env), "red");
+        
+        // check that a line is plotted
+        par.setName("layer"+evalModelTableName);
+        env.acquireValue(par);
+        assertEquals(par.objectValue(env), "line");
+        
+        // using reflection to access layers in plot display
+        Field layers_ = PlotDisplay.class.getDeclaredField("layers_");
+        layers_.setAccessible(true);
+        PlotLayer[] layers = (PlotLayer[]) layers_.get(display);
+        
+        // there should be one layer for the model
+        assertTrue(!ArrayUtils.isEmpty(layers));
+        assertEquals(ArrayUtils.getLength(layers), 1);
+        assertEquals(layers[0].getDataSpec().getSourceTable().getRowCount(), 
+                evalModelTable.getRowCount());
+        
+        
+        // Now, add some data to the plot, and use a large-ranged model to overplot.
+        // I want to make sure that when a user overplots a model on a 
+        // relatively small dataset, the plotter window doesn't zoom-out to 
+        // include the whole model. Imagine a powerlaw that goes from
+        // -infinity to +infinity; we wouldn't want the plotter to zoom out.
+        
+        // create a small sample SED
+        ExtSed sed = new ExtSed("my_sed");
+        sed.addSegment(TestUtils.createSampleSegment());
+        
+        // create plot
+        plot = setUpTests(sed);
+        
+        // create a large model
+        evalModelTable = new SegmentStarTable(
+                ExtSed.read(
+                        TestData.class.getResource("3c273.vot").openStream(), 
+                        SedFormat.VOT)
+                .getSegment(0));
+        
+        // overplot the model on the StilPlotter
+        plot.plot_model(evalModelTable);
+        
+        display = plot.getPlotDisplay();
+        
+        // using reflection to access layers in plot display
+        layers_ = PlotDisplay.class.getDeclaredField("layers_");
+        layers_.setAccessible(true);
+        layers = (PlotLayer[]) layers_.get(display);
+        
+        // there should be 3 layers: data, errors, and model
+        assertEquals(ArrayUtils.getLength(layers), 3);
     }
     
     private StilPlotter setUpTests(ExtSed sed) throws Exception {

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/plotter/StilPlotterTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/plotter/StilPlotterTest.java
@@ -23,6 +23,7 @@ import cfa.vo.iris.test.Ws;
 import cfa.vo.iris.visualizer.plotter.PlotPreferences.PlotType;
 import cfa.vo.iris.test.unit.TestUtils;
 import cfa.vo.iris.visualizer.plotter.PlotterView;
+import cfa.vo.iris.visualizer.preferences.FunctionModel;
 import cfa.vo.iris.visualizer.preferences.VisualizerComponentPreferences;
 import cfa.vo.sedlib.Segment;
 import cfa.vo.sedlib.io.SedFormat;
@@ -296,7 +297,7 @@ public class StilPlotterTest {
         assertEquals(0, aspect.getYMin(), 0.01);
     }
     @Test
-    public void testPlotModel() throws Exception {
+    public void testPlotFunctionModel() throws Exception {
         
         // create a SegmentStarTable that represents the evaluated model
         SegmentStarTable evalModelTable = new SegmentStarTable(TestUtils.createSampleSegment());
@@ -306,7 +307,7 @@ public class StilPlotterTest {
         StilPlotter plot = new StilPlotter(preferences);
         
         // plot the model
-        plot.plot_model(evalModelTable);
+        plot.plotModel(evalModelTable);
         PlotDisplay<?, ?> display = plot.getPlotDisplay();
         
         // check that plot env is correctly set
@@ -327,7 +328,7 @@ public class StilPlotterTest {
         layers_.setAccessible(true);
         PlotLayer[] layers = (PlotLayer[]) layers_.get(display);
         
-        // there should be one layer for the model
+        // there should be one layer for the function/model
         assertTrue(!ArrayUtils.isEmpty(layers));
         assertEquals(ArrayUtils.getLength(layers), 1);
         assertEquals(layers[0].getDataSpec().getSourceTable().getRowCount(), 
@@ -355,7 +356,7 @@ public class StilPlotterTest {
                 .getSegment(0));
         
         // overplot the model on the StilPlotter
-        plot.plot_model(evalModelTable);
+        plot.plotModel(evalModelTable);
         
         display = plot.getPlotDisplay();
         

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/plotter/StilPlotterTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/plotter/StilPlotterTest.java
@@ -330,43 +330,9 @@ public class StilPlotterTest {
         
         // there should be one layer for the function/model
         assertTrue(!ArrayUtils.isEmpty(layers));
-        assertEquals(ArrayUtils.getLength(layers), 1);
+        assertEquals(1, ArrayUtils.getLength(layers));
         assertEquals(layers[0].getDataSpec().getSourceTable().getRowCount(), 
                 evalModelTable.getRowCount());
-        
-        
-        // Now, add some data to the plot, and use a large-ranged model to overplot.
-        // I want to make sure that when a user overplots a model on a 
-        // relatively small dataset, the plotter window doesn't zoom-out to 
-        // include the whole model. Imagine a powerlaw that goes from
-        // -infinity to +infinity; we wouldn't want the plotter to zoom out.
-        
-        // create a small sample SED
-        ExtSed sed = new ExtSed("my_sed");
-        sed.addSegment(TestUtils.createSampleSegment());
-        
-        // create plot
-        plot = setUpTests(sed);
-        
-        // create a large model
-        evalModelTable = new SegmentStarTable(
-                ExtSed.read(
-                        TestData.class.getResource("3c273.vot").openStream(), 
-                        SedFormat.VOT)
-                .getSegment(0));
-        
-        // overplot the model on the StilPlotter
-        plot.plotModel(evalModelTable);
-        
-        display = plot.getPlotDisplay();
-        
-        // using reflection to access layers in plot display
-        layers_ = PlotDisplay.class.getDeclaredField("layers_");
-        layers_.setAccessible(true);
-        layers = (PlotLayer[]) layers_.get(display);
-        
-        // there should be 3 layers: data, errors, and model
-        assertEquals(ArrayUtils.getLength(layers), 3);
     }
     
     private StilPlotter setUpTests(ExtSed sed) throws Exception {

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/tables/SortedStarTableTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/tables/SortedStarTableTest.java
@@ -1,0 +1,58 @@
+package cfa.vo.iris.visualizer.stil.tables;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import uk.ac.starlink.table.ColumnInfo;
+import uk.ac.starlink.table.ColumnStarTable;
+import uk.ac.starlink.table.PrimitiveArrayColumn;
+
+public class SortedStarTableTest {
+    
+    @Test
+    public void testSortedStarTable() throws Exception {
+        
+        ColumnInfo c1 = new ColumnInfo("c1");
+        c1.setContentClass(Integer.class);
+        ColumnInfo c2 = new ColumnInfo("c1");
+        c2.setContentClass(Integer.class);
+        
+        ColumnStarTable base = ColumnStarTable.makeTableWithRows(3);
+        base.addColumn(PrimitiveArrayColumn.makePrimitiveColumn(c1, new int[] {2, 1, 3}));
+        base.addColumn(PrimitiveArrayColumn.makePrimitiveColumn(c2, new int[] {3, 2, 1}));
+        
+        // Sort on c2, ascending
+        SortedStarTable t1 = new SortedStarTable(base, 1, true);
+        
+        // Verify columns sorted on second values
+        assertEquals((int) t1.getCell(0, 1), 1);
+        assertEquals((int) t1.getCell(1, 1), 2);
+        assertEquals((int) t1.getCell(2, 1), 3);
+        
+        // First column in reverse order
+        assertEquals((int) t1.getCell(0, 0), 3);
+        assertEquals((int) t1.getCell(1, 0), 1);
+        assertEquals((int) t1.getCell(2, 0), 2);
+        
+        // Base table still in same order?
+        assertEquals((int) base.getCell(0, 1), 3);
+        assertEquals((int) base.getCell(1, 1), 2);
+        assertEquals((int) base.getCell(2, 1), 1);
+        
+        //
+        // Sort on c1, descending
+        //
+        SortedStarTable t2 = new SortedStarTable(base, 0, false);
+        
+        // First column in sorted, descending order
+        assertEquals((int) t2.getCell(0, 0), 3);
+        assertEquals((int) t2.getCell(1, 0), 2);
+        assertEquals((int) t2.getCell(2, 0), 1);
+        
+        // Second column matches first
+        assertEquals((int) t2.getCell(0, 1), 1);
+        assertEquals((int) t2.getCell(1, 1), 3);
+        assertEquals((int) t2.getCell(2, 1), 2);
+    }
+}


### PR DESCRIPTION
Adds the capability of plotting a model on top of an SED.

This PR provides a very simple visualization of a plotted model. It assumes that the evaluated model is a SegmentStarTable. The method is called with `StilPlotter::plot_model(SegmentStarTable model)`.

A `FunctionModel` is the evaluated model's (or function's) "model", which contains the STILTS preferences for plotting a StarTable as a line. It is similar to the `SegmentModel` object. It's list of preferences is shorter: you can control the line thickness, color, and pattern. For now, the defaults are the same as STILTS' defaults: a solid, red line of thickness 1 (thin like Iris 2.1's line).

To take a look at the model on the visualizer, I've added a dummy "Plot Model" functionality to the PlotterView frame. It plots a FunctionModel version of the currently selected SED. I expect to remove/replace this functionality when we have fitting notifications defined.

Outstanding questions:

 - What should happen if a user overplots a relatively large model on a short SED? I.e., if the model's x range and/or y range >> SED's x and y range. Should the plot aspect increase to include the entirety of the model, or should it stay focused on the SED's data range? No matter what, users could still zoom in/out of the plot as usual. This question would determine how the `resetPlot()` method works when plotting functions.

