### PR TITLE
Model evaluation startable

### DIFF
--- a/iris-common/src/main/java/cfa/vo/iris/sed/ExtSed.java
+++ b/iris-common/src/main/java/cfa/vo/iris/sed/ExtSed.java
@@ -405,4 +405,24 @@ public class ExtSed extends Sed {
         
         return super.equals(o);
     }
+
+    public static Segment makeSegment(double[] x, double[] y, String xUnit, String yUnit) throws SedNoDataException {
+        Segment s = new Segment();
+        s.setSpectralAxisValues(x);
+        s.setFluxAxisValues(y);
+        s.setSpectralAxisUnits(xUnit);
+        s.setFluxAxisUnits(yUnit);
+        return s;
+    }
+
+    public static ExtSed makeSed(String name, boolean managed, double[] x, double[] y, String xUnit, String yUnit) throws SedNoDataException {
+        Segment s = makeSegment(x, y, xUnit, yUnit);
+        ExtSed sed = new ExtSed(name, managed);
+        try {
+            sed.addSegment(s);
+        } catch (SedInconsistentException e) {
+            throw new IllegalStateException("Incompatible Sed when creating Sed with single Segment");
+        }
+        return sed;
+    }
 }

--- a/iris-common/src/main/java/cfa/vo/iris/sed/stil/SegmentColumn.java
+++ b/iris-common/src/main/java/cfa/vo/iris/sed/stil/SegmentColumn.java
@@ -161,8 +161,11 @@ public abstract class SegmentColumn extends ColumnData
         Flux_Error_Low("Y axis low error values", "iris.flux.value.error.low", Double.class),
         Original_Flux_Error("Original Y axis error values", "iris.flux.value.original.error", Double.class),
         Original_Flux_Error_Hi("Original Y axis upper error values", "iris.flux.value.original.error.high", Double.class),
-        Original_Flux_Error_Low("Original Y axis low error values", "iris.flux.value.original.error.low", Double.class);
-        
+        Original_Flux_Error_Low("Original Y axis low error values", "iris.flux.value.original.error.low", Double.class),
+        Model_Values("Evaluated values from fit model", "iris.fit.values", Double.class),
+        Residuals("Observed - Expected", "iris.fit.residuals", Double.class),
+        Ratios("abs(Observerd - Expected)/Expected", "iris.fit.ratios", Double.class);
+
         
         public String description;
         public String utype;

--- a/iris-common/src/main/java/cfa/vo/iris/sed/stil/SegmentStarTable.java
+++ b/iris-common/src/main/java/cfa/vo/iris/sed/stil/SegmentStarTable.java
@@ -81,6 +81,9 @@ public class SegmentStarTable extends RandomStarTable {
     private double[] fluxErrValues;
     private double[] fluxErrValuesLo;
     private double[] fluxErrValuesHi;
+    private double[] modelValues;
+    private double[] residualValues;
+    private double[] ratioValues;
 
     public SegmentStarTable(double[] x, double[] y, String xUnit, String yUnit)
             throws SedNoDataException, UnitsException, SedInconsistentException {
@@ -390,6 +393,33 @@ public class SegmentStarTable extends RandomStarTable {
     public void setFluxErrValuesHi(double[] fluxErrValuesHi) {
         this.fluxErrValuesHi = fluxErrValuesHi;
         updateColumnValues(fluxErrValuesHi, Column.Flux_Error_High);
+    }
+
+    public double[] getModelValues() {
+        return modelValues;
+    }
+
+    public void setModelValues(double[] modelValues) {
+        this.modelValues = modelValues;
+        updateColumnValues(modelValues, Column.Model_Values);
+    }
+
+    public double[] getResidualValues() {
+        return residualValues;
+    }
+
+    public void setResidualValues(double[] residualValues) {
+        this.residualValues = residualValues;
+        updateColumnValues(residualValues, Column.Residuals);
+    }
+
+    public double[] getRatioValues() {
+        return ratioValues;
+    }
+
+    public void setRatioValues(double[] ratioValues) {
+        this.ratioValues = ratioValues;
+        updateColumnValues(ratioValues, Column.Ratios);
     }
 
     /**

--- a/iris-common/src/main/java/cfa/vo/iris/sed/stil/SegmentStarTable.java
+++ b/iris-common/src/main/java/cfa/vo/iris/sed/stil/SegmentStarTable.java
@@ -23,6 +23,7 @@ import java.util.TreeSet;
 import java.util.UUID;
 import java.util.logging.Logger;
 
+import cfa.vo.iris.sed.ExtSed;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 
@@ -80,7 +81,12 @@ public class SegmentStarTable extends RandomStarTable {
     private double[] fluxErrValues;
     private double[] fluxErrValuesLo;
     private double[] fluxErrValuesHi;
-    
+
+    public SegmentStarTable(double[] x, double[] y, String xUnit, String yUnit)
+            throws SedNoDataException, UnitsException, SedInconsistentException {
+        this(ExtSed.makeSegment(x, y, xUnit, yUnit));
+    }
+
     public SegmentStarTable(Segment segment) 
             throws SedNoDataException, UnitsException, SedInconsistentException {
         this(segment, null);

--- a/iris-common/src/main/java/cfa/vo/sherpa/SherpaClient.java
+++ b/iris-common/src/main/java/cfa/vo/sherpa/SherpaClient.java
@@ -55,16 +55,17 @@ public class SherpaClient {
         return fit(conf);
     }
 
-    public Data evaluate(ExtSed sed) throws Exception {
-        SherpaFitConfiguration conf = make(sed);
+    public double[] evaluate(double[] x, FitConfiguration fit) throws Exception {
+        SherpaFitConfiguration conf = make(x, fit);
         return evaluate(conf);
     }
 
-    public Data evaluate(SherpaFitConfiguration conf) throws Exception {
+    public double[] evaluate(SherpaFitConfiguration conf) throws Exception {
         fixDatasets(conf);
         SAMPMessage message = SAMPFactory.createMessage(EVALUATE_MTYPE, conf, SherpaFitConfiguration.class);
         Response response = sendMessage(message);
-        return SAMPFactory.get(response.getResult(), Data.class);
+        Data out = SAMPFactory.get(response.getResult(), Data.class);
+        return out.getY();
     }
 
     public FitResults fit(Data data, FitConfiguration fit) throws Exception {
@@ -150,6 +151,13 @@ public class SherpaClient {
         }
 
         return fc;
+    }
+
+    private SherpaFitConfiguration make(double[] x, FitConfiguration fit) {
+        Data data = SAMPFactory.get(Data.class);
+        data.setName(DATA_NAME);
+        data.setX(x);
+        return make(data, fit);
     }
 
     SherpaFitConfiguration make(ExtSed sed) throws Exception {

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedModel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedModel.java
@@ -21,6 +21,8 @@ import java.util.IdentityHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+
+import cfa.vo.iris.fitting.FitConfiguration;
 import org.apache.commons.lang.StringUtils;
 
 import cfa.vo.iris.sed.ExtSed;
@@ -279,5 +281,9 @@ public class SedModel {
 
     public String getYUnits() {
         return yunits;
+    }
+
+    public FitConfiguration getFitConfiguration() {
+        return sed.getFit();
     }
 }

--- a/iris-visualizer/src/test/java/cfa/vo/iris/fitting/FitControllerIT.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/fitting/FitControllerIT.java
@@ -17,10 +17,13 @@ package cfa.vo.iris.fitting;
 
 import cfa.vo.interop.SAMPFactory;
 import cfa.vo.iris.fitting.custom.CustomModelsManager;
-import cfa.vo.iris.fitting.custom.DefaultCustomModel;
 import cfa.vo.iris.sed.ExtSed;
+import cfa.vo.iris.sed.stil.SegmentStarTable;
 import cfa.vo.iris.test.unit.SherpaResource;
 import cfa.vo.iris.test.unit.TestUtils;
+import cfa.vo.iris.units.UnitsManager;
+import cfa.vo.iris.visualizer.preferences.SedModel;
+import cfa.vo.iris.visualizer.stil.tables.IrisStarTableAdapter;
 import cfa.vo.sedlib.Segment;
 import cfa.vo.sherpa.ConfidenceResults;
 import cfa.vo.sherpa.Data;
@@ -29,17 +32,13 @@ import cfa.vo.sherpa.SherpaClient;
 import cfa.vo.sherpa.models.*;
 import cfa.vo.sherpa.optimization.OptimizationMethod;
 import cfa.vo.sherpa.stats.Statistic;
-import net.javacrumbs.jsonunit.JsonAssert;
+import cfa.vo.utils.Default;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertArrayEquals;
@@ -51,6 +50,7 @@ public class FitControllerIT {
     private CustomModelsManager modelsManager;
     private SherpaClient client;
     private Data data;
+    private SedModel sedModel;
     private double[] x = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
     private double[] y = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
     private double[] err = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
@@ -72,6 +72,7 @@ public class FitControllerIT {
         data.setStaterror(err);
         client = sherpa.getClient();
         controller = new FitController(sed, modelsManager, client);
+        sedModel = new SedModel(sed, new IrisStarTableAdapter(null));
     }
 
     @Test
@@ -87,10 +88,49 @@ public class FitControllerIT {
         model.findParameter("c0").setVal(0.0);
         model.findParameter("c1").setVal(1.0);
         model.findParameter("c1").setFrozen(0);
-        Data data = controller.evaluateModel();
-        assertArrayEquals(x, data.getX(), 0.001);
-        assertArrayEquals(y, data.getY(), 0.001);
-        assertArrayEquals(err, data.getStaterror(), 0.001);
+        SegmentStarTable data = controller.evaluateModel(sedModel);
+        assertArrayEquals(x, data.getSpecValues(), 0.001);
+        assertArrayEquals(y, data.getFluxValues(), 0.001);
+        assertEquals(SherpaClient.X_UNIT, data.getSpecUnits().toString());
+        assertEquals(SherpaClient.Y_UNIT, data.getFluxUnits().toString());
+    }
+
+    @Test
+    public void testEvaluateUnitsConversionY() throws Exception {
+        String localUnit = "Jy";
+        sedModel.setUnits(SherpaClient.X_UNIT, localUnit);
+        Model model = controller.getFit().getModel().getParts().get(0);
+        model.findParameter("c0").setVal(0.0);
+        model.findParameter("c1").setVal(1.0);
+        model.findParameter("c1").setFrozen(0);
+        SegmentStarTable data = controller.evaluateModel(sedModel);
+        assertArrayEquals(x, data.getSpecValues(), 0.001);
+
+        UnitsManager uManager = Default.getInstance().getUnitsManager();
+        double[] yConverted = uManager.convertY(y, x, SherpaClient.Y_UNIT, SherpaClient.X_UNIT, localUnit);
+        assertArrayEquals(yConverted, data.getFluxValues(), 0.001);
+        assertEquals(SherpaClient.X_UNIT, data.getSpecUnits().toString());
+        assertEquals(localUnit, data.getFluxUnits().toString());
+    }
+
+    @Test
+    public void testEvaluateUnitsConversionXY() throws Exception {
+        String xUnit = "Hz";
+        String yUnit = "Jy";
+        sedModel.setUnits(xUnit, yUnit);
+        Model model = controller.getFit().getModel().getParts().get(0);
+        model.findParameter("c0").setVal(0.0);
+        model.findParameter("c1").setVal(1.0);
+        model.findParameter("c1").setFrozen(0);
+        SegmentStarTable data = controller.evaluateModel(sedModel);
+
+        UnitsManager uManager = Default.getInstance().getUnitsManager();
+        double[] xConverted = uManager.convertX(x, SherpaClient.X_UNIT, xUnit);
+        double[] yConverted = uManager.convertY(y, x, SherpaClient.Y_UNIT, SherpaClient.X_UNIT, yUnit);
+        assertArrayEquals(xConverted, data.getSpecValues(), 0.001);
+        assertArrayEquals(yConverted, data.getFluxValues(), 0.001);
+        assertEquals(yUnit, data.getFluxUnits().toString());
+        assertEquals(xUnit, data.getSpecUnits().toString());
     }
 
     private FitConfiguration createFit() throws Exception {

--- a/iris-visualizer/src/test/java/cfa/vo/iris/fitting/FitControllerIT.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/fitting/FitControllerIT.java
@@ -88,9 +88,37 @@ public class FitControllerIT {
         model.findParameter("c0").setVal(0.0);
         model.findParameter("c1").setVal(1.0);
         model.findParameter("c1").setFrozen(0);
-        SegmentStarTable data = controller.evaluateModel(sedModel);
+        controller.evaluateModel(sedModel);
+        SegmentStarTable data = sedModel.getDataTables().get(0).getPlotterDataTable();
         assertArrayEquals(x, data.getSpecValues(), 0.001);
-        assertArrayEquals(y, data.getFluxValues(), 0.001);
+        assertArrayEquals(y, data.getModelValues(), 0.001);
+
+        double[] zeros = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+        assertArrayEquals(zeros, data.getResidualValues(), 0.001);
+        assertArrayEquals(zeros, data.getRatioValues(), 0.001);
+
+        assertEquals(SherpaClient.X_UNIT, data.getSpecUnits().toString());
+        assertEquals(SherpaClient.Y_UNIT, data.getFluxUnits().toString());
+    }
+
+    @Test
+    public void testEvaluatePoorModel() throws Exception {
+        Model model = controller.getFit().getModel().getParts().get(0);
+        model.findParameter("c0").setVal(0.0);
+        model.findParameter("c1").setVal(2.0); // force to have wrong value
+        model.findParameter("c1").setFrozen(1);
+        controller.evaluateModel(sedModel);
+        SegmentStarTable data = sedModel.getDataTables().get(0).getPlotterDataTable();
+        assertArrayEquals(x, data.getSpecValues(), 0.001);
+
+        double[] y = {2.0, 4.0, 6.0, 8.0, 10.0, 12.0};
+        assertArrayEquals(y, data.getModelValues(), 0.001);
+
+        double[] expectedResiduals = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
+        double[] expectedRatios = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
+        assertArrayEquals(expectedResiduals, data.getResidualValues(), 0.001);
+        assertArrayEquals(expectedRatios, data.getRatioValues(), 0.001);
+
         assertEquals(SherpaClient.X_UNIT, data.getSpecUnits().toString());
         assertEquals(SherpaClient.Y_UNIT, data.getFluxUnits().toString());
     }
@@ -103,12 +131,18 @@ public class FitControllerIT {
         model.findParameter("c0").setVal(0.0);
         model.findParameter("c1").setVal(1.0);
         model.findParameter("c1").setFrozen(0);
-        SegmentStarTable data = controller.evaluateModel(sedModel);
+        controller.evaluateModel(sedModel);
+        SegmentStarTable data = sedModel.getDataTables().get(0).getPlotterDataTable();
         assertArrayEquals(x, data.getSpecValues(), 0.001);
 
         UnitsManager uManager = Default.getInstance().getUnitsManager();
         double[] yConverted = uManager.convertY(y, x, SherpaClient.Y_UNIT, SherpaClient.X_UNIT, localUnit);
-        assertArrayEquals(yConverted, data.getFluxValues(), 0.001);
+        assertArrayEquals(yConverted, data.getModelValues(), 0.001);
+
+        double[] zeros = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+        assertArrayEquals(zeros, data.getResidualValues(), 0.001);
+        assertArrayEquals(zeros, data.getRatioValues(), 0.001);
+
         assertEquals(SherpaClient.X_UNIT, data.getSpecUnits().toString());
         assertEquals(localUnit, data.getFluxUnits().toString());
     }
@@ -122,13 +156,19 @@ public class FitControllerIT {
         model.findParameter("c0").setVal(0.0);
         model.findParameter("c1").setVal(1.0);
         model.findParameter("c1").setFrozen(0);
-        SegmentStarTable data = controller.evaluateModel(sedModel);
+        controller.evaluateModel(sedModel);
+        SegmentStarTable data = sedModel.getDataTables().get(0).getPlotterDataTable();
 
         UnitsManager uManager = Default.getInstance().getUnitsManager();
         double[] xConverted = uManager.convertX(x, SherpaClient.X_UNIT, xUnit);
         double[] yConverted = uManager.convertY(y, x, SherpaClient.Y_UNIT, SherpaClient.X_UNIT, yUnit);
         assertArrayEquals(xConverted, data.getSpecValues(), 0.001);
-        assertArrayEquals(yConverted, data.getFluxValues(), 0.001);
+        assertArrayEquals(yConverted, data.getModelValues(), 0.001);
+
+        double[] zeros = new double[]{0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+        assertArrayEquals(zeros, data.getResidualValues(), 0.001);
+        assertArrayEquals(zeros, data.getRatioValues(), 0.001);
+
         assertEquals(yUnit, data.getFluxUnits().toString());
         assertEquals(xUnit, data.getSpecUnits().toString());
     }

--- a/iris-visualizer/src/test/java/cfa/vo/iris/fitting/FitControllerTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/fitting/FitControllerTest.java
@@ -22,6 +22,7 @@ import cfa.vo.iris.sed.ExtSed;
 import cfa.vo.iris.sed.stil.SegmentStarTable;
 import cfa.vo.iris.test.unit.TestUtils;
 import cfa.vo.iris.visualizer.preferences.SedModel;
+import cfa.vo.iris.visualizer.stil.tables.IrisStarTable;
 import cfa.vo.iris.visualizer.stil.tables.IrisStarTableAdapter;
 import cfa.vo.sherpa.ConfidenceResults;
 import cfa.vo.sherpa.Data;
@@ -96,11 +97,16 @@ public class FitControllerTest {
     public void testEvaluate() throws Exception {
         ExtSed sed = ExtSed.makeSed("test", false, x, y, SherpaClient.X_UNIT, SherpaClient.Y_UNIT);
         SedModel model = new SedModel(sed, new IrisStarTableAdapter(null));
-        SegmentStarTable out = controller.evaluateModel(model);
-        assertArrayEquals(x, out.getSpecValues(), 0.001);
-        assertArrayEquals(y, out.getFluxValues(), 0.001);
-        assertEquals(SherpaClient.X_UNIT, out.getSpecUnits().toString());
-        assertEquals(SherpaClient.Y_UNIT, out.getFluxUnits().toString());
+        controller.evaluateModel(model);
+        SegmentStarTable data = model.getDataTables().get(0).getPlotterDataTable();
+        assertArrayEquals(x, data.getSpecValues(), 0.001);
+        assertArrayEquals(y, data.getModelValues(), 0.001);
+
+        double[] zeros = new double[]{0.0, 0.0, 0.0};
+        assertArrayEquals(zeros, data.getResidualValues(), 0.001);
+        assertArrayEquals(zeros, data.getRatioValues(), 0.001);
+        assertEquals(SherpaClient.X_UNIT, data.getSpecUnits().toString());
+        assertEquals(SherpaClient.Y_UNIT, data.getFluxUnits().toString());
     }
 
     private FitConfiguration createFit() throws Exception {


### PR DESCRIPTION
This PR modifies the model evaluation method created in #298 to return a `SegmentStarTable`, which can be integrated in the visualizer to plot model functions. It also accepts a `SedModel` instance as an argument, as this is the model class used by the visualizer internally.

Units conversion should be properly handled by the method and its dependencies. When reviewing, please pay special attention to the tests: they should make sure the conversion is properly handled, but we need careful validation that I did the right calculations (I used astropy to validate the conversions, but I might have made the same mistake twice ;).

Also, you are welcome to suggest error handling test cases to add.

Note that this PR is based off of #303 for convenience, but only 3db91cf is relevant for this PR.