### PR TITLE
Enable Panning Buttons for the Plot Window

### DIFF
--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.form
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.form
@@ -375,6 +375,9 @@
                   <Dimension value="null"/>
                 </Property>
               </Properties>
+              <Events>
+                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="upActionPerformed"/>
+              </Events>
             </Component>
             <Component class="cfa.vo.iris.visualizer.plotter.JButtonArrow" name="down">
               <Properties>
@@ -388,6 +391,9 @@
                   <Dimension value="null"/>
                 </Property>
               </Properties>
+              <Events>
+                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="downActionPerformed"/>
+              </Events>
             </Component>
             <Component class="cfa.vo.iris.visualizer.plotter.JButtonArrow" name="left">
               <Properties>
@@ -401,6 +407,9 @@
                   <Dimension value="null"/>
                 </Property>
               </Properties>
+              <Events>
+                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="leftActionPerformed"/>
+              </Events>
             </Component>
             <Component class="cfa.vo.iris.visualizer.plotter.JButtonArrow" name="right">
               <Properties>
@@ -414,6 +423,9 @@
                   <Dimension value="null"/>
                 </Property>
               </Properties>
+              <Events>
+                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="rightActionPerformed"/>
+              </Events>
             </Component>
           </SubComponents>
         </Container>

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
@@ -29,6 +29,7 @@ import java.awt.event.ActionListener;
 import java.util.logging.Logger;
 import javax.swing.JFrame;
 import javax.swing.JInternalFrame;
+import javax.swing.SwingConstants;
 
 public class PlotterView extends JInternalFrame {
     
@@ -373,24 +374,44 @@ public class PlotterView extends JInternalFrame {
         up.setContentAreaFilled(false);
         up.setMaximumSize(null);
         up.setMinimumSize(null);
+        up.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                upActionPerformed(evt);
+            }
+        });
 
         down.setText("jButtonArrow2");
         down.setContentAreaFilled(false);
         down.setDirection(5);
         down.setMaximumSize(null);
         down.setMinimumSize(null);
+        down.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                downActionPerformed(evt);
+            }
+        });
 
         left.setText("jButtonArrow3");
         left.setContentAreaFilled(false);
         left.setDirection(3);
         left.setMaximumSize(null);
         left.setMinimumSize(null);
+        left.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                leftActionPerformed(evt);
+            }
+        });
 
         right.setText("jButtonArrow4");
         right.setContentAreaFilled(false);
         right.setDirection(7);
         right.setMaximumSize(null);
         right.setMinimumSize(null);
+        right.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                rightActionPerformed(evt);
+            }
+        });
 
         javax.swing.GroupLayout buttonPanelLayout = new javax.swing.GroupLayout(buttonPanel);
         buttonPanel.setLayout(buttonPanelLayout);
@@ -640,6 +661,22 @@ public class PlotterView extends JInternalFrame {
         ws.addFrame(pl);
         GUIUtils.moveToFront(pl);
     }//GEN-LAST:event_mntmCoplotActionPerformed
+
+    private void upActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_upActionPerformed
+        plotter.dataPan(SwingConstants.NORTH);
+    }//GEN-LAST:event_upActionPerformed
+
+    private void downActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_downActionPerformed
+        plotter.dataPan(SwingConstants.SOUTH);
+    }//GEN-LAST:event_downActionPerformed
+
+    private void leftActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_leftActionPerformed
+        plotter.dataPan(SwingConstants.EAST);
+    }//GEN-LAST:event_leftActionPerformed
+
+    private void rightActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_rightActionPerformed
+        plotter.dataPan(SwingConstants.WEST);
+    }//GEN-LAST:event_rightActionPerformed
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JPanel bottomButtonsPanel;

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/StilPlotter.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/StilPlotter.java
@@ -16,6 +16,8 @@
 package cfa.vo.iris.visualizer.plotter;
 
 import javax.swing.JPanel;
+import javax.swing.SwingConstants;
+
 import cfa.vo.iris.sed.ExtSed;
 import cfa.vo.iris.sed.quantities.SPVYQuantity;
 import cfa.vo.iris.visualizer.preferences.LayerModel;
@@ -209,7 +211,7 @@ public class StilPlotter extends JPanel {
     public void resetZoom() {
         resetPlot(true, false);
     }
-    
+
     /**
      * Zoom in or out of plot by a given scale factor.
      * @param zoomFactor 
@@ -264,6 +266,64 @@ public class StilPlotter extends JPanel {
             // calculate zoomed min and max values
             return Axis.zoom(min, max, center, zoomFactor, isLog);
         }
+    }
+    
+    /**
+     * Pan the plotter by a set amount in the direction specified.
+     * @param direction SwingConstant North, South, East, or West.
+     */
+    public void dataPan(int direction) {
+        
+        PlaneAspect aspect = getPlotDisplay().getAspect();
+        
+        double[] newX = new double[] { aspect.getXMin(), aspect.getXMax() };
+        double[] newY = new double[] { aspect.getYMin(), aspect.getYMax() };
+        
+        switch (direction) {
+        case SwingConstants.NORTH:
+            newY = panAxis(newY, getPlotPreferences().getYlog(), true);
+            break;
+        case SwingConstants.SOUTH:
+            newY = panAxis(newY, getPlotPreferences().getYlog(), false);
+            break;
+        case SwingConstants.EAST:
+            newX = panAxis(newX, getPlotPreferences().getXlog(), true);
+            break;
+        case SwingConstants.WEST:
+            newX = panAxis(newX, getPlotPreferences().getXlog(), false);
+            break;
+        default:
+            // ignore it
+            return;
+        }
+        
+        PlaneAspect newAspect = new PlaneAspect(newX, newY);
+        getPlotDisplay().setAspect(newAspect);
+    }
+    
+    private double[] panAxis(double[] cur, boolean isLog, boolean positive) {
+        double d0;
+        double d1;
+        
+        // For log move by a factor of 1/3 or 3
+        if (isLog) {
+            d0 = 1;
+            d1 = 3;
+        } 
+        // For linear move by 1/4 of the width
+        else {
+            d0 = cur[0];
+            d1 = d0 + Math.abs(cur[1] - cur[0])/4;
+        }
+        
+        double[] zoomed;
+        if (positive) {
+            zoomed = Axis.pan(cur[0], cur[1], d1, d0, isLog);
+        } else {
+            zoomed = Axis.pan(cur[0], cur[1], d0, d1, isLog);
+        }
+        
+        return zoomed;
     }
 
     /**

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/plotter/StilPlotterTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/plotter/StilPlotterTest.java
@@ -19,12 +19,15 @@ import cfa.vo.iris.visualizer.plotter.StilPlotter;
 import static org.junit.Assert.*;
 import cfa.vo.iris.sed.ExtSed;
 import cfa.vo.iris.test.Ws;
+import cfa.vo.iris.visualizer.plotter.PlotPreferences.PlotType;
 import cfa.vo.iris.visualizer.plotter.PlotterView;
 import cfa.vo.iris.visualizer.preferences.VisualizerComponentPreferences;
 import cfa.vo.sedlib.Segment;
 import cfa.vo.sedlib.io.SedFormat;
 
 import java.lang.reflect.Field;
+
+import javax.swing.SwingConstants;
 
 import org.apache.commons.lang.ArrayUtils;
 import org.junit.Test;
@@ -210,7 +213,85 @@ public class StilPlotterTest {
         assertEquals(Math.log10(xmin), Math.log10(aspect1.getXMin()), 0.000001);
         assertEquals(Math.log10(ymax), Math.log10(aspect1.getYMax()), 0.000001);
         assertEquals(Math.log10(ymin), Math.log10(aspect1.getYMin()), 0.000001);
+    }
+    
+    @Test
+    public void testPan() throws Exception {
+        ExtSed sed = new ExtSed("test", false);
+        StilPlotter plot = setUpTests(sed);
         
+        // Xlog, Y linear for testing both cases
+        plot.setPlotType(PlotType.X_LOG);
+        
+        // Get initial bounds
+        PlotDisplay<Profile, PlaneAspect> display = plot.getPlotDisplay();
+        PlaneAspect aspect = display.getAspect();
+        
+        // Verifying the default values, in case they ever change
+        assertEquals(10, aspect.getXMax(), 0.01);
+        assertEquals(1, aspect.getYMax(), 0.01);
+        assertEquals(1.0, aspect.getXMin(), 0.01);
+        assertEquals(0, aspect.getYMin(), 0.01);
+        
+        /*
+         * TEST LOG SCALES
+         */
+        
+        // Pan to the right (EAST)
+        // Verify new X-Values shifted by factor of 3
+        plot.dataPan(SwingConstants.EAST);
+        aspect = display.getAspect();
+        assertEquals(30, aspect.getXMax(), 0.01);
+        assertEquals(1, aspect.getYMax(), 0.01);
+        assertEquals(3, aspect.getXMin(), 0.01);
+        assertEquals(0, aspect.getYMin(), 0.01);
+        
+        // Shift back, should get to original values
+        plot.dataPan(SwingConstants.WEST);
+        aspect = display.getAspect();
+        assertEquals(10, aspect.getXMax(), 0.01);
+        assertEquals(1, aspect.getYMax(), 0.01);
+        assertEquals(1.0, aspect.getXMin(), 0.01);
+        assertEquals(0, aspect.getYMin(), 0.01);
+        
+        // Test negative X shift
+        // Verify new X-Values shifted by factor of 3
+        plot.dataPan(SwingConstants.WEST);
+        aspect = display.getAspect();
+        assertEquals(3 + 1.0/3, aspect.getXMax(), 0.01);
+        assertEquals(1, aspect.getYMax(), 0.01);
+        assertEquals(1.0/3, aspect.getXMin(), 0.01);
+        assertEquals(0, aspect.getYMin(), 0.01);
+        
+        // Shift back, should get to original values
+        plot.dataPan(SwingConstants.EAST);
+        aspect = display.getAspect();
+        assertEquals(10, aspect.getXMax(), 0.01);
+        assertEquals(1, aspect.getYMax(), 0.01);
+        assertEquals(1.0, aspect.getXMin(), 0.01);
+        assertEquals(0, aspect.getYMin(), 0.01);
+        
+        /*
+         * TEST LINEAR SCALES
+         */
+        
+        // Pan up
+        // Verify new Y-Values shifted by factor of .25 (width of Y scale)
+        plot.dataPan(SwingConstants.NORTH);
+        aspect = display.getAspect();
+        assertEquals(10, aspect.getXMax(), 0.01);
+        assertEquals(1.25, aspect.getYMax(), 0.01);
+        assertEquals(1, aspect.getXMin(), 0.01);
+        assertEquals(0.25, aspect.getYMin(), 0.01);
+        
+        // Pan back down should return to original values
+        // Verify new Y-Values shifted by factor of .25 (width of Y scale)
+        plot.dataPan(SwingConstants.SOUTH);
+        aspect = display.getAspect();
+        assertEquals(10, aspect.getXMax(), 0.01);
+        assertEquals(1, aspect.getYMax(), 0.01);
+        assertEquals(1.0, aspect.getXMin(), 0.01);
+        assertEquals(0, aspect.getYMin(), 0.01);
     }
     
     private StilPlotter setUpTests(ExtSed sed) throws Exception {


### PR DESCRIPTION
The little arrows in the plot window didn't do anything - so I added a simple notion of panning to the StilPlotter.

Basically for linear scales the axis moves by 1/4 the size of the axis. So panning on an axis of length 10 will move the axis by 2.5 in the specified direction.

Log scales will pan by a factor of 1/3, in either the positive or negative direction. I tried to figure out what Iris2.1 does, but it's panning is rather odd, so hopefully that makes sense.

Easy to change later on, I just wanted this functionality to be there.