### PR TITLE
iris-dev#77 Plot Evaluated Models

### DIFF
--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.form
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.form
@@ -55,7 +55,7 @@
     <AuxValue name="FormSettings_listenerGenerationStyle" type="java.lang.Integer" value="0"/>
     <AuxValue name="FormSettings_variablesLocal" type="java.lang.Boolean" value="false"/>
     <AuxValue name="FormSettings_variablesModifier" type="java.lang.Integer" value="2"/>
-    <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,1,-21,0,0,3,80"/>
+    <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,1,-8,0,0,3,80"/>
   </AuxValues>
 
   <Layout class="org.netbeans.modules.form.compat2.layouts.DesignGridLayout">
@@ -226,7 +226,7 @@
                                     <Property name="name" type="java.lang.String" value="optimizationCombo" noResource="true"/>
                                   </Properties>
                                   <BindingProperties>
-                                    <BindingProperty name="selectedItem" source="Form" sourcePath="${sed.fit.method}" target="optimizationCombo" targetPath="selectedItem" updateStrategy="0" immediately="false"/>
+                                    <BindingProperty name="selectedItem" source="Form" sourcePath="${sedModel.sed.fit.method}" target="optimizationCombo" targetPath="selectedItem" updateStrategy="0" immediately="false"/>
                                   </BindingProperties>
                                 </Component>
                                 <Component class="javax.swing.JLabel" name="jLabel2">
@@ -242,7 +242,7 @@
                                     <Property name="name" type="java.lang.String" value="statisticCombo" noResource="true"/>
                                   </Properties>
                                   <BindingProperties>
-                                    <BindingProperty name="selectedItem" source="Form" sourcePath="${sed.fit.stat}" target="statisticCombo" targetPath="selectedItem" updateStrategy="0" immediately="false"/>
+                                    <BindingProperty name="selectedItem" source="Form" sourcePath="${sedModel.sed.fit.stat}" target="statisticCombo" targetPath="selectedItem" updateStrategy="0" immediately="false"/>
                                   </BindingProperties>
                                 </Component>
                                 <Component class="javax.swing.JButton" name="fitButton">
@@ -477,7 +477,7 @@
             <Property name="name" type="java.lang.String" value="currentSedField" noResource="true"/>
           </Properties>
           <BindingProperties>
-            <BindingProperty name="text" source="Form" sourcePath="${sed.id}" target="currentSedField" targetPath="text" updateStrategy="0" immediately="false">
+            <BindingProperty name="text" source="Form" sourcePath="${sedModel.sed.id}" target="currentSedField" targetPath="text" updateStrategy="0" immediately="false">
               <BindingParameter name="javax.swing.binding.ParameterKeys.TEXT_CHANGE_STRATEGY" value="javax.swing.binding.TextChangeStrategy.ON_TYPE"/>
             </BindingProperty>
           </BindingProperties>

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.java
@@ -22,7 +22,9 @@ import cfa.vo.iris.fitting.custom.DefaultCustomModel;
 import cfa.vo.iris.fitting.custom.ModelsListener;
 import cfa.vo.iris.gui.NarrowOptionPane;
 import cfa.vo.iris.sed.ExtSed;
+import cfa.vo.iris.visualizer.IrisVisualizer;
 import cfa.vo.iris.visualizer.preferences.SedModel;
+import cfa.vo.iris.visualizer.preferences.VisualizerComponentPreferences;
 import cfa.vo.iris.visualizer.preferences.VisualizerDataStore;
 import cfa.vo.sherpa.models.Model;
 import cfa.vo.sherpa.optimization.OptimizationMethod;
@@ -426,6 +428,12 @@ public class FittingMainView extends JInternalFrame implements SedListener {
     private void doFit(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_doFit
         try {
             controller.fit();
+            
+            // Asynchronously evaluate the model
+            VisualizerComponentPreferences prefs = IrisVisualizer.getInstance().getActivePreferences();
+            if (prefs != null) {
+                prefs.evaluateModel(sedModel, controller);
+            }
         } catch (Exception e) {
             NarrowOptionPane.showMessageDialog(this,
                     e.getMessage(),

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.java
@@ -22,6 +22,8 @@ import cfa.vo.iris.fitting.custom.DefaultCustomModel;
 import cfa.vo.iris.fitting.custom.ModelsListener;
 import cfa.vo.iris.gui.NarrowOptionPane;
 import cfa.vo.iris.sed.ExtSed;
+import cfa.vo.iris.visualizer.preferences.SedModel;
+import cfa.vo.iris.visualizer.preferences.VisualizerDataStore;
 import cfa.vo.sherpa.models.Model;
 import cfa.vo.sherpa.optimization.OptimizationMethod;
 import cfa.vo.sherpa.stats.Statistic;
@@ -37,23 +39,28 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 
 public class FittingMainView extends JInternalFrame implements SedListener {
-    private ExtSed sed;
+    
+    private SedModel sedModel;
     private FitController controller;
     private JFileChooser chooser;
+    private VisualizerDataStore dataStore;
+    
     public final String DEFAULT_DESCRIPTION = "Double click on a Component to add it to the list of selected Components.";
     public final String CUSTOM_DESCRIPTION = "User Model";
-    public static final String PROP_SED = "sed";
+    
+    public static final String PROP_SEDMODEL = "sedModel";
 
     public FittingMainView() {
         initComponents();
         SedEvent.getInstance().add(this);
     }
 
-    public FittingMainView(JFileChooser chooser, FitController controller) {
+    public FittingMainView(VisualizerDataStore dataStore, JFileChooser chooser, FitController controller) {
         this();
         this.controller = controller;
         this.chooser = chooser;
-        setSed(controller.getSed());
+        this.dataStore = dataStore;
+        setSedModel(controller.getSedModel());
         initController();
         setUpAvailableModelsTree();
         setUpModelViewerPanel();
@@ -63,20 +70,21 @@ public class FittingMainView extends JInternalFrame implements SedListener {
         pack();
     }
 
-    public ExtSed getSed() {
-        return sed;
+    public SedModel getSedModel() {
+        return sedModel;
     }
 
-    public void setSed(ExtSed sed) {
-        this.sed = sed;
-        firePropertyChange(PROP_SED, null, sed);
-        controller.setSed(sed);
+    public void setSedModel(SedModel sedModel) {
+        this.sedModel = sedModel;
+        firePropertyChange(PROP_SEDMODEL, null, sedModel);
+        controller.setSedModel(sedModel);
     }
 
     @Override
     public void process(ExtSed source, SedCommand payload) {
-        if (SedCommand.SELECTED.equals(payload) || SedCommand.CHANGED.equals(payload) && source.equals(sed)) {
-            setSed(source);
+        if (SedCommand.SELECTED.equals(payload) || 
+                (SedCommand.CHANGED.equals(payload) && source.equals(sedModel.getSed()))) {
+            setSedModel(dataStore.getSedModel(source));
         }
     }
 
@@ -91,7 +99,7 @@ public class FittingMainView extends JInternalFrame implements SedListener {
     }
 
     private void setUpModelViewerPanel() {
-        modelViewerPanel.setSed(sed);
+        modelViewerPanel.setSed(sedModel.getSed());
         modelViewerPanel.setEditable(true);
     }
 
@@ -171,7 +179,7 @@ public class FittingMainView extends JInternalFrame implements SedListener {
         optimizationCombo.setModel(new DefaultComboBoxModel<>(OptimizationMethod.values()));
         optimizationCombo.setName("optimizationCombo"); // NOI18N
 
-        org.jdesktop.beansbinding.Binding binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${sed.fit.method}"), optimizationCombo, org.jdesktop.beansbinding.BeanProperty.create("selectedItem"));
+        org.jdesktop.beansbinding.Binding binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${sedModel.sed.fit.method}"), optimizationCombo, org.jdesktop.beansbinding.BeanProperty.create("selectedItem"));
         bindingGroup.addBinding(binding);
 
         jLabel2.setText("Statistic:");
@@ -179,7 +187,7 @@ public class FittingMainView extends JInternalFrame implements SedListener {
         statisticCombo.setModel(new DefaultComboBoxModel<>(Statistic.values()));
         statisticCombo.setName("statisticCombo"); // NOI18N
 
-        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${sed.fit.stat}"), statisticCombo, org.jdesktop.beansbinding.BeanProperty.create("selectedItem"));
+        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${sedModel.sed.fit.stat}"), statisticCombo, org.jdesktop.beansbinding.BeanProperty.create("selectedItem"));
         bindingGroup.addBinding(binding);
 
         fitButton.setText("Fit");
@@ -233,7 +241,7 @@ public class FittingMainView extends JInternalFrame implements SedListener {
         );
         modelPanelLayout.setVerticalGroup(
             modelPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addComponent(jSplitPane3, javax.swing.GroupLayout.DEFAULT_SIZE, 193, Short.MAX_VALUE)
+            .addComponent(jSplitPane3, javax.swing.GroupLayout.PREFERRED_SIZE, 193, Short.MAX_VALUE)
         );
 
         jSplitPane4.setLeftComponent(modelPanel);
@@ -251,7 +259,7 @@ public class FittingMainView extends JInternalFrame implements SedListener {
         );
         resultsContainerLayout.setVerticalGroup(
             resultsContainerLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addComponent(resultsPanel, javax.swing.GroupLayout.DEFAULT_SIZE, 185, Short.MAX_VALUE)
+            .addComponent(resultsPanel, javax.swing.GroupLayout.PREFERRED_SIZE, 185, Short.MAX_VALUE)
         );
 
         jSplitPane2.setLeftComponent(resultsContainer);
@@ -260,7 +268,7 @@ public class FittingMainView extends JInternalFrame implements SedListener {
         confidenceContainer.setLayout(confidenceContainerLayout);
         confidenceContainerLayout.setHorizontalGroup(
             confidenceContainerLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addComponent(confidencePanel, javax.swing.GroupLayout.DEFAULT_SIZE, 290, Short.MAX_VALUE)
+            .addComponent(confidencePanel, javax.swing.GroupLayout.PREFERRED_SIZE, 290, Short.MAX_VALUE)
         );
         confidenceContainerLayout.setVerticalGroup(
             confidenceContainerLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
@@ -279,7 +287,7 @@ public class FittingMainView extends JInternalFrame implements SedListener {
         );
         jPanel2Layout.setVerticalGroup(
             jPanel2Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addComponent(jSplitPane4, javax.swing.GroupLayout.DEFAULT_SIZE, 391, Short.MAX_VALUE)
+            .addComponent(jSplitPane4, javax.swing.GroupLayout.PREFERRED_SIZE, 391, Short.MAX_VALUE)
         );
 
         jSplitPane1.setRightComponent(jPanel2);
@@ -363,7 +371,7 @@ public class FittingMainView extends JInternalFrame implements SedListener {
         currentSedField.setEnabled(false);
         currentSedField.setName("currentSedField"); // NOI18N
 
-        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${sed.id}"), currentSedField, org.jdesktop.beansbinding.BeanProperty.create("text"));
+        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${sedModel.sed.id}"), currentSedField, org.jdesktop.beansbinding.BeanProperty.create("text"));
         bindingGroup.addBinding(binding);
 
         javax.swing.GroupLayout jPanel1Layout = new javax.swing.GroupLayout(jPanel1);
@@ -426,7 +434,7 @@ public class FittingMainView extends JInternalFrame implements SedListener {
             modelViewerPanel.fitResult(false);
             return; // TODO maybe should do something more/different.
         }
-        resultsPanel.setFit(sed.getFit());
+        resultsPanel.setFit(sedModel.getFit());
         modelViewerPanel.fitResult(true);
         modelViewerPanel.updateUI();
     }//GEN-LAST:event_doFit

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/FittingToolComponent.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/FittingToolComponent.java
@@ -25,6 +25,8 @@ import cfa.vo.iris.fitting.FittingMainView;
 import cfa.vo.iris.gui.NarrowOptionPane;
 import cfa.vo.iris.sed.ExtSed;
 
+import cfa.vo.iris.visualizer.preferences.SedModel;
+import cfa.vo.iris.visualizer.preferences.VisualizerComponentPreferences;
 import cfa.vo.sherpa.SherpaClient;
 import org.astrogrid.samp.client.MessageHandler;
 
@@ -44,6 +46,7 @@ public class FittingToolComponent implements IrisComponent {
     private CustomModelsManagerView customManagerView;
     private File customRootDir;
     private SherpaClient sherpaClient;
+    VisualizerComponentPreferences preferences;
     private final String CUSTOM_PATH = File.separator + "analysis" + File.separator + "custom_models";
     private static final Logger LOGGER = Logger.getLogger(FittingToolComponent.class.getName());
 
@@ -51,6 +54,7 @@ public class FittingToolComponent implements IrisComponent {
     public void init(IrisApplication irisApplication, IWorkspace iWorkspace) {
         this.app = irisApplication;
         this.ws = iWorkspace;
+        preferences = IrisVisualizer.getInstance().getActivePreferences(ws);
         sherpaClient = new SherpaClient(irisApplication.getSampService());
         customRootDir = new File(app.getConfigurationDir() + CUSTOM_PATH);
         try {
@@ -143,8 +147,9 @@ public class FittingToolComponent implements IrisComponent {
                                 NarrowOptionPane.showMessageDialog(null, "No SEDs open. Please start building SEDs using the SED builder", "Error", NarrowOptionPane.ERROR_MESSAGE);
                                 return;
                             }
-                            FitController controller = new FitController(sed, customManager, sherpaClient);
-                            view = new FittingMainView(ws.getFileChooser(), controller);
+                            SedModel model = preferences.getDataStore().getSedModel(sed);
+                            FitController controller = new FitController(model, customManager, sherpaClient);
+                            view = new FittingMainView(preferences.getDataStore(), ws.getFileChooser(), controller);
                             ws.addFrame(view);
                         } catch (Exception ex) {
                             throw new RuntimeException(ex);

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/FittingToolComponent.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/FittingToolComponent.java
@@ -54,7 +54,7 @@ public class FittingToolComponent implements IrisComponent {
     public void init(IrisApplication irisApplication, IWorkspace iWorkspace) {
         this.app = irisApplication;
         this.ws = iWorkspace;
-        preferences = IrisVisualizer.getInstance().getActivePreferences(ws);
+        preferences = IrisVisualizer.getInstance().createPreferences(ws);
         sherpaClient = new SherpaClient(irisApplication.getSampService());
         customRootDir = new File(app.getConfigurationDir() + CUSTOM_PATH);
         try {

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/IrisVisualizer.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/IrisVisualizer.java
@@ -1,0 +1,27 @@
+package cfa.vo.iris.visualizer;
+
+import cfa.vo.iris.IWorkspace;
+import cfa.vo.iris.visualizer.preferences.VisualizerComponentPreferences;
+
+public class IrisVisualizer {
+    
+    private VisualizerComponentPreferences preferences;
+    
+    private IrisVisualizer() {};
+    
+    private static class Holder {
+        private static final IrisVisualizer INSTANCE = new IrisVisualizer();
+    }
+    
+    public static IrisVisualizer getInstance() {
+        return Holder.INSTANCE;
+    }
+    
+    public VisualizerComponentPreferences getActivePreferences(IWorkspace ws) {
+        if (preferences == null) {
+            preferences = new VisualizerComponentPreferences(ws);
+        }
+        
+        return preferences;
+    }
+}

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/IrisVisualizer.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/IrisVisualizer.java
@@ -17,11 +17,15 @@ public class IrisVisualizer {
         return Holder.INSTANCE;
     }
     
-    public VisualizerComponentPreferences getActivePreferences(IWorkspace ws) {
+    public VisualizerComponentPreferences createPreferences(IWorkspace ws) {
         if (preferences == null) {
             preferences = new VisualizerComponentPreferences(ws);
         }
         
+        return preferences;
+    }
+    
+    public VisualizerComponentPreferences getActivePreferences() {
         return preferences;
     }
 }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/IrisVisualizer.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/IrisVisualizer.java
@@ -1,10 +1,31 @@
+/*
+ * Copyright 2016 Chandra X-Ray Observatory.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package cfa.vo.iris.visualizer;
 
 import cfa.vo.iris.IWorkspace;
 import cfa.vo.iris.visualizer.preferences.VisualizerComponentPreferences;
 
+/**
+ * Singleton class designed to give the Visualizer's components access to shared
+ * data storage/access objects.
+ *
+ */
 public class IrisVisualizer {
     
+    // Active visualizer component preferences
     private VisualizerComponentPreferences preferences;
     
     private IrisVisualizer() {};
@@ -17,6 +38,15 @@ public class IrisVisualizer {
         return Holder.INSTANCE;
     }
     
+    /**
+     * Calls to construct or fetch the current active preferences for the visualizer
+     * tools. As it is currently implemented, the preferences can only be created 
+     * once. In the future we may want to allow simultaneous opening of multiple visualizers,
+     * in which case this may be adjusted to point to the current visualizer prefereces
+     * currently in focus.
+     * @param ws IWorkspace for the preferences
+     * @return Active VisualizerComponentPreferences
+     */
     public VisualizerComponentPreferences createPreferences(IWorkspace ws) {
         if (preferences == null) {
             preferences = new VisualizerComponentPreferences(ws);
@@ -25,6 +55,9 @@ public class IrisVisualizer {
         return preferences;
     }
     
+    /**
+     * @return The active VisualizerComponentPreferences
+     */
     public VisualizerComponentPreferences getActivePreferences() {
         return preferences;
     }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/VisualizerComponent.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/VisualizerComponent.java
@@ -36,7 +36,7 @@ public class VisualizerComponent implements IrisComponent {
         this.app = irisApplication;
         this.ws = iWorkspace;
         
-        preferences = IrisVisualizer.getInstance().getActivePreferences(ws);
+        preferences = IrisVisualizer.getInstance().createPreferences(ws);
     }
 
     @Override

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/VisualizerComponent.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/VisualizerComponent.java
@@ -91,7 +91,7 @@ public class VisualizerComponent implements IrisComponent {
                 public void onClick() {
                     if (view == null) {
                         try {
-                            view = new PlotterView("Iris Visualizer", app, ws, preferences);
+                            view = new PlotterView("Iris Visualizer", ws, preferences);
                         } catch (Exception ex) {
                             throw new RuntimeException(ex);
                         }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/VisualizerComponent.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/VisualizerComponent.java
@@ -35,7 +35,8 @@ public class VisualizerComponent implements IrisComponent {
     public void init(IrisApplication irisApplication, IWorkspace iWorkspace) {
         this.app = irisApplication;
         this.ws = iWorkspace;
-        preferences = new VisualizerComponentPreferences(ws);
+        
+        preferences = IrisVisualizer.getInstance().getActivePreferences(ws);
     }
 
     @Override

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/HSVColorPalette.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/HSVColorPalette.java
@@ -26,17 +26,40 @@ import java.util.Random;
  */
 public class HSVColorPalette extends ColorPalette {
     
-    private Random random = new Random();
-    private Color color = new Color(Color.black.getRGB());
-    private double hue = 0;
-    private double saturation = 1.0;
-    private double brightness = 0;
-    private long index;
-    private final double INVERSE_GOLDEN_RATION = 1/1.61803398875;
+    private static final double INVERSE_GOLDEN_RATION = 1/1.61803398875;
     
     // saturation and brightness thresholds
-    private final double SATURATION_THRESHOLD = 0.3;
-    private final double BRIGHTNESS_THRESHOLD = 0.25;
+    private static final double SATURATION_THRESHOLD = 0.3;
+    private static final double BRIGHTNESS_THRESHOLD = 0.25;
+    
+    private Random random = new Random();
+    private Color color;
+    private double hue;
+    private double saturation;
+    private double brightness;
+    private long index;
+    
+    // Default constructor
+    public HSVColorPalette() {
+        this.hue = 0;
+        this.saturation = 1.0;
+        this.brightness = 0;
+        this.color = Color.getHSBColor((float) hue, (float) saturation, (float) brightness);
+    }
+    
+    /**
+     * Constructor for initial settings of the color palette. The wheel starts at the 
+     * specified hue, saturation, and brightness.
+     * @param hue
+     * @param saturation
+     * @param brightness
+     */
+    public HSVColorPalette(double hue, double saturation, double brightness) {
+        this.hue = hue;
+        this.saturation = saturation;
+        this.brightness = brightness;
+        this.color = Color.getHSBColor((float) hue, (float) saturation, (float) brightness);
+    }
     
     /**
      * Generate n distinct colors
@@ -66,9 +89,8 @@ public class HSVColorPalette extends ColorPalette {
     @Override
     public final Color getNextColor() {
         
-        // first, set the current color in the palette. 
-        // This is the return value
-        color = Color.getHSBColor((float) hue, (float) saturation, (float) brightness);
+        // Return current color then increment
+        Color ret = this.color;
         
         // calculate the next hue using the golden ratio
         hue += INVERSE_GOLDEN_RATION;
@@ -103,6 +125,9 @@ public class HSVColorPalette extends ColorPalette {
 //        // counter for hues.
 //        index++;
         
-        return color;
+        // Update the next color value
+        color = Color.getHSBColor((float) hue, (float) saturation, (float) brightness);
+        
+        return ret;
     }
 }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotPreferences.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotPreferences.java
@@ -31,6 +31,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import org.apache.commons.lang.StringUtils;
+
 import uk.ac.starlink.ttools.plot2.geom.PlaneAspect;
 
 public class PlotPreferences {
@@ -412,7 +415,8 @@ public class PlotPreferences {
     }
 
     protected ShapeType getMarkType() {
-        return (ShapeType) preferences.get(SHAPE);
+        String name = (String) preferences.get(SHAPE);
+        return StringUtils.isEmpty(name) ? null : ShapeType.valueOf(name);
     }
 
     public static final String PROP_MARK_TYPE = "markType";

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
@@ -16,24 +16,15 @@
 package cfa.vo.iris.visualizer.plotter;
 
 import cfa.vo.iris.IWorkspace;
-import cfa.vo.iris.IrisApplication;
 import cfa.vo.iris.gui.GUIUtils;
-import cfa.vo.iris.sed.ExtSed;
-import cfa.vo.iris.sed.stil.SegmentStarTable;
-import cfa.vo.iris.units.UnitsException;
 import cfa.vo.iris.visualizer.metadata.MetadataBrowserMainView;
 import cfa.vo.iris.visualizer.plotter.PlotPreferences.PlotType;
 import cfa.vo.iris.visualizer.preferences.CoPlotManagementWindow;
-import cfa.vo.iris.visualizer.preferences.FunctionModel;
-import cfa.vo.iris.visualizer.preferences.SedModel;
 import cfa.vo.iris.visualizer.preferences.VisualizerComponentPreferences;
 import cfa.vo.iris.visualizer.preferences.VisualizerDataModel;
-import cfa.vo.sedlib.common.SedException;
-import cfa.vo.sedlib.common.SedNoDataException;
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.JFrame;
 import javax.swing.JInternalFrame;
@@ -70,7 +61,6 @@ public class PlotterView extends JInternalFrame {
      * @throws java.lang.Exception
      */
     public PlotterView(String title, 
-                       IrisApplication app, 
                        IWorkspace ws,
                        VisualizerComponentPreferences preferences) 
                                throws Exception

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
@@ -25,14 +25,12 @@ import cfa.vo.iris.visualizer.preferences.VisualizerDataModel;
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.util.logging.Logger;
 import javax.swing.JFrame;
 import javax.swing.JInternalFrame;
 import javax.swing.SwingConstants;
 
+@SuppressWarnings({ "rawtypes", "unchecked" })
 public class PlotterView extends JInternalFrame {
-    
-    private static final Logger logger = Logger.getLogger(StilPlotter.class.getName());
     
     private static final long serialVersionUID = 1L;
     
@@ -49,6 +47,9 @@ public class PlotterView extends JInternalFrame {
     
     // Bound to the StilPlotter preferences
     private PlotPreferences plotPreferences;
+    
+    // Coplotting selection window
+    CoPlotManagementWindow coplotWindow;
     
     public static double ZOOM_SCALE = 0.5;
     
@@ -197,7 +198,7 @@ public class PlotterView extends JInternalFrame {
         
         this.mntmAutoFixed.setSelected(plotPreferences.getFixed());
     }
-    
+
     /**
      * This method is called from within the constructor to initialize the form.
      * WARNING: Do NOT modify this code. The content of this method is always
@@ -658,9 +659,9 @@ public class PlotterView extends JInternalFrame {
     }//GEN-LAST:event_metadataButtonActionPerformed
 
     private void mntmCoplotActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_mntmCoplotActionPerformed
-        CoPlotManagementWindow pl = new CoPlotManagementWindow(this.preferences);
-        ws.addFrame(pl);
-        GUIUtils.moveToFront(pl);
+        coplotWindow = new CoPlotManagementWindow(this.preferences);
+        ws.addFrame(coplotWindow);
+        GUIUtils.moveToFront(coplotWindow);
     }//GEN-LAST:event_mntmCoplotActionPerformed
 
     private void upActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_upActionPerformed

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/StilPlotter.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/StilPlotter.java
@@ -490,7 +490,9 @@ public class StilPlotter extends JPanel {
         resEnv.setValue("type", "plot2plane");
         resEnv.setValue("insets", new Insets(20, 80, 20, 50));
         
+        // Get settings from the overall plot preferences and manually add them here.
         resEnv.setValue(PlotPreferences.SIZE, pp.getSize());
+        resEnv.setValue(PlotPreferences.SHAPE, pp.getMarkType().name());
         resEnv.setValue(PlotPreferences.X_LOG, pp.getPlotType().xlog);
         resEnv.setValue(PlotPreferences.GRID, pp.getShowGrid());
         
@@ -498,7 +500,6 @@ public class StilPlotter extends JPanel {
         resEnv.setValue("xlabel", null);
         resEnv.setValue("legend", false);
         
-
         // add model functions
         for (FunctionModel model : dataModel.getFunctionModels()) {
             // If no model available (e.g. no fit) skip it

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/StilPlotter.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/StilPlotter.java
@@ -462,15 +462,28 @@ public class StilPlotter extends JPanel {
                 env.setValue(key, prefs.get(key));
             }
         }
+
+        // Add model functions
+        addFunctionModels(env);
+    }
+    
+    private void addFunctionModels(MapEnvironment env) {
         
-        // add model functions
+        // Override color settings so that each model function is a different color,
+        // starting with dark red
+        ColorPalette palette = new HSVColorPalette(360, 100, 75);
+        
         for (FunctionModel model : dataModel.getFunctionModels()) {
             // If no model available (e.g. no fit) skip it
             if (!model.hasModelValues()) {
                 continue;
             }
             
+            // Update color
             LayerModel layer = model.getFunctionLayerModel();
+            layer.setLineColor(ColorPalette.colorToHex(palette.getNextColor()));
+            
+            // Add layer prefereces for function models
             Map<String, Object> prefs = layer.getPreferences();
             for (String key : prefs.keySet()) {
                 env.setValue(key, prefs.get(key));

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedModel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedModel.java
@@ -224,7 +224,7 @@ public class SedModel {
     
     /**
      * Removes a segment from the sed preferences map.
-     * @param segment
+     * @param seg
      * @return true if the segment was removed from the models map
      */
     boolean removeSegment(Segment seg) {
@@ -293,7 +293,15 @@ public class SedModel {
         return yunits;
     }
 
-    public FitConfiguration getFitConfiguration() {
+    public FitConfiguration getFit() {
         return sed.getFit();
+    }
+
+    public void setFit(FitConfiguration fit) {
+        sed.setFit(fit);
+    }
+
+    public ExtSed getSed() {
+        return sed;
     }
 }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerComponentPreferences.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerComponentPreferences.java
@@ -24,6 +24,7 @@ import org.apache.commons.collections.CollectionUtils;
 import com.google.common.collect.MapMaker;
 
 import cfa.vo.iris.IWorkspace;
+import cfa.vo.iris.fitting.FitController;
 import cfa.vo.iris.sed.ExtSed;
 import cfa.vo.iris.visualizer.plotter.MouseListenerManager;
 import cfa.vo.iris.visualizer.plotter.PlotPreferences;
@@ -139,6 +140,34 @@ public class VisualizerComponentPreferences {
         });
         
         return sed;
+    }
+    
+    /**
+     * Asynchronously evaluates the model using the fit controller specified. The visualizer
+     * will refresh if the specified sed model is currently live.
+     * 
+     */
+    public void evaluateModel(final SedModel model, final FitController controller) {
+        
+        // Do nothing for null data 
+        if (controller == null || model == null) {
+            return;
+        }
+        
+        // Otherwise asynchronously evaluate the model
+        final VisualizerDataModel dataModel = this.getDataModel();
+        visualizerExecutor.submit(new Callable<SedModel>() {
+            @Override
+            public SedModel call() throws Exception {
+                controller.evaluateModel(model);
+                
+                // Refresh the model once completed
+                if (dataModel.getSelectedSeds().contains(model.getSed())) {
+                    dataModel.refresh();
+                }
+                return model;
+            }
+        });
     }
     
     /**

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerComponentPreferences.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerComponentPreferences.java
@@ -191,8 +191,10 @@ public class VisualizerComponentPreferences {
      */
     public void removeSed(ExtSed sed) {
         List<ExtSed> selectedSeds = dataModel.getSelectedSeds();
-        if (selectedSeds.remove(sed)) {
-            dataModel.setSelectedSeds(selectedSeds);
+        if (selectedSeds.contains(sed)) {
+            List<ExtSed> newSeds = new LinkedList<>(selectedSeds);
+            newSeds.remove(sed);
+            dataModel.setSelectedSeds(newSeds);
         }
     }
 

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerDataModel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerDataModel.java
@@ -12,6 +12,7 @@ import cfa.vo.iris.visualizer.plotter.PlotPreferences;
 import cfa.vo.iris.visualizer.stil.tables.IrisStarTable;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 
@@ -221,6 +222,14 @@ public class VisualizerDataModel {
         this.setFunctionModels(newFunctionModels);
         
         pcs.firePropertyChange(PROP_SELECTED_SEDS, oldSeds, selectedSeds);
+    }
+    
+    /**
+     * Simple function for setting a single selected SED, this is only for SETTING
+     * an SED, does not support binding!
+     */
+    public void setSelectedSed(ExtSed sed) {
+        this.setSelectedSeds(Arrays.asList(sed));
     }
     
     private void updateColors(List<LayerModel> layers) {

--- a/iris-visualizer/src/test/java/cfa/vo/iris/fitting/FitControllerIT.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/fitting/FitControllerIT.java
@@ -25,7 +25,6 @@ import cfa.vo.iris.units.UnitsManager;
 import cfa.vo.iris.visualizer.preferences.SedModel;
 import cfa.vo.iris.visualizer.stil.tables.IrisStarTableAdapter;
 import cfa.vo.sedlib.Segment;
-import cfa.vo.sherpa.ConfidenceResults;
 import cfa.vo.sherpa.Data;
 import cfa.vo.sherpa.FitResults;
 import cfa.vo.sherpa.SherpaClient;
@@ -46,10 +45,6 @@ import static org.junit.Assert.assertEquals;
 
 public class FitControllerIT {
     private FitController controller;
-    private FitConfiguration configuration;
-    private CustomModelsManager modelsManager;
-    private SherpaClient client;
-    private Data data;
     private SedModel sedModel;
     private double[] x = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
     private double[] y = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
@@ -63,16 +58,16 @@ public class FitControllerIT {
         ExtSed sed = new ExtSed("Test", false);
         Segment segment = TestUtils.createSampleSegment(x, y, SherpaClient.X_UNIT, SherpaClient.Y_UNIT);
         sed.addSegment(segment);
-        configuration = createFit();
+        FitConfiguration configuration = createFit();
         sed.setFit(configuration);
-        modelsManager = Mockito.mock(CustomModelsManager.class);
-        data = SAMPFactory.get(Data.class);
+        CustomModelsManager modelsManager = Mockito.mock(CustomModelsManager.class);
+        Data data = SAMPFactory.get(Data.class);
         data.setX(x);
         data.setY(y);
         data.setStaterror(err);
-        client = sherpa.getClient();
-        controller = new FitController(sed, modelsManager, client);
+        SherpaClient client = sherpa.getClient();
         sedModel = new SedModel(sed, new IrisStarTableAdapter(null));
+        controller = new FitController(sedModel, modelsManager, client);
     }
 
     @Test

--- a/iris-visualizer/src/test/java/cfa/vo/iris/fitting/FitControllerTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/fitting/FitControllerTest.java
@@ -22,7 +22,6 @@ import cfa.vo.iris.sed.ExtSed;
 import cfa.vo.iris.sed.stil.SegmentStarTable;
 import cfa.vo.iris.test.unit.TestUtils;
 import cfa.vo.iris.visualizer.preferences.SedModel;
-import cfa.vo.iris.visualizer.stil.tables.IrisStarTable;
 import cfa.vo.iris.visualizer.stil.tables.IrisStarTableAdapter;
 import cfa.vo.sherpa.ConfidenceResults;
 import cfa.vo.sherpa.Data;
@@ -63,7 +62,8 @@ public class FitControllerTest {
         data.setY(y);
         data.setStaterror(err);
         Mockito.stub(client.evaluate(Mockito.any(double[].class), Mockito.any(FitConfiguration.class))).toReturn(y);
-        controller = new FitController(sed, modelsManager, client);
+        SedModel sedModel = new SedModel(sed, new IrisStarTableAdapter(null));
+        controller = new FitController(sedModel, modelsManager, client);
     }
 
     @Test

--- a/iris-visualizer/src/test/java/cfa/vo/iris/fitting/FittingMainViewTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/fitting/FittingMainViewTest.java
@@ -15,9 +15,16 @@
  */
 package cfa.vo.iris.fitting;
 
+import cfa.vo.iris.IrisApplication;
 import cfa.vo.iris.fitting.custom.CustomModelsManager;
 import cfa.vo.iris.sed.ExtSed;
 import cfa.vo.iris.sed.SedlibSedManager;
+import cfa.vo.iris.test.Ws;
+import cfa.vo.iris.test.unit.ApplicationStub;
+import cfa.vo.iris.visualizer.preferences.SedModel;
+import cfa.vo.iris.visualizer.preferences.VisualizerComponentPreferences;
+import cfa.vo.iris.visualizer.preferences.VisualizerDataStore;
+import cfa.vo.iris.visualizer.stil.tables.IrisStarTableAdapter;
 import cfa.vo.sherpa.SherpaClient;
 import cfa.vo.sherpa.optimization.OptimizationMethod;
 import cfa.vo.sherpa.stats.Statistic;
@@ -48,8 +55,11 @@ public class FittingMainViewTest {
         Mockito.when(modelsManager.getCustomModels()).thenReturn(new DefaultMutableTreeNode("Custom Models"));
         SherpaClient client = Mockito.mock(SherpaClient.class);
         JFileChooser chooser = Mockito.mock(JFileChooser.class);
-        FitController controller = new FitController(sed, modelsManager, client);
-        FittingMainView view = new FittingMainView(chooser, controller);
+        SedModel sedModel = new SedModel(sed, new IrisStarTableAdapter(null));
+        FitController controller = new FitController(sedModel, modelsManager, client);
+        ApplicationStub app = new ApplicationStub();
+        VisualizerDataStore store = new VisualizerDataStore(null, new VisualizerComponentPreferences(app.getWorkspace()));
+        FittingMainView view = new FittingMainView(store, chooser, controller);
 
         fittingView = new Window(view);
         sedId = fittingView.getInputTextBox("currentSedField");

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/FittingToolComponentTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/FittingToolComponentTest.java
@@ -90,9 +90,7 @@ public class FittingToolComponentTest extends AbstractComponentGUITest {
     
     @Test
     public void testFittingEmptySed() throws Exception {
-        sedManager.newSed("TestSed");
-        
-        final Window mainFit = openWindow();
+        final Window mainFit = setupFitWindow(sedManager.newSed("TestSed"));
 
         TextBox parName = mainFit.getTextBox("Par Name");
         parName.textEquals("No Parameter Selected").check();
@@ -101,8 +99,7 @@ public class FittingToolComponentTest extends AbstractComponentGUITest {
 
     @Test
     public void testSedNameChange() throws Exception {
-        sedManager.newSed("TestSed");
-        final Window mainFit = openWindow();
+        final Window mainFit = setupFitWindow(sedManager.newSed("TestSed"));
         assertEquals("TestSed", mainFit.getTextBox("currentSedField").getText());
         sedManager.newSed("TestSed2");
         TestUtils.invokeWithRetry(50, 100, new Runnable(){
@@ -116,10 +113,8 @@ public class FittingToolComponentTest extends AbstractComponentGUITest {
     @Test
     public void testViewNonEmptySed() throws Exception {
         ExtSed sed = sedManager.newSed("TestSed");
-
-        final Window mainFit = openWindow();
-
         addFit(sed);
+        final Window mainFit = setupFitWindow(sed);
 
         TestUtils.invokeWithRetry(50, 100, new Runnable(){
             @Override
@@ -152,8 +147,7 @@ public class FittingToolComponentTest extends AbstractComponentGUITest {
 
     @Test
     public void testModelSelection() throws Exception {
-        sedManager.newSed("TestSed");
-        Window mainFit = openWindow();
+        final Window mainFit = setupFitWindow(sedManager.newSed("TestSed"));
 
         Tree availableTree = mainFit.getTree("availableTree");
         final TextBox descriptionArea = mainFit.getTextBox("descriptionArea");
@@ -169,8 +163,7 @@ public class FittingToolComponentTest extends AbstractComponentGUITest {
 
     @Test
     public void testModelSearch() throws Exception {
-        sedManager.newSed("TestSed");
-        Window mainFit = openWindow();
+        final Window mainFit = setupFitWindow(sedManager.newSed("TestSed"));
 
         TextBox searchField = mainFit.getInputTextBox("searchField");
         searchField.setText("power");
@@ -187,7 +180,7 @@ public class FittingToolComponentTest extends AbstractComponentGUITest {
     public void testSaveText() throws Exception {
         ExtSed sed = sedManager.newSed("TestSed");
         addFit(sed);
-        Window mainFit = openWindow();
+        final Window mainFit = setupFitWindow(sed);
 
         File outputFile = tempFolder.newFile("output.fit");
 
@@ -206,7 +199,7 @@ public class FittingToolComponentTest extends AbstractComponentGUITest {
     @Test
     public void testLoadJson() throws Exception {
         ExtSed sed = sedManager.newSed("TestSed");
-        Window mainFit = openWindow();
+        final Window mainFit = setupFitWindow(sed);
 
         String path = getClass().getResource("fit.json").getFile();
 
@@ -236,7 +229,7 @@ public class FittingToolComponentTest extends AbstractComponentGUITest {
     public void testSaveJson() throws Exception {
         ExtSed sed = sedManager.newSed("TestSed");
         addFit(sed);
-        Window mainFit = openWindow();
+        final Window mainFit = setupFitWindow(sed);
 
         Tree modelsTree = mainFit.getTree("modelsTree");
         modelsTree.click("polynomial.m/m.c1");
@@ -273,6 +266,18 @@ public class FittingToolComponentTest extends AbstractComponentGUITest {
     @Test
     public void testLoadJsonNonExistentFile() throws Exception {
         nonExistentFile("Load Json...");
+    }
+    
+    private Window setupFitWindow(final ExtSed sed) throws Exception {
+        // Wait for swing EDT to update datastore with the SED
+        TestUtils.invokeWithRetry(10, 100, new Runnable() {
+            @Override
+            public void run() {
+                assertNotNull(comp.preferences.getDataStore().getSedModel(sed));
+            }
+        });
+        
+        return openWindow();
     }
 
     private Window openWindow() {

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/FittingToolComponentTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/FittingToolComponentTest.java
@@ -46,8 +46,6 @@ import org.uispec4j.interception.FileChooserHandler;
 import org.uispec4j.interception.WindowHandler;
 import org.uispec4j.interception.WindowInterceptor;
 
-import javax.swing.*;
-
 public class FittingToolComponentTest extends AbstractComponentGUITest {
 
     private FittingToolComponent comp = new FittingToolComponent();


### PR DESCRIPTION
Resolves 
https://github.com/ChandraCXC/iris-dev/issues/76
https://github.com/ChandraCXC/iris-dev/issues/77

Adds basic support for plotting the evaluated models after a fit. After a fit is completed the fitting tool immediately calls to evaluate the sed asynchronously from the visualizer preferences. I added a singleton holder, IrisVisualizer, for objects that need to be shared between the fitting tool and the plotter/MB. At this point it's pretty simple, but will need to be expanded for future integration of the two components.

A few points:
  + The models are evaluated asynchronously, and the datamodel will be updated after the evaluation completes.
  + As of now there is no notion of validation on the models. That will come in a later commit.
  + I fixed the unit tests in the visualizer, they were dependent on the serialization of the the SED in the swing EDT, now they are not.
  + Updated the color palette so that external callers can specify a starting color. Model functions will start at red then move around from there.
  + Changed the appearance of residuals/ratios to match whatever shape is currently in the plotter. Right now that is open circles, but easily changed.

