### PR TITLE
iris-dev#111 Model Validation

### DIFF
--- a/iris-common/src/main/java/cfa/vo/iris/fitting/FitConfiguration.java
+++ b/iris-common/src/main/java/cfa/vo/iris/fitting/FitConfiguration.java
@@ -10,8 +10,6 @@ import cfa.vo.sherpa.optimization.OptimizationMethod;
 import cfa.vo.sherpa.stats.Stat;
 import cfa.vo.sherpa.stats.Statistic;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.jdesktop.observablecollections.ObservableCollections;
 import org.jdesktop.observablecollections.ObservableList;
@@ -48,6 +46,7 @@ public class FitConfiguration {
     private Integer numPoints;
     private Double statVal;
     private Integer dof;
+    private int sedVersion;
 
     private ObservableList<UserModel> userModelList = ObservableCollections.observableList(new ArrayList<UserModel>());
     private ModelExpressionVerifier verifier = new ModelExpressionVerifier();
@@ -236,6 +235,14 @@ public class FitConfiguration {
         else {
             return "No Model";
         }
+    }
+
+    protected int getSedVersion() {
+        return sedVersion;
+    }
+
+    protected void setSedVersion(int sedVersion) {
+        this.sedVersion = sedVersion;
     }
 
     public void integrateResults(FitResults results) {

--- a/iris-common/src/main/java/cfa/vo/iris/fitting/FitConfiguration.java
+++ b/iris-common/src/main/java/cfa/vo/iris/fitting/FitConfiguration.java
@@ -237,11 +237,11 @@ public class FitConfiguration {
         }
     }
 
-    protected int getSedVersion() {
+    public int getSedVersion() {
         return sedVersion;
     }
 
-    protected void setSedVersion(int sedVersion) {
+    public void setSedVersion(int sedVersion) {
         this.sedVersion = sedVersion;
     }
 

--- a/iris-common/src/main/java/cfa/vo/iris/fitting/FitConfiguration.java
+++ b/iris-common/src/main/java/cfa/vo/iris/fitting/FitConfiguration.java
@@ -9,6 +9,7 @@ import cfa.vo.sherpa.optimization.Method;
 import cfa.vo.sherpa.optimization.OptimizationMethod;
 import cfa.vo.sherpa.stats.Stat;
 import cfa.vo.sherpa.stats.Statistic;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.jdesktop.observablecollections.ObservableCollections;
@@ -20,7 +21,7 @@ import java.beans.PropertyChangeSupport;
 import java.util.*;
 import java.util.logging.Logger;
 
-@JsonIgnoreProperties({"treeModel", "modelValid", "expression"})
+@JsonIgnoreProperties({"treeModel", "modelValid", "expression", "sedVersion"})
 public class FitConfiguration {
     public static final String PROP_MODEL = "model";
     public static final String PROP_STAT = "stat";

--- a/iris-common/src/main/java/cfa/vo/iris/sed/stil/SegmentStarTable.java
+++ b/iris-common/src/main/java/cfa/vo/iris/sed/stil/SegmentStarTable.java
@@ -26,6 +26,7 @@ import java.util.logging.Logger;
 import cfa.vo.iris.sed.ExtSed;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.builder.HashCodeBuilder;
 
 import uk.ac.starlink.table.ColumnData;
 import uk.ac.starlink.table.ColumnInfo;
@@ -84,6 +85,11 @@ public class SegmentStarTable extends RandomStarTable {
     private double[] modelValues;
     private double[] residualValues;
     private double[] ratioValues;
+    
+    // Store the hashCode for cached computation, and whether or not the hashCode
+    // is valid and needs to be recomputed.
+    private int hashCode;
+    volatile boolean validHashCode = false;
 
     public SegmentStarTable(double[] x, double[] y, String xUnit, String yUnit)
             throws SedNoDataException, UnitsException, SedInconsistentException {
@@ -286,6 +292,7 @@ public class SegmentStarTable extends RandomStarTable {
     }
     
     public void setSpecValues(double[] specValues) {
+        this.validHashCode = false;
         this.specValues = specValues;
         updateColumnValues(specValues, Column.Spectral_Value);
     }
@@ -295,6 +302,7 @@ public class SegmentStarTable extends RandomStarTable {
     }
 
     public void setFluxValues(double[] fluxValues) {
+        this.validHashCode = false;
         this.fluxValues = fluxValues;
         updateColumnValues(fluxValues, Column.Flux_Value);
     }
@@ -346,6 +354,7 @@ public class SegmentStarTable extends RandomStarTable {
     }
 
     public void setSpecErrValues(double[] specErrValues) {
+        this.validHashCode = false;
         this.specErrValues = specErrValues;
         updateColumnValues(specErrValues, Column.Spectral_Error);
     }
@@ -355,6 +364,7 @@ public class SegmentStarTable extends RandomStarTable {
     }
 
     public void setSpecErrValuesLo(double[] specErrValuesLo) {
+        this.validHashCode = false;
         this.specErrValuesLo = specErrValuesLo;
         updateColumnValues(specErrValuesLo, Column.Spectral_Error_Low);
     }
@@ -364,6 +374,7 @@ public class SegmentStarTable extends RandomStarTable {
     }
 
     public void setSpecErrValuesHi(double[] specErrValuesHi) {
+        this.validHashCode = false;
         this.specErrValuesHi = specErrValuesHi;
         updateColumnValues(specErrValuesHi, Column.Spectral_Error_High);
     }
@@ -373,6 +384,7 @@ public class SegmentStarTable extends RandomStarTable {
     }
 
     public void setFluxErrValues(double[] fluxErrValues) {
+        this.validHashCode = false;
         this.fluxErrValues = fluxErrValues;
         updateColumnValues(fluxErrValues, Column.Flux_Error);
     }
@@ -382,6 +394,7 @@ public class SegmentStarTable extends RandomStarTable {
     }
 
     public void setFluxErrValuesLo(double[] fluxErrValuesLo) {
+        this.validHashCode = false;
         this.fluxErrValuesLo = fluxErrValuesLo;
         updateColumnValues(fluxErrValuesLo, Column.Flux_Error_Low);
     }
@@ -391,6 +404,7 @@ public class SegmentStarTable extends RandomStarTable {
     }
 
     public void setFluxErrValuesHi(double[] fluxErrValuesHi) {
+        this.validHashCode = false;
         this.fluxErrValuesHi = fluxErrValuesHi;
         updateColumnValues(fluxErrValuesHi, Column.Flux_Error_High);
     }
@@ -453,6 +467,29 @@ public class SegmentStarTable extends RandomStarTable {
             throw new IllegalArgumentException("Data must have equal length to existing segments");
         }
         columns.add(newColumn);
+    }
+    
+    @Override
+    public int hashCode() {
+        
+        if (this.validHashCode) {
+            return this.hashCode;
+        }
+        
+        this.hashCode = new HashCodeBuilder(17,31)
+            .append(this.specValues)
+            .append(this.fluxValues)
+            .append(this.specErrValues)
+            .append(this.specErrValuesLo)
+            .append(this.specErrValuesHi)
+            .append(this.specErrValuesHi)
+            .append(this.fluxErrValues)
+            .append(this.fluxErrValuesLo)
+            .append(this.fluxErrValuesHi)
+            .hashCode();
+        
+        this.validHashCode = true;
+        return this.hashCode;
     }
 
     /**

--- a/iris-common/src/main/java/cfa/vo/iris/sed/stil/SegmentStarTable.java
+++ b/iris-common/src/main/java/cfa/vo/iris/sed/stil/SegmentStarTable.java
@@ -469,6 +469,11 @@ public class SegmentStarTable extends RandomStarTable {
         columns.add(newColumn);
     }
     
+    /**
+     * Produces a hashCode based on the StarTables spectral, flux, and error values. All other
+     * object specific values are ignored.
+     * 
+     */
     @Override
     public int hashCode() {
         
@@ -481,7 +486,6 @@ public class SegmentStarTable extends RandomStarTable {
             .append(this.fluxValues)
             .append(this.specErrValues)
             .append(this.specErrValuesLo)
-            .append(this.specErrValuesHi)
             .append(this.specErrValuesHi)
             .append(this.fluxErrValues)
             .append(this.fluxErrValuesLo)

--- a/iris-common/src/test/java/cfa/vo/iris/sed/stil/SegmentStarTableTest.java
+++ b/iris-common/src/test/java/cfa/vo/iris/sed/stil/SegmentStarTableTest.java
@@ -18,6 +18,7 @@ package cfa.vo.iris.sed.stil;
 import org.junit.Before;
 import org.junit.Test;
 import cfa.vo.iris.sed.stil.SegmentColumn.Column;
+import cfa.vo.iris.test.unit.TestUtils;
 import cfa.vo.iris.units.spv.XUnits;
 import cfa.vo.iris.units.spv.YUnits;
 import cfa.vo.sedlib.Sed;
@@ -155,7 +156,6 @@ public class SegmentStarTableTest {
         segment.getData().setDataValues(err, Utypes.SEG_DATA_FLUXAXIS_ACC_STATERR);
         
         SegmentStarTable table = new SegmentStarTable(segment);
-        ColumnIdentifier id = new ColumnIdentifier(table);
         
         // erg/s/cm2/Hz to ABMAG
         table.setFluxUnits(new YUnits("ABMAG"));
@@ -194,5 +194,31 @@ public class SegmentStarTableTest {
             assertEquals(y[i], table.getFluxValues()[i], 0.000001);
             assertEquals(0.1, table.getFluxErrValues()[i], 0.000001);
         }
+    }
+    
+    @Test
+    public void hashCodeTest() throws Exception {
+        Segment segment = TestUtils.createSampleSegment(new double[] {1}, new double[] {1});
+        SegmentStarTable table = new SegmentStarTable(segment);
+        
+        assertFalse(table.validHashCode);
+        
+        // Compute initial hashCode
+        int h1 = table.hashCode();
+        assertTrue(table.validHashCode);
+        
+        // Update values
+        table.setSpecErrValues(new double[] {2});
+        assertFalse(table.validHashCode);
+        int h2 = table.hashCode();
+        assertFalse(h1 == h2);
+        assertTrue(table.validHashCode);
+        
+        // Update values
+        table.setFluxErrValues(new double[] {2});
+        assertFalse(table.validHashCode);
+        int h3 = table.hashCode();
+        assertFalse(h2 == h3);
+        assertTrue(table.validHashCode);
     }
 }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FitController.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FitController.java
@@ -116,6 +116,10 @@ public class FitController {
     public FitResults fit() throws Exception {
         FitResults retVal = client.fit(sedModel.getSed());
         sedModel.getFit().integrateResults(retVal);
+        
+        // Record the version number on the SED in the FitConfiguration
+        sedModel.getFit().setSedVersion(sedModel.getVersion());
+        
         return retVal;
     }
 
@@ -208,6 +212,10 @@ public class FitController {
      * @throws Exception
      */
     public void evaluateModel(SedModel sedModel) throws Exception {
+        
+        // Update the model version with the current version of the Sed
+        sedModel.setModelVersion(sedModel.getModelVersion());
+        
         String xUnit = sedModel.getXUnits();
         String yUnit = sedModel.getYUnits();
 

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FitController.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FitController.java
@@ -214,7 +214,8 @@ public class FitController {
     public void evaluateModel(SedModel sedModel) throws Exception {
         
         // Update the model version with the current version of the Sed
-        sedModel.setModelVersion(sedModel.getModelVersion());
+        sedModel.setModelVersion(sedModel.getVersion());
+        sedModel.setHasModelFunction(true);
         
         String xUnit = sedModel.getXUnits();
         String yUnit = sedModel.getYUnits();

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/FittingToolComponent.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/FittingToolComponent.java
@@ -150,6 +150,10 @@ public class FittingToolComponent implements IrisComponent {
                             SedModel model = preferences.getDataStore().getSedModel(sed);
                             FitController controller = new FitController(model, customManager, sherpaClient);
                             view = new FittingMainView(preferences.getDataStore(), ws.getFileChooser(), controller);
+                            
+                            // Add the FitController to the IrisVisualizer
+                            IrisVisualizer.getInstance().setFitController(controller);
+                            
                             ws.addFrame(view);
                         } catch (Exception ex) {
                             throw new RuntimeException(ex);

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/IrisVisualizer.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/IrisVisualizer.java
@@ -16,6 +16,7 @@
 package cfa.vo.iris.visualizer;
 
 import cfa.vo.iris.IWorkspace;
+import cfa.vo.iris.fitting.FitController;
 import cfa.vo.iris.visualizer.preferences.VisualizerComponentPreferences;
 
 /**
@@ -27,6 +28,9 @@ public class IrisVisualizer {
     
     // Active visualizer component preferences
     private VisualizerComponentPreferences preferences;
+    
+    // Active FitController
+    private FitController controller;
     
     private IrisVisualizer() {};
     
@@ -60,5 +64,13 @@ public class IrisVisualizer {
      */
     public VisualizerComponentPreferences getActivePreferences() {
         return preferences;
+    }
+
+    public void setFitController(FitController controller) {
+        this.controller = controller;
+    }
+    
+    public FitController getController() {
+        return this.controller;
     }
 }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.form
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.form
@@ -199,6 +199,8 @@
                   <Component id="tglbtnShowHideResiduals" min="-2" max="-2" attributes="0"/>
                   <EmptySpace max="-2" attributes="0"/>
                   <Component id="secondaryPlotTypeComboBox" min="-2" max="-2" attributes="0"/>
+                  <EmptySpace max="32767" attributes="0"/>
+                  <Component id="evaluateButton" min="-2" max="-2" attributes="0"/>
                   <EmptySpace max="-2" attributes="0"/>
               </Group>
           </Group>
@@ -210,6 +212,7 @@
                   <Group type="103" groupAlignment="3" attributes="0">
                       <Component id="tglbtnShowHideResiduals" alignment="3" min="-2" max="-2" attributes="0"/>
                       <Component id="secondaryPlotTypeComboBox" alignment="3" min="-2" max="-2" attributes="0"/>
+                      <Component id="evaluateButton" alignment="3" min="-2" max="-2" attributes="0"/>
                   </Group>
                   <EmptySpace max="32767" attributes="0"/>
               </Group>
@@ -231,6 +234,15 @@
               </StringArray>
             </Property>
           </Properties>
+        </Component>
+        <Component class="javax.swing.JButton" name="evaluateButton">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="Evaluate Models"/>
+            <Property name="toolTipText" type="java.lang.String" value="Re-evaluates the models using the current fit results"/>
+          </Properties>
+          <Events>
+            <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="evaluateButtonActionPerformed"/>
+          </Events>
         </Component>
       </SubComponents>
     </Container>

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.form
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.form
@@ -22,33 +22,6 @@
                 <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="mntmExportActionPerformed"/>
               </Events>
             </MenuItem>
-            <MenuItem class="javax.swing.JMenuItem" name="mntmProperties">
-              <Properties>
-                <Property name="text" type="java.lang.String" value="Properties"/>
-              </Properties>
-            </MenuItem>
-            <MenuItem class="javax.swing.JMenuItem" name="mntmOpen">
-              <Properties>
-                <Property name="text" type="java.lang.String" value="Open"/>
-              </Properties>
-            </MenuItem>
-            <MenuItem class="javax.swing.JMenuItem" name="mntmSave">
-              <Properties>
-                <Property name="text" type="java.lang.String" value="Save"/>
-              </Properties>
-            </MenuItem>
-          </SubComponents>
-        </Menu>
-        <Menu class="javax.swing.JMenu" name="mnEdit">
-          <Properties>
-            <Property name="text" type="java.lang.String" value="Edit"/>
-          </Properties>
-          <SubComponents>
-            <MenuItem class="javax.swing.JMenuItem" name="mntmSomething">
-              <Properties>
-                <Property name="text" type="java.lang.String" value="Something"/>
-              </Properties>
-            </MenuItem>
           </SubComponents>
         </Menu>
         <Menu class="javax.swing.JMenu" name="mnView">

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
@@ -236,11 +236,6 @@ public class PlotterView extends JInternalFrame {
         menuBar = new javax.swing.JMenuBar();
         mnF = new javax.swing.JMenu();
         mntmExport = new javax.swing.JMenuItem();
-        mntmProperties = new javax.swing.JMenuItem();
-        mntmOpen = new javax.swing.JMenuItem();
-        mntmSave = new javax.swing.JMenuItem();
-        mnEdit = new javax.swing.JMenu();
-        mntmSomething = new javax.swing.JMenuItem();
         mnView = new javax.swing.JMenu();
         mnPlotType = new javax.swing.JMenu();
         mntmLog = new javax.swing.JRadioButtonMenuItem();
@@ -540,23 +535,7 @@ public class PlotterView extends JInternalFrame {
         });
         mnF.add(mntmExport);
 
-        mntmProperties.setText("Properties");
-        mnF.add(mntmProperties);
-
-        mntmOpen.setText("Open");
-        mnF.add(mntmOpen);
-
-        mntmSave.setText("Save");
-        mnF.add(mntmSave);
-
         menuBar.add(mnF);
-
-        mnEdit.setText("Edit");
-
-        mntmSomething.setText("Something");
-        mnEdit.add(mntmSomething);
-
-        menuBar.add(mnEdit);
 
         mnView.setText("View");
 
@@ -719,7 +698,6 @@ public class PlotterView extends JInternalFrame {
     private cfa.vo.iris.visualizer.plotter.JButtonArrow left;
     private javax.swing.JMenuBar menuBar;
     private javax.swing.JButton metadataButton;
-    private javax.swing.JMenu mnEdit;
     private javax.swing.JMenu mnF;
     private javax.swing.JMenu mnHelp;
     private javax.swing.JMenu mnPlotType;
@@ -731,11 +709,7 @@ public class PlotterView extends JInternalFrame {
     private javax.swing.JCheckBoxMenuItem mntmGridOnOff;
     private javax.swing.JRadioButtonMenuItem mntmLinear;
     private javax.swing.JRadioButtonMenuItem mntmLog;
-    private javax.swing.JMenuItem mntmOpen;
     private javax.swing.JMenuItem mntmPlotterNavigationHelp;
-    private javax.swing.JMenuItem mntmProperties;
-    private javax.swing.JMenuItem mntmSave;
-    private javax.swing.JMenuItem mntmSomething;
     private javax.swing.JRadioButtonMenuItem mntmXlog;
     private javax.swing.JRadioButtonMenuItem mntmYlog;
     private javax.swing.JPanel mouseCoordPanel;

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
@@ -16,10 +16,13 @@
 package cfa.vo.iris.visualizer.plotter;
 
 import cfa.vo.iris.IWorkspace;
+import cfa.vo.iris.fitting.FitController;
 import cfa.vo.iris.gui.GUIUtils;
+import cfa.vo.iris.visualizer.IrisVisualizer;
 import cfa.vo.iris.visualizer.metadata.MetadataBrowserMainView;
 import cfa.vo.iris.visualizer.plotter.PlotPreferences.PlotType;
 import cfa.vo.iris.visualizer.preferences.CoPlotManagementWindow;
+import cfa.vo.iris.visualizer.preferences.SedModel;
 import cfa.vo.iris.visualizer.preferences.VisualizerComponentPreferences;
 import cfa.vo.iris.visualizer.preferences.VisualizerDataModel;
 import java.awt.Dimension;
@@ -213,6 +216,7 @@ public class PlotterView extends JInternalFrame {
         bottomButtonsPanel = new javax.swing.JPanel();
         tglbtnShowHideResiduals = new javax.swing.JToggleButton();
         secondaryPlotTypeComboBox = new javax.swing.JComboBox();
+        evaluateButton = new javax.swing.JButton();
         topButtonsPanel = new javax.swing.JPanel();
         btnReset = new javax.swing.JButton();
         zoomIn = new javax.swing.JButton();
@@ -264,6 +268,14 @@ public class PlotterView extends JInternalFrame {
 
         secondaryPlotTypeComboBox.setModel(new javax.swing.DefaultComboBoxModel(new String[] { "Residuals", "Ratios" }));
 
+        evaluateButton.setText("Evaluate Models");
+        evaluateButton.setToolTipText("Re-evaluates the models using the current fit results");
+        evaluateButton.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                evaluateButtonActionPerformed(evt);
+            }
+        });
+
         javax.swing.GroupLayout bottomButtonsPanelLayout = new javax.swing.GroupLayout(bottomButtonsPanel);
         bottomButtonsPanel.setLayout(bottomButtonsPanelLayout);
         bottomButtonsPanelLayout.setHorizontalGroup(
@@ -273,6 +285,8 @@ public class PlotterView extends JInternalFrame {
                 .addComponent(tglbtnShowHideResiduals)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(secondaryPlotTypeComboBox, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                .addComponent(evaluateButton)
                 .addContainerGap())
         );
         bottomButtonsPanelLayout.setVerticalGroup(
@@ -281,7 +295,8 @@ public class PlotterView extends JInternalFrame {
                 .addContainerGap()
                 .addGroup(bottomButtonsPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(tglbtnShowHideResiduals)
-                    .addComponent(secondaryPlotTypeComboBox, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                    .addComponent(secondaryPlotTypeComboBox, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(evaluateButton))
                 .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
 
@@ -680,12 +695,26 @@ public class PlotterView extends JInternalFrame {
         plotter.dataPan(SwingConstants.WEST);
     }//GEN-LAST:event_rightActionPerformed
 
+    private void evaluateButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_evaluateButtonActionPerformed
+        // Do nothing if there is not controller available
+        FitController controller = IrisVisualizer.getInstance().getController();
+        if (controller == null) {
+            return;
+        }
+        
+        // Re-evaluate all models currently plotted
+        for (SedModel model : preferences.getDataModel().getSedModels()) {
+            preferences.evaluateModel(model, controller);
+        }
+    }//GEN-LAST:event_evaluateButtonActionPerformed
+
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JPanel bottomButtonsPanel;
     private javax.swing.JButton btnReset;
     private javax.swing.JButton btnUnits;
     private javax.swing.JPanel buttonPanel;
     private cfa.vo.iris.visualizer.plotter.JButtonArrow down;
+    private javax.swing.JButton evaluateButton;
     private javax.swing.JSpinner fluxOrDensity;
     private cfa.vo.iris.visualizer.plotter.JButtonArrow left;
     private javax.swing.JMenuBar menuBar;

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/StilPlotter.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/StilPlotter.java
@@ -19,7 +19,6 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.SwingConstants;
 
-import cfa.vo.iris.gui.NarrowOptionPane;
 import cfa.vo.iris.sed.ExtSed;
 import cfa.vo.iris.sed.quantities.SPVYQuantity;
 import cfa.vo.iris.visualizer.preferences.FunctionModel;
@@ -284,10 +283,10 @@ public class StilPlotter extends JPanel {
         if (sedIds.length() > 0) {
             JOptionPane.showMessageDialog(this, 
                     String.format(
-                    "Warning: %smay no longer be valid! You may want to refit the sed or re-evaluate the model for the fit.",
+                    "Warning: %smay no longer be valid! You may want to\n refit the sed or re-evaluate the model for the fit.",
                     sedIds.toString()),
                     "Warning",
-                    NarrowOptionPane.WARNING_MESSAGE);
+                    JOptionPane.WARNING_MESSAGE);
         }
     }
 

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/StilPlotter.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/StilPlotter.java
@@ -273,10 +273,6 @@ public class StilPlotter extends JPanel {
             }
             
             sedIds.append(sedModel.getSed().getId() + ", ");
-            
-            // We will have warned the user, so update the modelVersionNumber so
-            // this popup doesn't show twice for the same sed model
-            sedModel.setModelVersion(sedModel.getVersion());
         }
         
         // If any models were invalid notify the user, this should only display once
@@ -287,6 +283,10 @@ public class StilPlotter extends JPanel {
                     sedIds.toString()),
                     "Warning",
                     JOptionPane.WARNING_MESSAGE);
+            
+            // We will have warned the user, so update the modelVersionNumbers for all SedModels so
+            // this popup doesn't show twice for the same sed model
+            dataModel.updateFittingVersionNumbers();
         }
     }
 

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/StilPlotter.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/StilPlotter.java
@@ -284,7 +284,7 @@ public class StilPlotter extends JPanel {
         if (sedIds.length() > 0) {
             JOptionPane.showMessageDialog(this, 
                     String.format(
-                    "Warning: %smay no longer be valid, you may want to refit the sed or reevaluate the model",
+                    "Warning: %smay no longer be valid! You may want to refit the sed or re-evaluate the model for the fit.",
                     sedIds.toString()),
                     "Warning",
                     NarrowOptionPane.WARNING_MESSAGE);

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/StilPlotter.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/StilPlotter.java
@@ -15,13 +15,16 @@
  */
 package cfa.vo.iris.visualizer.plotter;
 
+import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.SwingConstants;
 
+import cfa.vo.iris.gui.NarrowOptionPane;
 import cfa.vo.iris.sed.ExtSed;
 import cfa.vo.iris.sed.quantities.SPVYQuantity;
 import cfa.vo.iris.visualizer.preferences.FunctionModel;
 import cfa.vo.iris.visualizer.preferences.LayerModel;
+import cfa.vo.iris.visualizer.preferences.SedModel;
 import cfa.vo.iris.visualizer.preferences.VisualizerComponentPreferences;
 import cfa.vo.iris.visualizer.preferences.VisualizerDataModel;
 
@@ -250,8 +253,44 @@ public class StilPlotter extends JPanel {
         
         // Add the display to the plot view
         addPlotToDisplay();
+        
+        // Check for valid model functions on redraws
+        validateModelFunctions();
     }
     
+    /**
+     * Verify all model functions are valid and up to date with the original version
+     * of the fit function. Notify the user if not.
+     */
+    private void validateModelFunctions() {
+        StringBuilder sedIds = new StringBuilder();
+        for (SedModel sedModel : dataModel.getSedModels()) {
+            
+            // If there is no model or the model is valid, then we're good
+            if (!sedModel.getHasModelFunction() ||
+               (sedModel.getVersion() == sedModel.getModelVersion())) 
+            {
+                continue;
+            }
+            
+            sedIds.append(sedModel.getSed().getId() + ", ");
+            
+            // We will have warned the user, so update the modelVersionNumber so
+            // this popup doesn't show twice for the same sed model
+            sedModel.setModelVersion(sedModel.getVersion());
+        }
+        
+        // If any models were invalid notify the user, this should only display once
+        if (sedIds.length() > 0) {
+            JOptionPane.showMessageDialog(this, 
+                    String.format(
+                    "Warning: %smay no longer be valid, you may want to refit the sed or reevaluate the model",
+                    sedIds.toString()),
+                    "Warning",
+                    NarrowOptionPane.WARNING_MESSAGE);
+        }
+    }
+
     /**
      * Resets boundaries on the zoom to their original settings.
      */

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/UnitsManagerFrame.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/UnitsManagerFrame.java
@@ -137,7 +137,11 @@ public class UnitsManagerFrame extends javax.swing.JInternalFrame {
 
     private void updateButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_updateButtonActionPerformed
         dataModel.setUnits(unitsWidget.getXunit(), unitsWidget.getYunit());
+        
+        // Updating units doesn't fundamentally change the segments, so we force update the version
+        dataModel.updateFittingVersionNumbers();
         dataModel.refresh();
+        
         setVisible(false);
     }//GEN-LAST:event_updateButtonActionPerformed
 

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedModel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedModel.java
@@ -58,6 +58,9 @@ public class SedModel {
     private String xunits;
     private String yunits;
     
+    // Evaluated model version number
+    private int modelVersion;
+
     public SedModel(ExtSed sed, IrisStarTableAdapter adapter) {
         this.sed = sed;
         this.adapter = adapter;
@@ -310,7 +313,15 @@ public class SedModel {
     public void setFit(FitConfiguration fit) {
         sed.setFit(fit);
     }
+    
+    public int getModelVersion() {
+        return modelVersion;
+    }
 
+    public void setModelVersion(int modelVersion) {
+        this.modelVersion = modelVersion;
+    }
+    
     public ExtSed getSed() {
         return sed;
     }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedModel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedModel.java
@@ -16,6 +16,7 @@
 
 package cfa.vo.iris.visualizer.preferences;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.LinkedList;
@@ -24,6 +25,7 @@ import java.util.Map;
 
 import cfa.vo.iris.fitting.FitConfiguration;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.builder.HashCodeBuilder;
 
 import cfa.vo.iris.sed.ExtSed;
 import cfa.vo.iris.visualizer.plotter.ColorPalette;
@@ -111,7 +113,7 @@ public class SedModel {
      * order as they appear in the SED.
      */
     public List<IrisStarTable> getDataTables() {
-        List<IrisStarTable> ret = new LinkedList<>();
+        List<IrisStarTable> ret = new ArrayList<>();
         for (Segment seg : sed.getSegments()) {
             // If this isn't available then it hasn't yet been serialized in the DataStore
             if (starTableData.containsKey(seg)) {
@@ -283,6 +285,14 @@ public class SedModel {
                         .log(Level.SEVERE, null, ex);
             }
         }
+    }
+    
+    public int getVersion() {
+        HashCodeBuilder hcb = new HashCodeBuilder(13,31);
+        for (IrisStarTable table : getDataTables()) {
+            hcb.append(table.getPlotterDataTable().hashCode());
+        }
+        return hcb.hashCode();
     }
     
     public String getXUnits() {

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedModel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedModel.java
@@ -59,7 +59,8 @@ public class SedModel {
     private String yunits;
     
     // Evaluated model version number
-    private int modelVersion;
+    private int modelVersion = 13;
+    private boolean hasModelFunction = false;
 
     public SedModel(ExtSed sed, IrisStarTableAdapter adapter) {
         this.sed = sed;
@@ -290,14 +291,6 @@ public class SedModel {
         }
     }
     
-    public int getVersion() {
-        HashCodeBuilder hcb = new HashCodeBuilder(13,31);
-        for (IrisStarTable table : getDataTables()) {
-            hcb.append(table.getPlotterDataTable().hashCode());
-        }
-        return hcb.hashCode();
-    }
-    
     public String getXUnits() {
         return xunits;
     }
@@ -314,12 +307,28 @@ public class SedModel {
         sed.setFit(fit);
     }
     
+    public int getVersion() {
+        HashCodeBuilder hcb = new HashCodeBuilder(13,31);
+        for (IrisStarTable table : getDataTables()) {
+            hcb.append(table.getPlotterDataTable().hashCode());
+        }
+        return hcb.hashCode();
+    }
+    
     public int getModelVersion() {
         return modelVersion;
     }
 
     public void setModelVersion(int modelVersion) {
         this.modelVersion = modelVersion;
+    }
+
+    public boolean getHasModelFunction() {
+        return hasModelFunction;
+    }
+
+    public void setHasModelFunction(boolean hasModelFunction) {
+        this.hasModelFunction = hasModelFunction;
     }
     
     public ExtSed getSed() {

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerDataModel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerDataModel.java
@@ -344,6 +344,26 @@ public class VisualizerDataModel {
         pp.setYUnits(yunit);
     }
     
+    /**
+     * This method should be called when we want to explicitly bring the version numbers
+     * of each SedModel's fitting and evaluated models up to date with the latest version
+     * of the Sed. In particular, when changing units we want the version numbers to update.
+     * Or when the user explicitly asks to ignore future warnings of the model being out 
+     * of date.
+     * 
+     */
+    public void updateFittingVersionNumbers() {
+        for (SedModel model : getSedModels()) {
+            int version = model.getVersion();
+            if (model.getHasModelFunction()) {
+                model.setModelVersion(version);
+            }
+            if (model.getSed().getFit() != null) {
+                model.getSed().getFit().setSedVersion(version);
+            }
+        }
+    }
+    
     public String getXunits() {
         return xUnits;
     }

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/VisualizerComponentTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/VisualizerComponentTest.java
@@ -154,7 +154,7 @@ public class VisualizerComponentTest extends AbstractComponentGUITest {
         
         // check the grid is on by default
         JMenuBar menu = viewer.findSwingComponent(JMenuBar.class, "menuBar");
-        JCheckBoxMenuItem gridMenuItem = (JCheckBoxMenuItem) menu.getMenu(2).getMenuComponent(3);
+        JCheckBoxMenuItem gridMenuItem = (JCheckBoxMenuItem) menu.getMenu(1).getMenuComponent(3);
         assertTrue(gridMenuItem.isSelected());
         
         // on by default. switch grids off
@@ -182,7 +182,7 @@ public class VisualizerComponentTest extends AbstractComponentGUITest {
         
         // when a new SED is added, it should have the default plot preferences.
         // check that the Grid on/off checkbox is selected.
-        gridMenuItem = (JCheckBoxMenuItem) menu.getMenu(2).getMenuComponent(3);
+        gridMenuItem = (JCheckBoxMenuItem) menu.getMenu(1).getMenuComponent(3);
         assertTrue(gridMenuItem.isSelected());
         
         // switch sed2's plot type to xlog
@@ -191,7 +191,7 @@ public class VisualizerComponentTest extends AbstractComponentGUITest {
                 .getSubMenu("Plot Type")
                 .getSubMenu("X Log")
                 .click();
-        JMenu plotTypeMenu = (JMenu) menu.getMenu(2).getMenuComponent(0);
+        JMenu plotTypeMenu = (JMenu) menu.getMenu(1).getMenuComponent(0);
         JRadioButtonMenuItem xlog = (JRadioButtonMenuItem) plotTypeMenu.getItem(2);
         assertTrue(xlog.isSelected());
         
@@ -207,7 +207,7 @@ public class VisualizerComponentTest extends AbstractComponentGUITest {
         });
         
         // grid check box should still be unselected.
-        gridMenuItem = (JCheckBoxMenuItem) menu.getMenu(2).getMenuComponent(3);
+        gridMenuItem = (JCheckBoxMenuItem) menu.getMenu(1).getMenuComponent(3);
         assertTrue(!gridMenuItem.isSelected());
         
         // now, switch sed1 to linear space
@@ -217,7 +217,7 @@ public class VisualizerComponentTest extends AbstractComponentGUITest {
                 .getSubMenu("Linear")
                 .click();
         
-        plotTypeMenu = (JMenu) menu.getMenu(2).getMenuComponent(0);
+        plotTypeMenu = (JMenu) menu.getMenu(1).getMenuComponent(0);
         JRadioButtonMenuItem linear = (JRadioButtonMenuItem) plotTypeMenu.getItem(1);
         assertTrue(linear.isSelected());
         
@@ -268,7 +268,7 @@ public class VisualizerComponentTest extends AbstractComponentGUITest {
         // get components: PlotPreferences and autoFixed menuCheckBox
         PlotPreferences preferences = plotter.getPlotPreferences();
         JMenuBar menu = viewer.findSwingComponent(JMenuBar.class, "menuBar");
-        JCheckBoxMenuItem autoFixed = (JCheckBoxMenuItem) menu.getMenu(2).getMenuComponent(2);
+        JCheckBoxMenuItem autoFixed = (JCheckBoxMenuItem) menu.getMenu(1).getMenuComponent(2);
         
         // check that box is unchecked (auto range viewport by default)
         assertFalse(autoFixed.isSelected());
@@ -351,7 +351,7 @@ public class VisualizerComponentTest extends AbstractComponentGUITest {
         });
         
         // check that the fixed check box is unmarked (default value)
-        autoFixed = (JCheckBoxMenuItem) menu.getMenu(2).getMenuComponent(2);
+        autoFixed = (JCheckBoxMenuItem) menu.getMenu(1).getMenuComponent(2);
         assertFalse(autoFixed.isSelected());
         
         // assert that the plot range is for sed2, which should be the default
@@ -372,7 +372,7 @@ public class VisualizerComponentTest extends AbstractComponentGUITest {
         });
         
         // check that the fixed check box is marked since we're on sed1 now
-        autoFixed = (JCheckBoxMenuItem) menu.getMenu(2).getMenuComponent(2);
+        autoFixed = (JCheckBoxMenuItem) menu.getMenu(1).getMenuComponent(2);
         assertTrue(autoFixed.isSelected());
         
         // make sure the view port is the same as it was before switching

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/plotter/StilPlotterTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/plotter/StilPlotterTest.java
@@ -495,7 +495,7 @@ public class StilPlotterTest extends AbstractUISpecTest {
             public Trigger process(Window warning) throws Exception {
                 assertTrue(StringUtils.contains(warning.getTitle(), "Warning"));
                 assertTrue(StringUtils.contains(
-                        warning.getTextBox("OptionPane.label").getText(), sed1.getId()));
+                        warning.getTextBox("Warning").getText(), sed1.getId()));
                 return Trigger.DO_NOTHING;
             }
         }).run();


### PR DESCRIPTION
Resolves
https://github.com/ChandraCXC/iris-dev/issues/111

Validation uses hashCodes built on the spectral, flux, and error values in a SegmentStarTable. The logic being that a fit will be valid as long as those values haven't changed. The SedModel uses those hashCodes to produce a "hashCode" for all the segments in the SED. Note that I call it a version rather than a HashCode, as I don't really want to overwrite the SedModel's hashCode function as it's pretty heavily utilized already in the Visualizer.

Right now the default behaviour is to show a warning message once when a function model is no longer valid for the given SedModel. Once the user has acknowledged the warning it will not be shown again until the SED version number changes.

The Version numbers are recorded in two places: The FitConfiguration whenever .fit is called in the FitController, and in the SedModel whenever .evaluateModel is called in the FitController.

The FitConfiguration now has a version number attached to it, though this change isn't currently using it. I can easily add an additional check in the StilPlotter if we think it should go there. Otherwise I would like to see something in the Fitting Tool also doing a check to see if the FitConfiguration is still valid for the SED. There's definitely more behaviour we could add in the Fitting Tool but I won't mess with it until the GUI changes are in place.