### PR TITLE
Fix fitting tool bugs

### DIFF
--- a/iris-common/src/main/java/cfa/vo/iris/fitting/FitConfiguration.java
+++ b/iris-common/src/main/java/cfa/vo/iris/fitting/FitConfiguration.java
@@ -58,7 +58,7 @@ public class FitConfiguration {
     public FitConfiguration() {
         model = SAMPFactory.get(CompositeModel.class);
         confidence = SAMPFactory.get(Confidence.class);
-        confidence.setSigma(1.6);
+        confidence.getConfig().setSigma(1.6);
         confidence.setName("conf");
         stat = Statistic.Chi2;
         method = OptimizationMethod.LevenbergMarquardt;

--- a/iris-common/src/main/java/cfa/vo/iris/fitting/FitConfiguration.java
+++ b/iris-common/src/main/java/cfa/vo/iris/fitting/FitConfiguration.java
@@ -268,6 +268,8 @@ public class FitConfiguration {
         setNumPoints(results.getNumpoints());
         setStatVal(results.getStatval());
         setDof(results.getDof().intValue());
+
+        setConfidenceResults(null);
     }
 
     @Override

--- a/iris-common/src/main/java/cfa/vo/iris/gui/widgets/ModelViewerPanel.form
+++ b/iris-common/src/main/java/cfa/vo/iris/gui/widgets/ModelViewerPanel.form
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <Form version="1.7" maxVersion="1.7" type="org.netbeans.modules.form.forminfo.JPanelFormInfo">
+  <Properties>
+    <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+      <Dimension value="[487, 224]"/>
+    </Property>
+    <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+      <Dimension value="[487, 224]"/>
+    </Property>
+  </Properties>
   <AuxValues>
     <AuxValue name="FormSettings_autoResourcing" type="java.lang.Integer" value="0"/>
     <AuxValue name="FormSettings_autoSetComponentName" type="java.lang.Boolean" value="true"/>
@@ -11,47 +19,21 @@
     <AuxValue name="FormSettings_listenerGenerationStyle" type="java.lang.Integer" value="0"/>
     <AuxValue name="FormSettings_variablesLocal" type="java.lang.Boolean" value="false"/>
     <AuxValue name="FormSettings_variablesModifier" type="java.lang.Integer" value="2"/>
+    <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,0,-32,0,0,1,-25"/>
   </AuxValues>
 
-  <Layout>
-    <DimensionLayout dim="0">
-      <Group type="103" groupAlignment="0" attributes="0">
-          <Component id="statusPanel" alignment="0" pref="397" max="32767" attributes="0"/>
-          <Group type="102" alignment="1" attributes="0">
-              <EmptySpace min="-2" max="-2" attributes="0"/>
-              <Component id="jLabel1" min="-2" max="-2" attributes="1"/>
-              <EmptySpace min="-2" max="-2" attributes="0"/>
-              <Component id="modelExpressionField" max="32767" attributes="0"/>
-              <EmptySpace min="-2" max="-2" attributes="0"/>
-          </Group>
-          <Group type="102" alignment="1" attributes="0">
-              <EmptySpace min="-2" pref="12" max="-2" attributes="0"/>
-              <Component id="jSplitPane1" pref="385" max="32767" attributes="0"/>
-          </Group>
-      </Group>
-    </DimensionLayout>
-    <DimensionLayout dim="1">
-      <Group type="103" groupAlignment="0" attributes="0">
-          <Group type="102" alignment="0" attributes="0">
-              <EmptySpace min="-2" max="-2" attributes="0"/>
-              <Group type="103" groupAlignment="3" attributes="0">
-                  <Component id="jLabel1" alignment="3" min="-2" max="-2" attributes="0"/>
-                  <Component id="modelExpressionField" alignment="3" min="-2" max="-2" attributes="0"/>
-              </Group>
-              <EmptySpace type="unrelated" min="-2" max="-2" attributes="0"/>
-              <Component id="jSplitPane1" pref="157" max="32767" attributes="0"/>
-              <EmptySpace min="-2" max="-2" attributes="0"/>
-              <Component id="statusPanel" min="-2" max="-2" attributes="0"/>
-          </Group>
-      </Group>
-    </DimensionLayout>
-  </Layout>
+  <Layout class="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout"/>
   <SubComponents>
     <Component class="javax.swing.JLabel" name="jLabel1">
       <Properties>
         <Property name="text" type="java.lang.String" value="Model Expression: "/>
         <Property name="name" type="java.lang.String" value="jLabel1" noResource="true"/>
       </Properties>
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+          <GridBagConstraints gridX="0" gridY="0" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="17" insetsLeft="12" insetsBottom="0" insetsRight="0" anchor="18" weightX="0.0" weightY="0.1"/>
+        </Constraint>
+      </Constraints>
     </Component>
     <Component class="javax.swing.JTextField" name="modelExpressionField">
       <Properties>
@@ -66,38 +48,25 @@
         </BindingProperty>
         <BindingProperty name="editable" source="Form" sourcePath="${editable}" target="modelExpressionField" targetPath="editable" updateStrategy="0" immediately="false"/>
       </BindingProperties>
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+          <GridBagConstraints gridX="1" gridY="0" gridWidth="2" gridHeight="2" fill="2" ipadX="249" ipadY="0" insetsTop="12" insetsLeft="12" insetsBottom="0" insetsRight="0" anchor="18" weightX="0.0" weightY="0.1"/>
+        </Constraint>
+      </Constraints>
     </Component>
     <Container class="javax.swing.JSplitPane" name="jSplitPane1">
       <Properties>
         <Property name="dividerLocation" type="int" value="150"/>
         <Property name="name" type="java.lang.String" value="jSplitPane1" noResource="true"/>
       </Properties>
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+          <GridBagConstraints gridX="0" gridY="2" gridWidth="3" gridHeight="1" fill="2" ipadX="280" ipadY="7" insetsTop="12" insetsLeft="12" insetsBottom="0" insetsRight="0" anchor="18" weightX="1.0" weightY="0.8"/>
+        </Constraint>
+      </Constraints>
 
       <Layout class="org.netbeans.modules.form.compat2.layouts.support.JSplitPaneSupportLayout"/>
       <SubComponents>
-        <Container class="javax.swing.JPanel" name="jPanel1">
-          <Properties>
-            <Property name="name" type="java.lang.String" value="jPanel1" noResource="true"/>
-          </Properties>
-          <Constraints>
-            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.support.JSplitPaneSupportLayout" value="org.netbeans.modules.form.compat2.layouts.support.JSplitPaneSupportLayout$JSplitPaneConstraintsDescription">
-              <JSplitPaneConstraints position="left"/>
-            </Constraint>
-          </Constraints>
-
-          <Layout>
-            <DimensionLayout dim="0">
-              <Group type="103" groupAlignment="0" attributes="0">
-                  <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
-              </Group>
-            </DimensionLayout>
-            <DimensionLayout dim="1">
-              <Group type="103" groupAlignment="0" attributes="0">
-                  <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
-              </Group>
-            </DimensionLayout>
-          </Layout>
-        </Container>
         <Container class="javax.swing.JPanel" name="jPanel2">
           <Properties>
             <Property name="name" type="java.lang.String" value="jPanel2" noResource="true"/>
@@ -111,7 +80,7 @@
           <Layout>
             <DimensionLayout dim="0">
               <Group type="103" groupAlignment="0" attributes="0">
-                  <Component id="paramPanel" alignment="0" pref="248" max="32767" attributes="0"/>
+                  <Component id="paramPanel" alignment="0" pref="319" max="32767" attributes="0"/>
               </Group>
             </DimensionLayout>
             <DimensionLayout dim="1">
@@ -148,9 +117,6 @@
           <SubComponents>
             <Component class="javax.swing.JTree" name="modelsTree">
               <Properties>
-                <Property name="model" type="javax.swing.tree.TreeModel" editor="org.netbeans.modules.form.editors2.TreeModelEditor">
-                  <TreeModel code="Model Components"/>
-                </Property>
                 <Property name="name" type="java.lang.String" value="modelsTree" noResource="true"/>
               </Properties>
               <BindingProperties>
@@ -173,11 +139,16 @@
           <Dimension value="[4, 14]"/>
         </Property>
       </Properties>
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+          <GridBagConstraints gridX="0" gridY="3" gridWidth="3" gridHeight="1" fill="1" ipadX="393" ipadY="2" insetsTop="6" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="18" weightX="1.0" weightY="0.1"/>
+        </Constraint>
+      </Constraints>
 
       <Layout>
         <DimensionLayout dim="0">
           <Group type="103" groupAlignment="0" attributes="0">
-              <Component id="statusField" alignment="0" max="32767" attributes="0"/>
+              <Component id="statusField" alignment="0" pref="483" max="32767" attributes="0"/>
           </Group>
         </DimensionLayout>
         <DimensionLayout dim="1">

--- a/iris-common/src/main/java/cfa/vo/iris/gui/widgets/ModelViewerPanel.java
+++ b/iris-common/src/main/java/cfa/vo/iris/gui/widgets/ModelViewerPanel.java
@@ -55,6 +55,7 @@ public final class ModelViewerPanel extends javax.swing.JPanel implements SedLis
         initComponents();
         SedEvent.getInstance().add(this);
         initModelsTree();
+        revalidate();
     }
 
     public boolean isEditable() {
@@ -141,12 +142,12 @@ public final class ModelViewerPanel extends javax.swing.JPanel implements SedLis
     @SuppressWarnings("unchecked")
     // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents
     private void initComponents() {
+        java.awt.GridBagConstraints gridBagConstraints;
         bindingGroup = new org.jdesktop.beansbinding.BindingGroup();
 
         jLabel1 = new javax.swing.JLabel();
         modelExpressionField = new javax.swing.JTextField();
         jSplitPane1 = new javax.swing.JSplitPane();
-        jPanel1 = new javax.swing.JPanel();
         jPanel2 = new javax.swing.JPanel();
         paramPanel = new cfa.vo.iris.gui.widgets.ModelParameterPanel();
         jScrollPane1 = new javax.swing.JScrollPane();
@@ -154,8 +155,19 @@ public final class ModelViewerPanel extends javax.swing.JPanel implements SedLis
         statusPanel = new javax.swing.JPanel();
         statusField = new javax.swing.JLabel();
 
+        setMinimumSize(new java.awt.Dimension(487, 224));
+        setPreferredSize(new java.awt.Dimension(487, 224));
+        setLayout(new java.awt.GridBagLayout());
+
         jLabel1.setText("Model Expression: ");
         jLabel1.setName("jLabel1"); // NOI18N
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 0;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
+        gridBagConstraints.weighty = 0.1;
+        gridBagConstraints.insets = new java.awt.Insets(17, 12, 0, 0);
+        add(jLabel1, gridBagConstraints);
 
         modelExpressionField.setInputVerifier(new Verifier());
         modelExpressionField.setName("modelExpressionField"); // NOI18N
@@ -165,23 +177,20 @@ public final class ModelViewerPanel extends javax.swing.JPanel implements SedLis
         binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${editable}"), modelExpressionField, org.jdesktop.beansbinding.BeanProperty.create("editable"));
         bindingGroup.addBinding(binding);
 
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 1;
+        gridBagConstraints.gridy = 0;
+        gridBagConstraints.gridwidth = 2;
+        gridBagConstraints.gridheight = 2;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.ipadx = 249;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
+        gridBagConstraints.weighty = 0.1;
+        gridBagConstraints.insets = new java.awt.Insets(12, 12, 0, 0);
+        add(modelExpressionField, gridBagConstraints);
+
         jSplitPane1.setDividerLocation(150);
         jSplitPane1.setName("jSplitPane1"); // NOI18N
-
-        jPanel1.setName("jPanel1"); // NOI18N
-
-        org.jdesktop.layout.GroupLayout jPanel1Layout = new org.jdesktop.layout.GroupLayout(jPanel1);
-        jPanel1.setLayout(jPanel1Layout);
-        jPanel1Layout.setHorizontalGroup(
-            jPanel1Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
-        );
-        jPanel1Layout.setVerticalGroup(
-            jPanel1Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
-        );
-
-        jSplitPane1.setLeftComponent(jPanel1);
 
         jPanel2.setName("jPanel2"); // NOI18N
 
@@ -194,7 +203,7 @@ public final class ModelViewerPanel extends javax.swing.JPanel implements SedLis
         jPanel2.setLayout(jPanel2Layout);
         jPanel2Layout.setHorizontalGroup(
             jPanel2Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(paramPanel, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 248, Short.MAX_VALUE)
+            .add(paramPanel, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 319, Short.MAX_VALUE)
         );
         jPanel2Layout.setVerticalGroup(
             jPanel2Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
@@ -205,8 +214,6 @@ public final class ModelViewerPanel extends javax.swing.JPanel implements SedLis
 
         jScrollPane1.setName("jScrollPane1"); // NOI18N
 
-        javax.swing.tree.DefaultMutableTreeNode treeNode1 = new javax.swing.tree.DefaultMutableTreeNode("Model Components");
-        modelsTree.setModel(new javax.swing.tree.DefaultTreeModel(treeNode1));
         modelsTree.setName("modelsTree"); // NOI18N
 
         binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${fit.treeModel}"), modelsTree, org.jdesktop.beansbinding.BeanProperty.create("model"));
@@ -215,6 +222,19 @@ public final class ModelViewerPanel extends javax.swing.JPanel implements SedLis
         jScrollPane1.setViewportView(modelsTree);
 
         jSplitPane1.setLeftComponent(jScrollPane1);
+
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 2;
+        gridBagConstraints.gridwidth = 3;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.ipadx = 280;
+        gridBagConstraints.ipady = 7;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
+        gridBagConstraints.weightx = 1.0;
+        gridBagConstraints.weighty = 0.8;
+        gridBagConstraints.insets = new java.awt.Insets(12, 12, 0, 0);
+        add(jSplitPane1, gridBagConstraints);
 
         statusPanel.setBorder(javax.swing.BorderFactory.createEtchedBorder());
         statusPanel.setName("statusPanel"); // NOI18N
@@ -233,7 +253,7 @@ public final class ModelViewerPanel extends javax.swing.JPanel implements SedLis
         statusPanel.setLayout(statusPanelLayout);
         statusPanelLayout.setHorizontalGroup(
             statusPanelLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(statusField, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+            .add(statusField, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 483, Short.MAX_VALUE)
         );
         statusPanelLayout.setVerticalGroup(
             statusPanelLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
@@ -242,40 +262,24 @@ public final class ModelViewerPanel extends javax.swing.JPanel implements SedLis
                 .add(0, 2, Short.MAX_VALUE))
         );
 
-        org.jdesktop.layout.GroupLayout layout = new org.jdesktop.layout.GroupLayout(this);
-        this.setLayout(layout);
-        layout.setHorizontalGroup(
-            layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(statusPanel, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 397, Short.MAX_VALUE)
-            .add(org.jdesktop.layout.GroupLayout.TRAILING, layout.createSequentialGroup()
-                .addContainerGap()
-                .add(jLabel1)
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(modelExpressionField)
-                .addContainerGap())
-            .add(org.jdesktop.layout.GroupLayout.TRAILING, layout.createSequentialGroup()
-                .add(12, 12, 12)
-                .add(jSplitPane1, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 385, Short.MAX_VALUE))
-        );
-        layout.setVerticalGroup(
-            layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(layout.createSequentialGroup()
-                .addContainerGap()
-                .add(layout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-                    .add(jLabel1)
-                    .add(modelExpressionField, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
-                .add(jSplitPane1, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 157, Short.MAX_VALUE)
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(statusPanel, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
-        );
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 3;
+        gridBagConstraints.gridwidth = 3;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
+        gridBagConstraints.ipadx = 393;
+        gridBagConstraints.ipady = 2;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
+        gridBagConstraints.weightx = 1.0;
+        gridBagConstraints.weighty = 0.1;
+        gridBagConstraints.insets = new java.awt.Insets(6, 0, 0, 0);
+        add(statusPanel, gridBagConstraints);
 
         bindingGroup.bind();
     }// </editor-fold>//GEN-END:initComponents
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JLabel jLabel1;
-    private javax.swing.JPanel jPanel1;
     private javax.swing.JPanel jPanel2;
     private javax.swing.JScrollPane jScrollPane1;
     private javax.swing.JSplitPane jSplitPane1;

--- a/iris-common/src/main/java/cfa/vo/sherpa/SherpaClient.java
+++ b/iris-common/src/main/java/cfa/vo/sherpa/SherpaClient.java
@@ -28,7 +28,7 @@ import java.util.logging.Logger;
 public class SherpaClient {
     public static final String DATA_NAME = "fitdata";
     public static final String X_UNIT = "Angstrom";
-    public static final String Y_UNIT = "erg/s/cm2/Angstrom";
+    public static final String Y_UNIT = "photon/s/cm2/Angstrom";
 
     private ModelFactory modelFactory = new ModelFactory();
     private SampService sampService;

--- a/iris-common/src/test/java/cfa/vo/iris/test/unit/TestUtils.java
+++ b/iris-common/src/test/java/cfa/vo/iris/test/unit/TestUtils.java
@@ -42,17 +42,17 @@ public class TestUtils {
      * 
      */
     public static void invokeWithRetry(int maxRetries, long wait, Runnable runnable) throws Exception {
-        Exception last = null;
+        Throwable last = null;
         for (int i=0; i<maxRetries; i++) {
             try {
                 SwingUtilities.invokeAndWait(runnable);
                 return;
-            } catch (Exception e) {
+            } catch (Exception | AssertionError e) {
                 last = e;
                 Thread.sleep(wait);
             }
         }
-        throw last;
+        throw new RuntimeException("Giving up invoke and retry", last);
     }
 
     /**

--- a/iris-common/src/test/java/cfa/vo/iris/test/unit/TestUtils.java
+++ b/iris-common/src/test/java/cfa/vo/iris/test/unit/TestUtils.java
@@ -42,17 +42,20 @@ public class TestUtils {
      * 
      */
     public static void invokeWithRetry(int maxRetries, long wait, Runnable runnable) throws Exception {
-        Throwable last = null;
+        Exception last = null;
         for (int i=0; i<maxRetries; i++) {
             try {
                 SwingUtilities.invokeAndWait(runnable);
                 return;
-            } catch (Exception | AssertionError e) {
+            } catch (Exception e) {
                 last = e;
+                Thread.sleep(wait);
+            } catch (AssertionError e) {
+                last = new RuntimeException(e);
                 Thread.sleep(wait);
             }
         }
-        throw new RuntimeException("Giving up invoke and retry", last);
+        throw last;
     }
 
     /**

--- a/iris-common/src/test/java/cfa/vo/sherpa/SherpaClientTest.java
+++ b/iris-common/src/test/java/cfa/vo/sherpa/SherpaClientTest.java
@@ -34,7 +34,7 @@ public class SherpaClientTest {
         segment.setSpectralAxisValues(x);
         segment.setFluxAxisValues(y);
         segment.setSpectralAxisUnits("Angstrom");
-        segment.setFluxAxisUnits("erg/s/cm2/Angstrom");
+        segment.setFluxAxisUnits("photon/s/cm2/Angstrom");
         sed.addSegment(segment);
 
         ModelFactory factory = new ModelFactory();

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/ConfidencePanel.form
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/ConfidencePanel.form
@@ -16,6 +16,7 @@
     <AuxValue name="FormSettings_listenerGenerationStyle" type="java.lang.Integer" value="0"/>
     <AuxValue name="FormSettings_variablesLocal" type="java.lang.Boolean" value="false"/>
     <AuxValue name="FormSettings_variablesModifier" type="java.lang.Integer" value="2"/>
+    <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,1,44,0,0,1,-112"/>
   </AuxValues>
 
   <Layout class="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout"/>
@@ -45,10 +46,18 @@
         </Constraint>
       </Constraints>
     </Component>
-    <Component class="javax.swing.JLabel" name="jLabel2">
+    <Component class="javax.swing.JLabel" name="sigmaText">
       <Properties>
-        <Property name="text" type="java.lang.String" value="sigma - 89.04%"/>
+        <Property name="text" type="java.lang.String" value="sigma - 90.00%"/>
+        <Property name="name" type="java.lang.String" value="sigmaPercent" noResource="true"/>
       </Properties>
+      <BindingProperties>
+        <BindingProperty name="text" source="Form" sourcePath="${confidenceResults.percent}" target="sigmaText" targetPath="text" updateStrategy="0" immediately="false">
+          <Property name="converter" type="org.jdesktop.beansbinding.Converter" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+            <Connection code="new SigmaConverter()" type="code"/>
+          </Property>
+        </BindingProperty>
+      </BindingProperties>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
           <GridBagConstraints gridX="2" gridY="0" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="17" insetsLeft="12" insetsBottom="0" insetsRight="12" anchor="13" weightX="0.0" weightY="0.0"/>

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/ConfidencePanel.form
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/ConfidencePanel.form
@@ -58,8 +58,11 @@
       </Properties>
     </Component>
     <Component class="javax.swing.JTextField" name="jTextField1">
+      <Properties>
+        <Property name="name" type="java.lang.String" value="sigma" noResource="true"/>
+      </Properties>
       <BindingProperties>
-        <BindingProperty name="text" source="Form" sourcePath="${controller.fit.confidence.sigma}" target="jTextField1" targetPath="text" updateStrategy="0" immediately="false">
+        <BindingProperty name="text" source="Form" sourcePath="${controller.fit.confidence.config.sigma}" target="jTextField1" targetPath="text" updateStrategy="0" immediately="false">
           <BindingParameter name="javax.swing.binding.ParameterKeys.TEXT_CHANGE_STRATEGY" value="javax.swing.binding.TextChangeStrategy.ON_TYPE"/>
         </BindingProperty>
       </BindingProperties>
@@ -89,6 +92,7 @@
             <Property name="columnModel" type="javax.swing.table.TableColumnModel" editor="org.netbeans.modules.form.editors2.TableColumnModelEditor">
               <TableColumnModel selectionModel="0"/>
             </Property>
+            <Property name="name" type="java.lang.String" value="confidenceTable" noResource="true"/>
             <Property name="tableHeader" type="javax.swing.table.JTableHeader" editor="org.netbeans.modules.form.editors2.JTableHeaderEditor">
               <TableHeader reorderingAllowed="true" resizingAllowed="true"/>
             </Property>

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/ConfidencePanel.form
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/ConfidencePanel.form
@@ -27,7 +27,7 @@
       </Properties>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="0" gridY="0" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="17" insetsLeft="12" insetsBottom="0" insetsRight="0" anchor="18" weightX="0.0" weightY="0.0"/>
+          <GridBagConstraints gridX="0" gridY="0" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="17" insetsLeft="12" insetsBottom="0" insetsRight="0" anchor="18" weightX="0.1" weightY="0.0"/>
         </Constraint>
       </Constraints>
     </Component>
@@ -42,7 +42,7 @@
       </BindingProperties>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="1" gridY="0" gridWidth="1" gridHeight="2" fill="2" ipadX="30" ipadY="0" insetsTop="12" insetsLeft="12" insetsBottom="0" insetsRight="0" anchor="18" weightX="0.0" weightY="0.0"/>
+          <GridBagConstraints gridX="1" gridY="0" gridWidth="1" gridHeight="2" fill="2" ipadX="30" ipadY="0" insetsTop="12" insetsLeft="12" insetsBottom="0" insetsRight="0" anchor="18" weightX="0.1" weightY="0.0"/>
         </Constraint>
       </Constraints>
     </Component>
@@ -60,20 +60,7 @@
       </BindingProperties>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="2" gridY="0" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="17" insetsLeft="12" insetsBottom="0" insetsRight="12" anchor="13" weightX="0.0" weightY="0.0"/>
-        </Constraint>
-      </Constraints>
-    </Component>
-    <Component class="javax.swing.JButton" name="jButton1">
-      <Properties>
-        <Property name="text" type="java.lang.String" value="Compute"/>
-      </Properties>
-      <Events>
-        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="doConfidence"/>
-      </Events>
-      <Constraints>
-        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="2" gridY="3" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="6" insetsLeft="35" insetsBottom="12" insetsRight="12" anchor="13" weightX="0.0" weightY="0.0"/>
+          <GridBagConstraints gridX="2" gridY="0" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="17" insetsLeft="10" insetsBottom="0" insetsRight="12" anchor="13" weightX="0.8" weightY="0.0"/>
         </Constraint>
       </Constraints>
     </Component>
@@ -107,6 +94,27 @@
               <Property name="name" type="java.lang.String" value="table"/>
             </BindingProperty>
           </BindingProperties>
+        </Component>
+      </SubComponents>
+    </Container>
+    <Container class="javax.swing.JPanel" name="jPanel1">
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+          <GridBagConstraints gridX="2" gridY="3" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="13" weightX="0.0" weightY="0.0"/>
+        </Constraint>
+      </Constraints>
+
+      <Layout class="org.netbeans.modules.form.compat2.layouts.DesignFlowLayout"/>
+      <SubComponents>
+        <Component class="org.jdesktop.swingx.JXBusyLabel" name="busyConfidence">
+        </Component>
+        <Component class="javax.swing.JButton" name="jButton1">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="Compute"/>
+          </Properties>
+          <Events>
+            <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="doConfidence"/>
+          </Events>
         </Component>
       </SubComponents>
     </Container>

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/ConfidencePanel.form
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/ConfidencePanel.form
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <Form version="1.5" maxVersion="1.9" type="org.netbeans.modules.form.forminfo.JPanelFormInfo">
+  <Properties>
+    <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+      <Dimension value="[287, 191]"/>
+    </Property>
+  </Properties>
   <AuxValues>
     <AuxValue name="FormSettings_autoResourcing" type="java.lang.Integer" value="0"/>
     <AuxValue name="FormSettings_autoSetComponentName" type="java.lang.Boolean" value="false"/>
@@ -13,49 +18,17 @@
     <AuxValue name="FormSettings_variablesModifier" type="java.lang.Integer" value="2"/>
   </AuxValues>
 
-  <Layout>
-    <DimensionLayout dim="0">
-      <Group type="103" groupAlignment="0" attributes="0">
-          <Group type="102" alignment="0" attributes="0">
-              <EmptySpace min="-2" max="-2" attributes="0"/>
-              <Group type="103" groupAlignment="1" attributes="0">
-                  <Component id="jButton1" min="-2" max="-2" attributes="0"/>
-                  <Component id="jScrollPane1" pref="0" max="32767" attributes="0"/>
-                  <Group type="102" attributes="0">
-                      <Component id="jLabel1" min="-2" max="-2" attributes="0"/>
-                      <EmptySpace min="-2" max="-2" attributes="0"/>
-                      <Component id="jTextField1" pref="40" max="32767" attributes="0"/>
-                      <EmptySpace min="-2" max="-2" attributes="0"/>
-                      <Component id="jLabel2" min="-2" max="-2" attributes="0"/>
-                  </Group>
-              </Group>
-              <EmptySpace min="-2" max="-2" attributes="0"/>
-          </Group>
-      </Group>
-    </DimensionLayout>
-    <DimensionLayout dim="1">
-      <Group type="103" groupAlignment="0" attributes="0">
-          <Group type="102" alignment="0" attributes="0">
-              <EmptySpace min="-2" max="-2" attributes="0"/>
-              <Group type="103" groupAlignment="3" attributes="0">
-                  <Component id="jLabel1" alignment="3" min="-2" max="-2" attributes="0"/>
-                  <Component id="jTextField1" alignment="3" min="-2" max="-2" attributes="0"/>
-                  <Component id="jLabel2" alignment="3" min="-2" max="-2" attributes="0"/>
-              </Group>
-              <EmptySpace min="-2" max="-2" attributes="0"/>
-              <Component id="jScrollPane1" pref="107" max="32767" attributes="0"/>
-              <EmptySpace min="-2" max="-2" attributes="0"/>
-              <Component id="jButton1" min="-2" max="-2" attributes="0"/>
-              <EmptySpace min="-2" max="-2" attributes="0"/>
-          </Group>
-      </Group>
-    </DimensionLayout>
-  </Layout>
+  <Layout class="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout"/>
   <SubComponents>
     <Component class="javax.swing.JLabel" name="jLabel1">
       <Properties>
         <Property name="text" type="java.lang.String" value="Confidence Interval: "/>
       </Properties>
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+          <GridBagConstraints gridX="0" gridY="0" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="17" insetsLeft="12" insetsBottom="0" insetsRight="0" anchor="18" weightX="0.0" weightY="0.0"/>
+        </Constraint>
+      </Constraints>
     </Component>
     <Component class="javax.swing.JTextField" name="jTextField1">
       <Properties>
@@ -66,11 +39,21 @@
           <BindingParameter name="javax.swing.binding.ParameterKeys.TEXT_CHANGE_STRATEGY" value="javax.swing.binding.TextChangeStrategy.ON_TYPE"/>
         </BindingProperty>
       </BindingProperties>
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+          <GridBagConstraints gridX="1" gridY="0" gridWidth="1" gridHeight="2" fill="2" ipadX="30" ipadY="0" insetsTop="12" insetsLeft="12" insetsBottom="0" insetsRight="0" anchor="18" weightX="0.0" weightY="0.0"/>
+        </Constraint>
+      </Constraints>
     </Component>
     <Component class="javax.swing.JLabel" name="jLabel2">
       <Properties>
         <Property name="text" type="java.lang.String" value="sigma - 89.04%"/>
       </Properties>
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+          <GridBagConstraints gridX="2" gridY="0" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="17" insetsLeft="12" insetsBottom="0" insetsRight="12" anchor="13" weightX="0.0" weightY="0.0"/>
+        </Constraint>
+      </Constraints>
     </Component>
     <Component class="javax.swing.JButton" name="jButton1">
       <Properties>
@@ -79,11 +62,21 @@
       <Events>
         <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="doConfidence"/>
       </Events>
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+          <GridBagConstraints gridX="2" gridY="3" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="6" insetsLeft="35" insetsBottom="12" insetsRight="12" anchor="13" weightX="0.0" weightY="0.0"/>
+        </Constraint>
+      </Constraints>
     </Component>
     <Container class="javax.swing.JScrollPane" name="jScrollPane1">
       <AuxValues>
         <AuxValue name="autoScrollPane" type="java.lang.Boolean" value="true"/>
       </AuxValues>
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+          <GridBagConstraints gridX="0" gridY="2" gridWidth="3" gridHeight="1" fill="1" ipadX="239" ipadY="79" insetsTop="6" insetsLeft="12" insetsBottom="0" insetsRight="12" anchor="18" weightX="1.0" weightY="1.0"/>
+        </Constraint>
+      </Constraints>
 
       <Layout class="org.netbeans.modules.form.compat2.layouts.support.JScrollPaneSupportLayout"/>
       <SubComponents>

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/ConfidencePanel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/ConfidencePanel.java
@@ -93,6 +93,7 @@ public class ConfidencePanel extends javax.swing.JPanel {
     @SuppressWarnings("unchecked")
     // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents
     private void initComponents() {
+        java.awt.GridBagConstraints gridBagConstraints;
         bindingGroup = new org.jdesktop.beansbinding.BindingGroup();
 
         jLabel1 = new javax.swing.JLabel();
@@ -102,14 +103,39 @@ public class ConfidencePanel extends javax.swing.JPanel {
         jScrollPane1 = new javax.swing.JScrollPane();
         jTable1 = new javax.swing.JTable();
 
+        setMinimumSize(new java.awt.Dimension(287, 191));
+        setLayout(new java.awt.GridBagLayout());
+
         jLabel1.setText("Confidence Interval: ");
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 0;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
+        gridBagConstraints.insets = new java.awt.Insets(17, 12, 0, 0);
+        add(jLabel1, gridBagConstraints);
 
         jTextField1.setName("sigma"); // NOI18N
 
         org.jdesktop.beansbinding.Binding binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${controller.fit.confidence.config.sigma}"), jTextField1, org.jdesktop.beansbinding.BeanProperty.create("text"));
         bindingGroup.addBinding(binding);
 
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 1;
+        gridBagConstraints.gridy = 0;
+        gridBagConstraints.gridheight = 2;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.ipadx = 30;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
+        gridBagConstraints.insets = new java.awt.Insets(12, 12, 0, 0);
+        add(jTextField1, gridBagConstraints);
+
         jLabel2.setText("sigma - 89.04%");
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 2;
+        gridBagConstraints.gridy = 0;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.EAST;
+        gridBagConstraints.insets = new java.awt.Insets(17, 12, 0, 12);
+        add(jLabel2, gridBagConstraints);
 
         jButton1.setText("Compute");
         jButton1.addActionListener(new java.awt.event.ActionListener() {
@@ -117,6 +143,12 @@ public class ConfidencePanel extends javax.swing.JPanel {
                 doConfidence(evt);
             }
         });
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 2;
+        gridBagConstraints.gridy = 3;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.EAST;
+        gridBagConstraints.insets = new java.awt.Insets(6, 35, 12, 12);
+        add(jButton1, gridBagConstraints);
 
         jTable1.setName("confidenceTable"); // NOI18N
 
@@ -127,37 +159,18 @@ public class ConfidencePanel extends javax.swing.JPanel {
         jTableBinding.bind();
         jScrollPane1.setViewportView(jTable1);
 
-        javax.swing.GroupLayout layout = new javax.swing.GroupLayout(this);
-        this.setLayout(layout);
-        layout.setHorizontalGroup(
-            layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(layout.createSequentialGroup()
-                .addContainerGap()
-                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
-                    .addComponent(jButton1)
-                    .addComponent(jScrollPane1, javax.swing.GroupLayout.PREFERRED_SIZE, 0, Short.MAX_VALUE)
-                    .addGroup(layout.createSequentialGroup()
-                        .addComponent(jLabel1)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(jTextField1, javax.swing.GroupLayout.DEFAULT_SIZE, 40, Short.MAX_VALUE)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(jLabel2)))
-                .addContainerGap())
-        );
-        layout.setVerticalGroup(
-            layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(layout.createSequentialGroup()
-                .addContainerGap()
-                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                    .addComponent(jLabel1)
-                    .addComponent(jTextField1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(jLabel2))
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(jScrollPane1, javax.swing.GroupLayout.DEFAULT_SIZE, 107, Short.MAX_VALUE)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(jButton1)
-                .addContainerGap())
-        );
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 2;
+        gridBagConstraints.gridwidth = 3;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
+        gridBagConstraints.ipadx = 239;
+        gridBagConstraints.ipady = 79;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
+        gridBagConstraints.weightx = 1.0;
+        gridBagConstraints.weighty = 1.0;
+        gridBagConstraints.insets = new java.awt.Insets(6, 12, 0, 12);
+        add(jScrollPane1, gridBagConstraints);
 
         bindingGroup.bind();
     }// </editor-fold>//GEN-END:initComponents

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/ConfidencePanel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/ConfidencePanel.java
@@ -104,7 +104,9 @@ public class ConfidencePanel extends javax.swing.JPanel {
 
         jLabel1.setText("Confidence Interval: ");
 
-        org.jdesktop.beansbinding.Binding binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${controller.fit.confidence.sigma}"), jTextField1, org.jdesktop.beansbinding.BeanProperty.create("text"));
+        jTextField1.setName("sigma"); // NOI18N
+
+        org.jdesktop.beansbinding.Binding binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${controller.fit.confidence.config.sigma}"), jTextField1, org.jdesktop.beansbinding.BeanProperty.create("text"));
         bindingGroup.addBinding(binding);
 
         jLabel2.setText("sigma - 89.04%");
@@ -115,6 +117,8 @@ public class ConfidencePanel extends javax.swing.JPanel {
                 doConfidence(evt);
             }
         });
+
+        jTable1.setName("confidenceTable"); // NOI18N
 
         org.jdesktop.beansbinding.ELProperty eLProperty = org.jdesktop.beansbinding.ELProperty.create("${confidenceResults}");
         org.jdesktop.swingbinding.JTableBinding jTableBinding = org.jdesktop.swingbinding.SwingBindings.createJTableBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ, this, eLProperty, jTable1, "table");

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/ConfidencePanel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/ConfidencePanel.java
@@ -23,6 +23,7 @@ import org.jdesktop.swingbinding.JTableBinding;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jdesktop.beansbinding.Converter;
 
 
 public class ConfidencePanel extends javax.swing.JPanel {
@@ -98,7 +99,7 @@ public class ConfidencePanel extends javax.swing.JPanel {
 
         jLabel1 = new javax.swing.JLabel();
         jTextField1 = new javax.swing.JTextField();
-        jLabel2 = new javax.swing.JLabel();
+        sigmaText = new javax.swing.JLabel();
         jButton1 = new javax.swing.JButton();
         jScrollPane1 = new javax.swing.JScrollPane();
         jTable1 = new javax.swing.JTable();
@@ -129,13 +130,19 @@ public class ConfidencePanel extends javax.swing.JPanel {
         gridBagConstraints.insets = new java.awt.Insets(12, 12, 0, 0);
         add(jTextField1, gridBagConstraints);
 
-        jLabel2.setText("sigma - 89.04%");
+        sigmaText.setText("sigma - 90.00%");
+        sigmaText.setName("sigmaPercent"); // NOI18N
+
+        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${confidenceResults.percent}"), sigmaText, org.jdesktop.beansbinding.BeanProperty.create("text"));
+        binding.setConverter(new SigmaConverter());
+        bindingGroup.addBinding(binding);
+
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 2;
         gridBagConstraints.gridy = 0;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.EAST;
         gridBagConstraints.insets = new java.awt.Insets(17, 12, 0, 12);
-        add(jLabel2, gridBagConstraints);
+        add(sigmaText, gridBagConstraints);
 
         jButton1.setText("Compute");
         jButton1.addActionListener(new java.awt.event.ActionListener() {
@@ -194,11 +201,25 @@ public class ConfidencePanel extends javax.swing.JPanel {
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JButton jButton1;
     private javax.swing.JLabel jLabel1;
-    private javax.swing.JLabel jLabel2;
     private javax.swing.JScrollPane jScrollPane1;
     private javax.swing.JTable jTable1;
     private javax.swing.JTextField jTextField1;
+    private javax.swing.JLabel sigmaText;
     private org.jdesktop.beansbinding.BindingGroup bindingGroup;
     // End of variables declaration//GEN-END:variables
+
+    private class SigmaConverter extends Converter {
+
+        @Override
+        public Object convertForward(Object s) {
+            Double sigma = (Double) s;
+            return String.format("sigma - %2.2f%%", sigma);
+        }
+
+        @Override
+        public Object convertReverse(Object t) {
+            throw new UnsupportedOperationException("Not supported yet."); // Never called
+        }
+    }
 
 }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FitResultsPanel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FitResultsPanel.java
@@ -1,6 +1,7 @@
 package cfa.vo.iris.fitting;
 
 import cfa.vo.iris.gui.widgets.AbstractGridPanel;
+import java.awt.Dimension;
 
 import javax.swing.*;
 
@@ -34,6 +35,7 @@ public class FitResultsPanel extends AbstractGridPanel {
         numPoints = addTextField("Number of Points");
         dof = addTextField("Degrees of Freedom");
         this.setEnabled(false);
+        setMinimumSize(new Dimension(250, 50));
     }
 
     @Override

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.form
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.form
@@ -171,7 +171,7 @@
                                   </Properties>
                                   <Constraints>
                                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-                                      <GridBagConstraints gridX="0" gridY="0" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="18" weightX="1.0" weightY="0.0"/>
+                                      <GridBagConstraints gridX="0" gridY="0" gridWidth="2" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="18" weightX="1.0" weightY="0.0"/>
                                     </Constraint>
                                   </Constraints>
                                 </Component>
@@ -187,7 +187,7 @@
                                   </BindingProperties>
                                   <Constraints>
                                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-                                      <GridBagConstraints gridX="0" gridY="1" gridWidth="1" gridHeight="1" fill="2" ipadX="82" ipadY="0" insetsTop="6" insetsLeft="0" insetsBottom="6" insetsRight="0" anchor="18" weightX="1.0" weightY="0.0"/>
+                                      <GridBagConstraints gridX="0" gridY="1" gridWidth="2" gridHeight="1" fill="2" ipadX="82" ipadY="0" insetsTop="6" insetsLeft="0" insetsBottom="6" insetsRight="0" anchor="18" weightX="1.0" weightY="0.0"/>
                                     </Constraint>
                                   </Constraints>
                                 </Component>
@@ -197,7 +197,7 @@
                                   </Properties>
                                   <Constraints>
                                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-                                      <GridBagConstraints gridX="0" gridY="2" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="18" weightX="1.0" weightY="0.0"/>
+                                      <GridBagConstraints gridX="0" gridY="2" gridWidth="2" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="18" weightX="1.0" weightY="0.0"/>
                                     </Constraint>
                                   </Constraints>
                                 </Component>
@@ -213,7 +213,7 @@
                                   </BindingProperties>
                                   <Constraints>
                                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-                                      <GridBagConstraints gridX="0" gridY="3" gridWidth="1" gridHeight="1" fill="2" ipadX="82" ipadY="0" insetsTop="6" insetsLeft="0" insetsBottom="6" insetsRight="0" anchor="17" weightX="1.0" weightY="0.0"/>
+                                      <GridBagConstraints gridX="0" gridY="3" gridWidth="2" gridHeight="1" fill="2" ipadX="82" ipadY="0" insetsTop="6" insetsLeft="0" insetsBottom="6" insetsRight="0" anchor="17" weightX="1.0" weightY="0.0"/>
                                     </Constraint>
                                   </Constraints>
                                 </Component>
@@ -226,7 +226,14 @@
                                   </Events>
                                   <Constraints>
                                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-                                      <GridBagConstraints gridX="0" gridY="4" gridWidth="1" gridHeight="1" fill="2" ipadX="64" ipadY="0" insetsTop="18" insetsLeft="0" insetsBottom="18" insetsRight="0" anchor="17" weightX="1.0" weightY="0.0"/>
+                                      <GridBagConstraints gridX="1" gridY="4" gridWidth="1" gridHeight="1" fill="2" ipadX="64" ipadY="0" insetsTop="18" insetsLeft="0" insetsBottom="18" insetsRight="0" anchor="17" weightX="1.0" weightY="0.0"/>
+                                    </Constraint>
+                                  </Constraints>
+                                </Component>
+                                <Component class="org.jdesktop.swingx.JXBusyLabel" name="busyFit">
+                                  <Constraints>
+                                    <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+                                      <GridBagConstraints gridX="0" gridY="4" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="0.0" weightY="0.0"/>
                                     </Constraint>
                                   </Constraints>
                                 </Component>

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.form
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
-<Form version="1.7" maxVersion="1.9" type="org.netbeans.modules.form.forminfo.JInternalFrameFormInfo">
+<Form version="1.8" maxVersion="1.9" type="org.netbeans.modules.form.forminfo.JInternalFrameFormInfo">
   <NonVisualComponents>
     <Menu class="javax.swing.JMenuBar" name="menuBar">
       <SubComponents>
@@ -38,7 +38,10 @@
     <Property name="title" type="java.lang.String" value="Fitting Tool"/>
     <Property name="autoscrolls" type="boolean" value="true"/>
     <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-      <Dimension value="[700, 500]"/>
+      <Dimension value="[900, 600]"/>
+    </Property>
+    <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+      <Dimension value="[900, 600]"/>
     </Property>
   </Properties>
   <SyntheticProperties>
@@ -55,7 +58,7 @@
     <AuxValue name="FormSettings_listenerGenerationStyle" type="java.lang.Integer" value="0"/>
     <AuxValue name="FormSettings_variablesLocal" type="java.lang.Boolean" value="false"/>
     <AuxValue name="FormSettings_variablesModifier" type="java.lang.Integer" value="2"/>
-    <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,1,-8,0,0,3,80"/>
+    <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,2,115,0,0,4,54"/>
   </AuxValues>
 
   <Layout class="org.netbeans.modules.form.compat2.layouts.DesignGridLayout">
@@ -65,33 +68,7 @@
   <SubComponents>
     <Container class="javax.swing.JPanel" name="jPanel1">
 
-      <Layout>
-        <DimensionLayout dim="0">
-          <Group type="103" groupAlignment="0" attributes="0">
-              <Group type="102" attributes="0">
-                  <EmptySpace max="-2" attributes="0"/>
-                  <Component id="currentSedLabel" min="-2" max="-2" attributes="0"/>
-                  <EmptySpace max="-2" attributes="0"/>
-                  <Component id="currentSedField" min="-2" pref="598" max="-2" attributes="0"/>
-                  <EmptySpace max="32767" attributes="0"/>
-              </Group>
-              <Component id="jSplitPane1" alignment="0" max="32767" attributes="0"/>
-          </Group>
-        </DimensionLayout>
-        <DimensionLayout dim="1">
-          <Group type="103" groupAlignment="0" attributes="0">
-              <Group type="102" attributes="0">
-                  <EmptySpace max="-2" attributes="0"/>
-                  <Group type="103" groupAlignment="3" attributes="0">
-                      <Component id="currentSedLabel" alignment="3" min="-2" max="-2" attributes="0"/>
-                      <Component id="currentSedField" alignment="3" min="-2" max="-2" attributes="0"/>
-                  </Group>
-                  <EmptySpace max="-2" attributes="0"/>
-                  <Component id="jSplitPane1" max="32767" attributes="0"/>
-              </Group>
-          </Group>
-        </DimensionLayout>
-      </Layout>
+      <Layout class="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout"/>
       <SubComponents>
         <Container class="javax.swing.JSplitPane" name="jSplitPane1">
           <Properties>
@@ -100,8 +77,12 @@
                 <TitledBorder title="Fit Configuration"/>
               </Border>
             </Property>
-            <Property name="dividerLocation" type="int" value="250"/>
           </Properties>
+          <Constraints>
+            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+              <GridBagConstraints gridX="0" gridY="2" gridWidth="3" gridHeight="1" fill="1" ipadX="312" ipadY="39" insetsTop="6" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="18" weightX="1.0" weightY="0.9"/>
+            </Constraint>
+          </Constraints>
 
           <Layout class="org.netbeans.modules.form.compat2.layouts.support.JSplitPaneSupportLayout"/>
           <SubComponents>
@@ -120,13 +101,14 @@
                 </DimensionLayout>
                 <DimensionLayout dim="1">
                   <Group type="103" groupAlignment="0" attributes="0">
-                      <Component id="jSplitPane4" alignment="0" pref="391" max="32767" attributes="0"/>
+                      <Component id="jSplitPane4" alignment="0" max="32767" attributes="0"/>
                   </Group>
                 </DimensionLayout>
               </Layout>
               <SubComponents>
                 <Container class="javax.swing.JSplitPane" name="jSplitPane4">
                   <Properties>
+                    <Property name="dividerLocation" type="int" value="300"/>
                     <Property name="orientation" type="int" value="0"/>
                   </Properties>
 
@@ -149,12 +131,12 @@
                       <Layout>
                         <DimensionLayout dim="0">
                           <Group type="103" groupAlignment="0" attributes="0">
-                              <Component id="jSplitPane3" alignment="0" max="32767" attributes="0"/>
+                              <Component id="jSplitPane3" alignment="0" pref="798" max="32767" attributes="0"/>
                           </Group>
                         </DimensionLayout>
                         <DimensionLayout dim="1">
                           <Group type="103" groupAlignment="0" attributes="0">
-                              <Component id="jSplitPane3" alignment="0" pref="193" max="32767" attributes="0"/>
+                              <Component id="jSplitPane3" alignment="0" pref="296" max="32767" attributes="0"/>
                           </Group>
                         </DimensionLayout>
                       </Layout>
@@ -167,56 +149,31 @@
                           <Layout class="org.netbeans.modules.form.compat2.layouts.support.JSplitPaneSupportLayout"/>
                           <SubComponents>
                             <Container class="javax.swing.JPanel" name="jPanel5">
+                              <Properties>
+                                <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+                                  <Dimension value="[180, 193]"/>
+                                </Property>
+                                <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+                                  <Dimension value="[180, 193]"/>
+                                </Property>
+                              </Properties>
                               <Constraints>
                                 <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.support.JSplitPaneSupportLayout" value="org.netbeans.modules.form.compat2.layouts.support.JSplitPaneSupportLayout$JSplitPaneConstraintsDescription">
                                   <JSplitPaneConstraints position="right"/>
                                 </Constraint>
                               </Constraints>
 
-                              <Layout>
-                                <DimensionLayout dim="0">
-                                  <Group type="103" groupAlignment="0" attributes="0">
-                                      <Group type="102" alignment="0" attributes="0">
-                                          <EmptySpace max="-2" attributes="0"/>
-                                          <Group type="103" groupAlignment="0" attributes="0">
-                                              <Component id="optimizationCombo" max="32767" attributes="0"/>
-                                              <Group type="102" attributes="0">
-                                                  <Group type="103" groupAlignment="0" attributes="0">
-                                                      <Component id="jLabel1" alignment="0" min="-2" max="-2" attributes="0"/>
-                                                      <Component id="jLabel2" min="-2" max="-2" attributes="0"/>
-                                                      <Component id="fitButton" alignment="0" min="-2" pref="89" max="-2" attributes="0"/>
-                                                  </Group>
-                                                  <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
-                                              </Group>
-                                              <Component id="statisticCombo" alignment="0" max="32767" attributes="0"/>
-                                          </Group>
-                                          <EmptySpace max="-2" attributes="0"/>
-                                      </Group>
-                                  </Group>
-                                </DimensionLayout>
-                                <DimensionLayout dim="1">
-                                  <Group type="103" groupAlignment="0" attributes="0">
-                                      <Group type="102" alignment="0" attributes="0">
-                                          <EmptySpace max="-2" attributes="0"/>
-                                          <Component id="jLabel1" min="-2" max="-2" attributes="0"/>
-                                          <EmptySpace max="-2" attributes="0"/>
-                                          <Component id="optimizationCombo" min="-2" max="-2" attributes="0"/>
-                                          <EmptySpace max="-2" attributes="0"/>
-                                          <Component id="jLabel2" min="-2" max="-2" attributes="0"/>
-                                          <EmptySpace max="-2" attributes="0"/>
-                                          <Component id="statisticCombo" min="-2" max="-2" attributes="0"/>
-                                          <EmptySpace type="separate" max="-2" attributes="0"/>
-                                          <Component id="fitButton" min="-2" max="-2" attributes="0"/>
-                                          <EmptySpace pref="58" max="32767" attributes="0"/>
-                                      </Group>
-                                  </Group>
-                                </DimensionLayout>
-                              </Layout>
+                              <Layout class="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout"/>
                               <SubComponents>
                                 <Component class="javax.swing.JLabel" name="jLabel1">
                                   <Properties>
                                     <Property name="text" type="java.lang.String" value="Optimization Method:"/>
                                   </Properties>
+                                  <Constraints>
+                                    <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+                                      <GridBagConstraints gridX="0" gridY="0" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="18" weightX="1.0" weightY="0.0"/>
+                                    </Constraint>
+                                  </Constraints>
                                 </Component>
                                 <Component class="javax.swing.JComboBox" name="optimizationCombo">
                                   <Properties>
@@ -228,11 +185,21 @@
                                   <BindingProperties>
                                     <BindingProperty name="selectedItem" source="Form" sourcePath="${sedModel.sed.fit.method}" target="optimizationCombo" targetPath="selectedItem" updateStrategy="0" immediately="false"/>
                                   </BindingProperties>
+                                  <Constraints>
+                                    <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+                                      <GridBagConstraints gridX="0" gridY="1" gridWidth="1" gridHeight="1" fill="2" ipadX="82" ipadY="0" insetsTop="6" insetsLeft="0" insetsBottom="6" insetsRight="0" anchor="18" weightX="1.0" weightY="0.0"/>
+                                    </Constraint>
+                                  </Constraints>
                                 </Component>
                                 <Component class="javax.swing.JLabel" name="jLabel2">
                                   <Properties>
                                     <Property name="text" type="java.lang.String" value="Statistic:"/>
                                   </Properties>
+                                  <Constraints>
+                                    <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+                                      <GridBagConstraints gridX="0" gridY="2" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="18" weightX="1.0" weightY="0.0"/>
+                                    </Constraint>
+                                  </Constraints>
                                 </Component>
                                 <Component class="javax.swing.JComboBox" name="statisticCombo">
                                   <Properties>
@@ -244,6 +211,11 @@
                                   <BindingProperties>
                                     <BindingProperty name="selectedItem" source="Form" sourcePath="${sedModel.sed.fit.stat}" target="statisticCombo" targetPath="selectedItem" updateStrategy="0" immediately="false"/>
                                   </BindingProperties>
+                                  <Constraints>
+                                    <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+                                      <GridBagConstraints gridX="0" gridY="3" gridWidth="1" gridHeight="1" fill="2" ipadX="82" ipadY="0" insetsTop="6" insetsLeft="0" insetsBottom="6" insetsRight="0" anchor="17" weightX="1.0" weightY="0.0"/>
+                                    </Constraint>
+                                  </Constraints>
                                 </Component>
                                 <Component class="javax.swing.JButton" name="fitButton">
                                   <Properties>
@@ -252,10 +224,20 @@
                                   <Events>
                                     <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="doFit"/>
                                   </Events>
+                                  <Constraints>
+                                    <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+                                      <GridBagConstraints gridX="0" gridY="4" gridWidth="1" gridHeight="1" fill="2" ipadX="64" ipadY="0" insetsTop="18" insetsLeft="0" insetsBottom="18" insetsRight="0" anchor="17" weightX="1.0" weightY="0.0"/>
+                                    </Constraint>
+                                  </Constraints>
                                 </Component>
                               </SubComponents>
                             </Container>
                             <Component class="cfa.vo.iris.gui.widgets.ModelViewerPanel" name="modelViewerPanel">
+                              <Properties>
+                                <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+                                  <Dimension value="[300, 217]"/>
+                                </Property>
+                              </Properties>
                               <Constraints>
                                 <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.support.JSplitPaneSupportLayout" value="org.netbeans.modules.form.compat2.layouts.support.JSplitPaneSupportLayout$JSplitPaneConstraintsDescription">
                                   <JSplitPaneConstraints position="left"/>
@@ -273,7 +255,7 @@
                             <EtchetBorder/>
                           </Border>
                         </Property>
-                        <Property name="dividerLocation" type="int" value="325"/>
+                        <Property name="dividerLocation" type="int" value="320"/>
                       </Properties>
                       <Constraints>
                         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.support.JSplitPaneSupportLayout" value="org.netbeans.modules.form.compat2.layouts.support.JSplitPaneSupportLayout$JSplitPaneConstraintsDescription">
@@ -298,17 +280,25 @@
                           <Layout>
                             <DimensionLayout dim="0">
                               <Group type="103" groupAlignment="0" attributes="0">
-                                  <Component id="resultsPanel" alignment="0" pref="303" max="32767" attributes="0"/>
+                                  <Component id="resultsPanel" alignment="0" pref="318" max="32767" attributes="0"/>
                               </Group>
                             </DimensionLayout>
                             <DimensionLayout dim="1">
                               <Group type="103" groupAlignment="0" attributes="0">
-                                  <Component id="resultsPanel" alignment="0" pref="185" max="32767" attributes="0"/>
+                                  <Component id="resultsPanel" alignment="0" max="32767" attributes="0"/>
                               </Group>
                             </DimensionLayout>
                           </Layout>
                           <SubComponents>
                             <Component class="cfa.vo.iris.fitting.FitResultsPanel" name="resultsPanel">
+                              <Properties>
+                                <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+                                  <Dimension value="[100, 180]"/>
+                                </Property>
+                                <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+                                  <Dimension value="[100, 180]"/>
+                                </Property>
+                              </Properties>
                             </Component>
                           </SubComponents>
                         </Container>
@@ -322,12 +312,12 @@
                           <Layout>
                             <DimensionLayout dim="0">
                               <Group type="103" groupAlignment="0" attributes="0">
-                                  <Component id="confidencePanel" alignment="0" pref="290" max="32767" attributes="0"/>
+                                  <Component id="confidencePanel" alignment="0" pref="474" max="32767" attributes="0"/>
                               </Group>
                             </DimensionLayout>
                             <DimensionLayout dim="1">
                               <Group type="103" groupAlignment="0" attributes="0">
-                                  <Component id="confidencePanel" alignment="1" max="32767" attributes="0"/>
+                                  <Component id="confidencePanel" alignment="1" pref="215" max="32767" attributes="0"/>
                               </Group>
                             </DimensionLayout>
                           </Layout>
@@ -360,7 +350,7 @@
                 </DimensionLayout>
                 <DimensionLayout dim="1">
                   <Group type="103" groupAlignment="0" attributes="0">
-                      <Component id="availableComponents" alignment="0" max="32767" attributes="0"/>
+                      <Component id="availableComponents" alignment="0" pref="525" max="32767" attributes="0"/>
                   </Group>
                 </DimensionLayout>
               </Layout>
@@ -374,38 +364,17 @@
                     </Property>
                   </Properties>
 
-                  <Layout>
-                    <DimensionLayout dim="0">
-                      <Group type="103" groupAlignment="0" attributes="0">
-                          <Group type="102" attributes="0">
-                              <Component id="searchField" max="32767" attributes="0"/>
-                              <EmptySpace min="-2" max="-2" attributes="0"/>
-                              <Component id="searchButton" min="-2" pref="93" max="-2" attributes="0"/>
-                          </Group>
-                          <Component id="jScrollPane2" alignment="0" pref="219" max="32767" attributes="0"/>
-                          <Component id="jScrollPane3" alignment="0" max="32767" attributes="0"/>
-                      </Group>
-                    </DimensionLayout>
-                    <DimensionLayout dim="1">
-                      <Group type="103" groupAlignment="0" attributes="0">
-                          <Group type="102" alignment="0" attributes="0">
-                              <Component id="jScrollPane3" pref="242" max="32767" attributes="0"/>
-                              <EmptySpace max="-2" attributes="0"/>
-                              <Component id="jScrollPane2" min="-2" pref="92" max="-2" attributes="0"/>
-                              <EmptySpace max="-2" attributes="0"/>
-                              <Group type="103" groupAlignment="3" attributes="0">
-                                  <Component id="searchButton" alignment="3" min="-2" max="-2" attributes="0"/>
-                                  <Component id="searchField" alignment="3" min="-2" max="-2" attributes="0"/>
-                              </Group>
-                          </Group>
-                      </Group>
-                    </DimensionLayout>
-                  </Layout>
+                  <Layout class="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout"/>
                   <SubComponents>
                     <Container class="javax.swing.JScrollPane" name="jScrollPane2">
                       <AuxValues>
                         <AuxValue name="autoScrollPane" type="java.lang.Boolean" value="true"/>
                       </AuxValues>
+                      <Constraints>
+                        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+                          <GridBagConstraints gridX="0" gridY="1" gridWidth="2" gridHeight="1" fill="1" ipadX="208" ipadY="68" insetsTop="6" insetsLeft="6" insetsBottom="0" insetsRight="6" anchor="18" weightX="1.0" weightY="1.0"/>
+                        </Constraint>
+                      </Constraints>
 
                       <Layout class="org.netbeans.modules.form.compat2.layouts.support.JScrollPaneSupportLayout"/>
                       <SubComponents>
@@ -433,16 +402,31 @@
                       <Events>
                         <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="searchButtonActionPerformed"/>
                       </Events>
+                      <Constraints>
+                        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+                          <GridBagConstraints gridX="1" gridY="2" gridWidth="1" gridHeight="2" fill="0" ipadX="43" ipadY="0" insetsTop="6" insetsLeft="6" insetsBottom="6" insetsRight="6" anchor="13" weightX="0.0" weightY="0.0"/>
+                        </Constraint>
+                      </Constraints>
                     </Component>
                     <Component class="javax.swing.JTextField" name="searchField">
                       <Properties>
                         <Property name="name" type="java.lang.String" value="searchField" noResource="true"/>
                       </Properties>
+                      <Constraints>
+                        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+                          <GridBagConstraints gridX="0" gridY="2" gridWidth="1" gridHeight="1" fill="2" ipadX="123" ipadY="0" insetsTop="7" insetsLeft="6" insetsBottom="0" insetsRight="0" anchor="18" weightX="1.0" weightY="0.0"/>
+                        </Constraint>
+                      </Constraints>
                     </Component>
                     <Container class="javax.swing.JScrollPane" name="jScrollPane3">
                       <AuxValues>
                         <AuxValue name="autoScrollPane" type="java.lang.Boolean" value="true"/>
                       </AuxValues>
+                      <Constraints>
+                        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+                          <GridBagConstraints gridX="0" gridY="0" gridWidth="2" gridHeight="1" fill="1" ipadX="208" ipadY="288" insetsTop="15" insetsLeft="6" insetsBottom="0" insetsRight="6" anchor="18" weightX="1.0" weightY="1.0"/>
+                        </Constraint>
+                      </Constraints>
 
                       <Layout class="org.netbeans.modules.form.compat2.layouts.support.JScrollPaneSupportLayout"/>
                       <SubComponents>
@@ -469,6 +453,11 @@
           <Properties>
             <Property name="text" type="java.lang.String" value="Current Sed: "/>
           </Properties>
+          <Constraints>
+            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+              <GridBagConstraints gridX="0" gridY="0" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="17" insetsLeft="12" insetsBottom="0" insetsRight="0" anchor="18" weightX="0.1" weightY="0.1"/>
+            </Constraint>
+          </Constraints>
         </Component>
         <Component class="javax.swing.JTextField" name="currentSedField">
           <Properties>
@@ -481,6 +470,11 @@
               <BindingParameter name="javax.swing.binding.ParameterKeys.TEXT_CHANGE_STRATEGY" value="javax.swing.binding.TextChangeStrategy.ON_TYPE"/>
             </BindingProperty>
           </BindingProperties>
+          <Constraints>
+            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+              <GridBagConstraints gridX="1" gridY="0" gridWidth="2" gridHeight="2" fill="2" ipadX="588" ipadY="0" insetsTop="12" insetsLeft="12" insetsBottom="0" insetsRight="2" anchor="18" weightX="0.9" weightY="0.1"/>
+            </Constraint>
+          </Constraints>
         </Component>
       </SubComponents>
     </Container>

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.java
@@ -121,6 +121,7 @@ public class FittingMainView extends JInternalFrame implements SedListener {
     @SuppressWarnings("unchecked")
     // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents
     private void initComponents() {
+        java.awt.GridBagConstraints gridBagConstraints;
         bindingGroup = new org.jdesktop.beansbinding.BindingGroup();
 
         jPanel1 = new javax.swing.JPanel();
@@ -164,19 +165,33 @@ public class FittingMainView extends JInternalFrame implements SedListener {
         setResizable(true);
         setTitle("Fitting Tool");
         setAutoscrolls(true);
-        setMinimumSize(new java.awt.Dimension(700, 500));
+        setMinimumSize(new java.awt.Dimension(900, 600));
+        setPreferredSize(new java.awt.Dimension(900, 600));
         getContentPane().setLayout(new java.awt.GridLayout(1, 1));
 
-        jSplitPane1.setBorder(javax.swing.BorderFactory.createTitledBorder("Fit Configuration"));
-        jSplitPane1.setDividerLocation(250);
+        jPanel1.setLayout(new java.awt.GridBagLayout());
 
+        jSplitPane1.setBorder(javax.swing.BorderFactory.createTitledBorder("Fit Configuration"));
+
+        jSplitPane4.setDividerLocation(300);
         jSplitPane4.setOrientation(javax.swing.JSplitPane.VERTICAL_SPLIT);
 
         modelPanel.setBorder(javax.swing.BorderFactory.createEtchedBorder());
 
         jSplitPane3.setDividerLocation(450);
 
+        jPanel5.setMinimumSize(new java.awt.Dimension(180, 193));
+        jPanel5.setPreferredSize(new java.awt.Dimension(180, 193));
+        jPanel5.setLayout(new java.awt.GridBagLayout());
+
         jLabel1.setText("Optimization Method:");
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 0;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
+        gridBagConstraints.weightx = 1.0;
+        jPanel5.add(jLabel1, gridBagConstraints);
 
         optimizationCombo.setModel(new DefaultComboBoxModel<>(OptimizationMethod.values()));
         optimizationCombo.setName("optimizationCombo"); // NOI18N
@@ -184,7 +199,24 @@ public class FittingMainView extends JInternalFrame implements SedListener {
         org.jdesktop.beansbinding.Binding binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${sedModel.sed.fit.method}"), optimizationCombo, org.jdesktop.beansbinding.BeanProperty.create("selectedItem"));
         bindingGroup.addBinding(binding);
 
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 1;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.ipadx = 82;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
+        gridBagConstraints.weightx = 1.0;
+        gridBagConstraints.insets = new java.awt.Insets(6, 0, 6, 0);
+        jPanel5.add(optimizationCombo, gridBagConstraints);
+
         jLabel2.setText("Statistic:");
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 2;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
+        gridBagConstraints.weightx = 1.0;
+        jPanel5.add(jLabel2, gridBagConstraints);
 
         statisticCombo.setModel(new DefaultComboBoxModel<>(Statistic.values()));
         statisticCombo.setName("statisticCombo"); // NOI18N
@@ -192,76 +224,67 @@ public class FittingMainView extends JInternalFrame implements SedListener {
         binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${sedModel.sed.fit.stat}"), statisticCombo, org.jdesktop.beansbinding.BeanProperty.create("selectedItem"));
         bindingGroup.addBinding(binding);
 
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 3;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.ipadx = 82;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
+        gridBagConstraints.weightx = 1.0;
+        gridBagConstraints.insets = new java.awt.Insets(6, 0, 6, 0);
+        jPanel5.add(statisticCombo, gridBagConstraints);
+
         fitButton.setText("Fit");
         fitButton.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 doFit(evt);
             }
         });
-
-        javax.swing.GroupLayout jPanel5Layout = new javax.swing.GroupLayout(jPanel5);
-        jPanel5.setLayout(jPanel5Layout);
-        jPanel5Layout.setHorizontalGroup(
-            jPanel5Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(jPanel5Layout.createSequentialGroup()
-                .addContainerGap()
-                .addGroup(jPanel5Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(optimizationCombo, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                    .addGroup(jPanel5Layout.createSequentialGroup()
-                        .addGroup(jPanel5Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                            .addComponent(jLabel1)
-                            .addComponent(jLabel2)
-                            .addComponent(fitButton, javax.swing.GroupLayout.PREFERRED_SIZE, 89, javax.swing.GroupLayout.PREFERRED_SIZE))
-                        .addGap(0, 0, Short.MAX_VALUE))
-                    .addComponent(statisticCombo, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
-                .addContainerGap())
-        );
-        jPanel5Layout.setVerticalGroup(
-            jPanel5Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(jPanel5Layout.createSequentialGroup()
-                .addContainerGap()
-                .addComponent(jLabel1)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(optimizationCombo, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(jLabel2)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(statisticCombo, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addGap(18, 18, 18)
-                .addComponent(fitButton)
-                .addContainerGap(58, Short.MAX_VALUE))
-        );
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 4;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.ipadx = 64;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
+        gridBagConstraints.weightx = 1.0;
+        gridBagConstraints.insets = new java.awt.Insets(18, 0, 18, 0);
+        jPanel5.add(fitButton, gridBagConstraints);
 
         jSplitPane3.setRightComponent(jPanel5);
+
+        modelViewerPanel.setMinimumSize(new java.awt.Dimension(300, 217));
         jSplitPane3.setLeftComponent(modelViewerPanel);
 
         javax.swing.GroupLayout modelPanelLayout = new javax.swing.GroupLayout(modelPanel);
         modelPanel.setLayout(modelPanelLayout);
         modelPanelLayout.setHorizontalGroup(
             modelPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addComponent(jSplitPane3)
+            .addComponent(jSplitPane3, javax.swing.GroupLayout.DEFAULT_SIZE, 798, Short.MAX_VALUE)
         );
         modelPanelLayout.setVerticalGroup(
             modelPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addComponent(jSplitPane3, javax.swing.GroupLayout.PREFERRED_SIZE, 193, Short.MAX_VALUE)
+            .addComponent(jSplitPane3, javax.swing.GroupLayout.DEFAULT_SIZE, 296, Short.MAX_VALUE)
         );
 
         jSplitPane4.setLeftComponent(modelPanel);
 
         jSplitPane2.setBorder(javax.swing.BorderFactory.createEtchedBorder());
-        jSplitPane2.setDividerLocation(325);
+        jSplitPane2.setDividerLocation(320);
 
         resultsContainer.setBorder(null);
+
+        resultsPanel.setMinimumSize(new java.awt.Dimension(100, 180));
+        resultsPanel.setPreferredSize(new java.awt.Dimension(100, 180));
 
         javax.swing.GroupLayout resultsContainerLayout = new javax.swing.GroupLayout(resultsContainer);
         resultsContainer.setLayout(resultsContainerLayout);
         resultsContainerLayout.setHorizontalGroup(
             resultsContainerLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addComponent(resultsPanel, javax.swing.GroupLayout.DEFAULT_SIZE, 303, Short.MAX_VALUE)
+            .addComponent(resultsPanel, javax.swing.GroupLayout.DEFAULT_SIZE, 318, Short.MAX_VALUE)
         );
         resultsContainerLayout.setVerticalGroup(
             resultsContainerLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addComponent(resultsPanel, javax.swing.GroupLayout.PREFERRED_SIZE, 185, Short.MAX_VALUE)
+            .addComponent(resultsPanel, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
         );
 
         jSplitPane2.setLeftComponent(resultsContainer);
@@ -270,11 +293,11 @@ public class FittingMainView extends JInternalFrame implements SedListener {
         confidenceContainer.setLayout(confidenceContainerLayout);
         confidenceContainerLayout.setHorizontalGroup(
             confidenceContainerLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addComponent(confidencePanel, javax.swing.GroupLayout.PREFERRED_SIZE, 290, Short.MAX_VALUE)
+            .addComponent(confidencePanel, javax.swing.GroupLayout.DEFAULT_SIZE, 474, Short.MAX_VALUE)
         );
         confidenceContainerLayout.setVerticalGroup(
             confidenceContainerLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addComponent(confidencePanel, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+            .addComponent(confidencePanel, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.DEFAULT_SIZE, 215, Short.MAX_VALUE)
         );
 
         jSplitPane2.setRightComponent(confidenceContainer);
@@ -289,12 +312,13 @@ public class FittingMainView extends JInternalFrame implements SedListener {
         );
         jPanel2Layout.setVerticalGroup(
             jPanel2Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addComponent(jSplitPane4, javax.swing.GroupLayout.PREFERRED_SIZE, 391, Short.MAX_VALUE)
+            .addComponent(jSplitPane4)
         );
 
         jSplitPane1.setRightComponent(jPanel2);
 
         availableComponents.setBorder(javax.swing.BorderFactory.createTitledBorder("Available Components"));
+        availableComponents.setLayout(new java.awt.GridBagLayout());
 
         descriptionArea.setEditable(false);
         descriptionArea.setColumns(20);
@@ -306,6 +330,19 @@ public class FittingMainView extends JInternalFrame implements SedListener {
         descriptionArea.setName("descriptionArea"); // NOI18N
         jScrollPane2.setViewportView(descriptionArea);
 
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 1;
+        gridBagConstraints.gridwidth = 2;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
+        gridBagConstraints.ipadx = 208;
+        gridBagConstraints.ipady = 68;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
+        gridBagConstraints.weightx = 1.0;
+        gridBagConstraints.weighty = 1.0;
+        gridBagConstraints.insets = new java.awt.Insets(6, 6, 0, 6);
+        availableComponents.add(jScrollPane2, gridBagConstraints);
+
         searchButton.setText("Search");
         searchButton.setName("searchButton"); // NOI18N
         searchButton.addActionListener(new java.awt.event.ActionListener() {
@@ -313,8 +350,25 @@ public class FittingMainView extends JInternalFrame implements SedListener {
                 searchButtonActionPerformed(evt);
             }
         });
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 1;
+        gridBagConstraints.gridy = 2;
+        gridBagConstraints.gridheight = 2;
+        gridBagConstraints.ipadx = 43;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.EAST;
+        gridBagConstraints.insets = new java.awt.Insets(6, 6, 6, 6);
+        availableComponents.add(searchButton, gridBagConstraints);
 
         searchField.setName("searchField"); // NOI18N
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 2;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.ipadx = 123;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
+        gridBagConstraints.weightx = 1.0;
+        gridBagConstraints.insets = new java.awt.Insets(7, 6, 0, 0);
+        availableComponents.add(searchField, gridBagConstraints);
 
         javax.swing.tree.DefaultMutableTreeNode treeNode1 = new javax.swing.tree.DefaultMutableTreeNode("Model Components");
         javax.swing.tree.DefaultMutableTreeNode treeNode2 = new javax.swing.tree.DefaultMutableTreeNode("Preset Model Components");
@@ -329,28 +383,18 @@ public class FittingMainView extends JInternalFrame implements SedListener {
         availableTree.setName("availableTree"); // NOI18N
         jScrollPane3.setViewportView(availableTree);
 
-        javax.swing.GroupLayout availableComponentsLayout = new javax.swing.GroupLayout(availableComponents);
-        availableComponents.setLayout(availableComponentsLayout);
-        availableComponentsLayout.setHorizontalGroup(
-            availableComponentsLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(availableComponentsLayout.createSequentialGroup()
-                .addComponent(searchField)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(searchButton, javax.swing.GroupLayout.PREFERRED_SIZE, 93, javax.swing.GroupLayout.PREFERRED_SIZE))
-            .addComponent(jScrollPane2, javax.swing.GroupLayout.DEFAULT_SIZE, 219, Short.MAX_VALUE)
-            .addComponent(jScrollPane3)
-        );
-        availableComponentsLayout.setVerticalGroup(
-            availableComponentsLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(availableComponentsLayout.createSequentialGroup()
-                .addComponent(jScrollPane3, javax.swing.GroupLayout.DEFAULT_SIZE, 242, Short.MAX_VALUE)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(jScrollPane2, javax.swing.GroupLayout.PREFERRED_SIZE, 92, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addGroup(availableComponentsLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                    .addComponent(searchButton)
-                    .addComponent(searchField, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)))
-        );
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 0;
+        gridBagConstraints.gridwidth = 2;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
+        gridBagConstraints.ipadx = 208;
+        gridBagConstraints.ipady = 288;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
+        gridBagConstraints.weightx = 1.0;
+        gridBagConstraints.weighty = 1.0;
+        gridBagConstraints.insets = new java.awt.Insets(15, 6, 0, 6);
+        availableComponents.add(jScrollPane3, gridBagConstraints);
 
         javax.swing.GroupLayout jPanel4Layout = new javax.swing.GroupLayout(jPanel4);
         jPanel4.setLayout(jPanel4Layout);
@@ -362,12 +406,34 @@ public class FittingMainView extends JInternalFrame implements SedListener {
         );
         jPanel4Layout.setVerticalGroup(
             jPanel4Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addComponent(availableComponents, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+            .addComponent(availableComponents, javax.swing.GroupLayout.DEFAULT_SIZE, 525, Short.MAX_VALUE)
         );
 
         jSplitPane1.setLeftComponent(jPanel4);
 
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 2;
+        gridBagConstraints.gridwidth = 3;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
+        gridBagConstraints.ipadx = 312;
+        gridBagConstraints.ipady = 39;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
+        gridBagConstraints.weightx = 1.0;
+        gridBagConstraints.weighty = 0.9;
+        gridBagConstraints.insets = new java.awt.Insets(6, 0, 0, 0);
+        jPanel1.add(jSplitPane1, gridBagConstraints);
+
         currentSedLabel.setText("Current Sed: ");
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 0;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
+        gridBagConstraints.weightx = 0.1;
+        gridBagConstraints.weighty = 0.1;
+        gridBagConstraints.insets = new java.awt.Insets(17, 12, 0, 0);
+        jPanel1.add(currentSedLabel, gridBagConstraints);
 
         currentSedField.setEditable(false);
         currentSedField.setEnabled(false);
@@ -376,28 +442,18 @@ public class FittingMainView extends JInternalFrame implements SedListener {
         binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${sedModel.sed.id}"), currentSedField, org.jdesktop.beansbinding.BeanProperty.create("text"));
         bindingGroup.addBinding(binding);
 
-        javax.swing.GroupLayout jPanel1Layout = new javax.swing.GroupLayout(jPanel1);
-        jPanel1.setLayout(jPanel1Layout);
-        jPanel1Layout.setHorizontalGroup(
-            jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(jPanel1Layout.createSequentialGroup()
-                .addContainerGap()
-                .addComponent(currentSedLabel)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(currentSedField, javax.swing.GroupLayout.PREFERRED_SIZE, 598, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
-            .addComponent(jSplitPane1)
-        );
-        jPanel1Layout.setVerticalGroup(
-            jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(jPanel1Layout.createSequentialGroup()
-                .addContainerGap()
-                .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                    .addComponent(currentSedLabel)
-                    .addComponent(currentSedField, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(jSplitPane1))
-        );
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 1;
+        gridBagConstraints.gridy = 0;
+        gridBagConstraints.gridwidth = 2;
+        gridBagConstraints.gridheight = 2;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.ipadx = 588;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
+        gridBagConstraints.weightx = 0.9;
+        gridBagConstraints.weighty = 0.1;
+        gridBagConstraints.insets = new java.awt.Insets(12, 12, 0, 2);
+        jPanel1.add(currentSedField, gridBagConstraints);
 
         getContentPane().add(jPanel1);
 

--- a/iris-visualizer/src/test/java/cfa/vo/iris/fitting/ConfidencePanelTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/fitting/ConfidencePanelTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.uispec4j.Panel;
 import org.uispec4j.TextBox;
+import org.uispec4j.assertion.UISpecAssert;
 
 import java.util.Arrays;
 
@@ -66,6 +67,6 @@ public class ConfidencePanelTest {
     @Test
     public void testDoConfidence() throws Exception {
         uiPanel.getButton().click();
-        uiPanel.getTable().contentEquals(columnNames, expected).check();
+        UISpecAssert.waitUntil(uiPanel.getTable().contentEquals(columnNames, expected), 1000);
     }
 }

--- a/iris-visualizer/src/test/java/cfa/vo/iris/fitting/ConfidencePanelTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/fitting/ConfidencePanelTest.java
@@ -50,7 +50,7 @@ public class ConfidencePanelTest {
         sigma.textEquals("1.6").check();
 
         sigma.setText("1.0");
-        assertEquals(1.0, panel.getController().getFit().getConfidence().getSigma(), Double.MIN_VALUE);
+        assertEquals(1.0, panel.getController().getFit().getConfidence().getConfig().getSigma(), Double.MIN_VALUE);
     }
 
     @Test

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/FittingToolComponentTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/FittingToolComponentTest.java
@@ -280,16 +280,21 @@ public class FittingToolComponentTest extends AbstractComponentGUITest {
         return openWindow();
     }
 
-    private Window openWindow() {
-        window.getMenuBar()
-                .getMenu("Tools")
-                .getSubMenu(comp.getName())
-                .getSubMenu(comp.getName())
-                .click();
+    private Window openWindow() throws Exception {
+        TestUtils.invokeWithRetry(50, 100, new Runnable() {
+            @Override
+            public void run() {
+                window.getMenuBar()
+                        .getMenu("Tools")
+                        .getSubMenu(comp.getName())
+                        .getSubMenu(comp.getName())
+                        .click();
+            }
+        });
         return desktop.getWindow(windowName);
     }
 
-    private void nonExistentFile(String menu) {
+    private void nonExistentFile(String menu) throws Exception {
         ExtSed sed = sedManager.newSed("TestSed");
         addFit(sed);
         Window mainFit = openWindow();

--- a/iris-visualizer/src/test/resources/cfa/vo/iris/fitting/fit.json
+++ b/iris-visualizer/src/test/resources/cfa/vo/iris/fitting/fit.json
@@ -151,10 +151,9 @@
   "stat" : "LeastSquares",
   "method" : "LevenbergMarquardt",
   "confidence" : {
-    "sigma" : 1.6,
-    "maxiters" : null,
-    "eps" : null,
-    "softLimits" : null,
+    "config": {
+      "sigma": 1.6
+    },
     "name" : "conf"
   },
   "rStat" : 0.4321,

--- a/iris-visualizer/src/test/resources/cfa/vo/iris/visualizer/fit.json
+++ b/iris-visualizer/src/test/resources/cfa/vo/iris/visualizer/fit.json
@@ -81,10 +81,9 @@
   "stat" : "Chi2",
   "method" : "MonteCarlo",
   "confidence" : {
-    "sigma" : 1.6,
-    "maxiters" : null,
-    "eps" : null,
-    "softLimits" : null,
+    "config": {
+      "sigma" : 1.6
+    },
     "name" : "conf"
   },
   "rStat" : null,

--- a/iris/src/test/java/cfa/vo/iris/fitting/FittingFunctionalIT.java
+++ b/iris/src/test/java/cfa/vo/iris/fitting/FittingFunctionalIT.java
@@ -40,7 +40,7 @@ import static org.junit.Assert.assertEquals;
 
 public class FittingFunctionalIT extends AbstractUISpecTest {
 
-    private final long TIMEOUT=2000;
+    private final long TIMEOUT=3000;
     
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();

--- a/iris/src/test/java/cfa/vo/iris/fitting/FittingFunctionalIT.java
+++ b/iris/src/test/java/cfa/vo/iris/fitting/FittingFunctionalIT.java
@@ -40,6 +40,8 @@ import static org.junit.Assert.assertEquals;
 
 public class FittingFunctionalIT extends AbstractUISpecTest {
 
+    private final long TIMEOUT=2000;
+    
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();
 
@@ -94,10 +96,10 @@ public class FittingFunctionalIT extends AbstractUISpecTest {
         String[][] table = new String[][]{{"3C 066A", "35.665, 43.036", "NASA/IPAC Extragalactic Database (NED)", "34"}};
         loadSed("3c66a.xml", table);
 
-        UISpecAssert.waitUntil(modelExpression.textEquals("No Model"), 1000);
+        UISpecAssert.waitUntil(modelExpression.textEquals("No Model"), TIMEOUT);
 
         availableTree.doubleClick("Preset Model Components/powerlaw");
-        UISpecAssert.waitUntil(modelsTree.contains("powerlaw.m9"), 1000);
+        UISpecAssert.waitUntil(modelsTree.contains("powerlaw.m9"), TIMEOUT);
 
         modelExpression.textEquals("m9").check();
 
@@ -107,7 +109,7 @@ public class FittingFunctionalIT extends AbstractUISpecTest {
         fittingView.getButton("Fit").click();
 
         TextBox np = fittingView.getInputTextBox("Number of Points");
-        UISpecAssert.waitUntil(np.textEquals("23"), 1000);
+        UISpecAssert.waitUntil(np.textEquals("23"), TIMEOUT);
 
         TextBox statS = fittingView.getInputTextBox("Final Fit Statistic");
         Double stat = Double.valueOf(statS.getText());
@@ -123,7 +125,7 @@ public class FittingFunctionalIT extends AbstractUISpecTest {
                 Double amplInf = Double.valueOf((String) confidenceTable.getContentAt(0, 1));
                 assertEquals(-6.202e-6, amplInf, 1e-8);
             }
-        }, 1000);
+        }, TIMEOUT);
 
         Double value = Double.valueOf((String) confidenceTable.getContentAt(0, 2));
         assertEquals(6.065e-6, value, 1e-8);
@@ -337,9 +339,8 @@ public class FittingFunctionalIT extends AbstractUISpecTest {
 
         fittingView.getButton("Fit").click();
 
-        UISpecAssert.waitUntil(UISpecAssert.not(val.textEquals("-0.5")), 1000);
+        UISpecAssert.waitUntil(val.textContains("-0.0526"), TIMEOUT);
 
-        val.textContains("-0.0526").check();
         modelsTree.select("powerlaw.m5/m5.ampl");
         val.textContains("0.00507").check();
 
@@ -363,13 +364,13 @@ public class FittingFunctionalIT extends AbstractUISpecTest {
         fittingView.getComboBox("statisticCombo").select("Chi2");
         fittingView.getButton("Fit").click();
 
-        UISpecAssert.waitUntil(np.textEquals("363"), 1000);
+        UISpecAssert.waitUntil(np.textEquals("363"), TIMEOUT);
 
         fittingView.getButton("Compute").click();
 
         Table confTable = fittingView.getTable();
         String[] columns = {"Parameter", "Lower Limit", "Upper Limit"};
-        UISpecAssert.waitUntil(UISpecAssert.not(confTable.isEmpty()), 1000);
+        UISpecAssert.waitUntil(UISpecAssert.not(confTable.isEmpty()), TIMEOUT);
 
         Assert.assertEquals(confTable.getContentAt(0, 0), "m5.ampl");
         Assert.assertEquals(confTable.getContentAt(1, 0), "m5.index");
@@ -391,7 +392,7 @@ public class FittingFunctionalIT extends AbstractUISpecTest {
     }
 
     private void assertFitSucceeded() {
-        UISpecAssert.waitUntil(fittingView.getTextBox("status").textEquals(ModelViewerPanel.FIT_SUCCEEDED), 1000);
+        UISpecAssert.waitUntil(fittingView.getTextBox("status").textEquals(ModelViewerPanel.FIT_SUCCEEDED), TIMEOUT);
 
     }
 
@@ -428,6 +429,6 @@ public class FittingFunctionalIT extends AbstractUISpecTest {
 
         Window builder = desktop.getWindow("SED Builder");
 //        builder.getListBox().click(0);
-        UISpecAssert.waitUntil(builder.getTable().contentEquals(table), 1000);
+        UISpecAssert.waitUntil(builder.getTable().contentEquals(table), TIMEOUT);
     }
 }

--- a/iris/src/test/java/cfa/vo/iris/fitting/FittingFunctionalIT.java
+++ b/iris/src/test/java/cfa/vo/iris/fitting/FittingFunctionalIT.java
@@ -131,6 +131,9 @@ public class FittingFunctionalIT extends AbstractUISpecTest {
 
         value = Double.valueOf((String) confidenceTable.getContentAt(1, 2));
         assertEquals(0.00486, value, 0.00001);
+
+        // check the confidence interval label updated
+        fittingView.getTextBox("sigmaPercent").textEquals("sigma - 99.99%").check();
     }
 
     private void saveText() throws Exception {

--- a/iris/src/test/java/cfa/vo/iris/fitting/FittingFunctionalIT.java
+++ b/iris/src/test/java/cfa/vo/iris/fitting/FittingFunctionalIT.java
@@ -59,6 +59,11 @@ public class FittingFunctionalIT extends AbstractUISpecTest {
 
     @Before
     public void setUp() throws Exception {
+        window = appResource.getAdapter().getMainWindow();
+        desktop = window.getDesktop();
+
+        // Set up tests/examples directory.
+        examplesUrlString = tempFolder.getRoot().getParentFile().getAbsolutePath()+"/examples";
         // Set up tests/examples directory.
         templateLibUrlString = examplesUrlString+"/sed_templates.dat";
         functionUrlString = examplesUrlString+"/mypowlaw.py";
@@ -101,11 +106,8 @@ public class FittingFunctionalIT extends AbstractUISpecTest {
 
         fittingView.getButton("Fit").click();
 
-        TextBox val = fittingView.getTextBox("Par Val");
-        UISpecAssert.waitUntil(UISpecAssert.not(val.textEquals("-0.5")), 1000);
-
         TextBox np = fittingView.getInputTextBox("Number of Points");
-        np.textEquals("23").check();
+        UISpecAssert.waitUntil(np.textEquals("23"), 1000);
 
         TextBox statS = fittingView.getInputTextBox("Final Fit Statistic");
         Double stat = Double.valueOf(statS.getText());
@@ -114,11 +116,11 @@ public class FittingFunctionalIT extends AbstractUISpecTest {
         fittingView.getInputTextBox("sigma").setText("4");
         fittingView.getButton("Compute").click();
 
-        Table confidenceTable = fittingView.getTable("confidenceTable");
-        final Double amplInf = Double.valueOf((String) confidenceTable.getContentAt(0, 1));
+        final Table confidenceTable = fittingView.getTable("confidenceTable");
         UISpecAssert.waitUntil(new Assertion() {
             @Override
             public void check() {
+                Double amplInf = Double.valueOf((String) confidenceTable.getContentAt(0, 1));
                 assertEquals(-6.202e-6, amplInf, 1e-8);
             }
         }, 1000);

--- a/iris/src/test/resources/cfa/vo/iris/fitting/fit.output
+++ b/iris/src/test/resources/cfa/vo/iris/fitting/fit.output
@@ -4,29 +4,29 @@ SED ID: Sed (Segments: 1)
 Model Expression: m6 + m7 + m8
 Components:
 	tablemodel.m6
-		                   m6.ampl =  1.00000E-38
+		                   m6.ampl =  1.04981E+00
 	usermodel.m7
 		                    m7.ref =  5.00000E+03 Frozen
-		                   m7.ampl =  1.00000E-38
-		                  m7.index = -4.08735E-01
+		                   m7.ampl =  9.78911E-06
+		                  m7.index = -3.75375E-01
 	template.m8
-		                    m8.idx = -3.75000E-01
+		                    m8.idx =  0.00000E+00
 		                  m8.refer =  5.00000E+03
 
 Fit Results:
-		       Final Fit Statistic =  2.01188E+20
-		         Reduced Statistic =  5.61977E+17
+		       Final Fit Statistic =  6.54346E+05
+		         Reduced Statistic =  1.82778E+03
 		     Probability (Q-value) =  0.00000E+00
 		        Degrees of Freedom = 358
 		               Data Points = 363
-		      Function Evaluations = 48
+		      Function Evaluations = 84
 
 		                 Optimizer = LevenbergMarquardt
 		 Statistic (Cost function) = Chi2
 
-Confidence Limits at 1.64 sigma (90.00%):
-                 m5.ampl: (-8.48169E-18,  6.44529E-18)
-                m5.index: (-7.27584E-06,          NAN)
+Confidence Limits at 1.60 sigma (89.04%):
+                 m5.ampl: (-1.66983E-06,  1.67318E-06)
+                m5.index: (-2.56885E-05,  5.29382E-05)
 
 User Models:
 		tablemodel.m6: (file: $HOME/.vao/iris/analysis/custom_models/tables/test_table, function: None)

--- a/iris/src/test/resources/cfa/vo/iris/fitting/fit.output
+++ b/iris/src/test/resources/cfa/vo/iris/fitting/fit.output
@@ -24,10 +24,6 @@ Fit Results:
 		                 Optimizer = LevenbergMarquardt
 		 Statistic (Cost function) = Chi2
 
-Confidence Limits at 1.60 sigma (89.04%):
-                 m5.ampl: (-1.66983E-06,  1.67318E-06)
-                m5.index: (-2.56885E-05,  5.29382E-05)
-
 User Models:
 		tablemodel.m6: (file: $HOME/.vao/iris/analysis/custom_models/tables/test_table, function: None)
 		usermodel.m7: (file: $HOME/.vao/iris/analysis/custom_models/functions/test_function, function: mypowlaw)

--- a/samp-factory/src/main/java/cfa/vo/sherpa/Confidence.java
+++ b/samp-factory/src/main/java/cfa/vo/sherpa/Confidence.java
@@ -22,7 +22,7 @@ public interface Confidence {
 
     void setName(String name);
 
-    Configuration getConfig();
+    ConfidenceConfiguration getConfig();
 
-    void setConfig(Configuration conf);
+    void setConfig(ConfidenceConfiguration conf);
 }

--- a/samp-factory/src/main/java/cfa/vo/sherpa/ConfidenceConfiguration.java
+++ b/samp-factory/src/main/java/cfa/vo/sherpa/ConfidenceConfiguration.java
@@ -15,7 +15,7 @@
  */
 package cfa.vo.sherpa;
 
-public interface Configuration {
+public interface ConfidenceConfiguration {
     Double getSigma();
 
     void setSigma(Double sigma);

--- a/samp-factory/src/main/java/cfa/vo/sherpa/Configuration.java
+++ b/samp-factory/src/main/java/cfa/vo/sherpa/Configuration.java
@@ -1,28 +1,22 @@
 /**
- * Copyright (C) 2012 Smithsonian Astrophysical Observatory
- *
+ * Copyright (C) 2016 Smithsonian Astrophysical Observatory
+ * <p/>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package cfa.vo.sherpa;
 
+public interface Configuration {
+    Double getSigma();
 
-public interface Confidence {
-    String getName();
-
-    void setName(String name);
-
-    Configuration getConfig();
-
-    void setConfig(Configuration conf);
+    void setSigma(Double sigma);
 }


### PR DESCRIPTION
This PR fixes three issues with the fitting tool:

 * chandracxc/iris-dev#91 - the sigma label now updates when the confidence is calculated. A potential issue here is that the confidence calculation must be performed and succeed for sherpa-samp to return the percentage value corresponding to the user's input. An improvement would be to perform the calculation in java on the fly.

 * chandracxc/iris-dev#99 - confidence now seems to properly work. Results are consistent with the ones in Iris 2.1. The problem in the previous code was that the SAMP configuration was not properly built, and unfortunately sherpa-samp does not much in terms of error handlind.

 * chandracxc/iris-dev#92 - introduced gridbag layout in GUI to try and fix some OSX issues. Not all issues are resolved, but this is an improvement.

 * chandracxc/iris-dev#90 - the fit and confidence calculations are now performed asynchronously (not in the EDT).