### PR TITLE
iris-dev#112 Don't Fit Masked Points

### DIFF
--- a/iris-common/src/main/java/cfa/vo/iris/sed/stil/IrisDataStarTable.java
+++ b/iris-common/src/main/java/cfa/vo/iris/sed/stil/IrisDataStarTable.java
@@ -1,0 +1,14 @@
+package cfa.vo.iris.sed.stil;
+
+import uk.ac.starlink.table.StarTable;
+
+public interface IrisDataStarTable extends StarTable {
+    public double[] getSpecValues();
+    public double[] getFluxValues();
+    public double[] getSpecErrValues();
+    public double[] getSpecErrValuesLo();
+    public double[] getSpecErrValuesHi();
+    public double[] getFluxErrValues();
+    public double[] getFluxErrValuesLo();
+    public double[] getFluxErrValuesHi();
+}

--- a/iris-common/src/main/java/cfa/vo/iris/sed/stil/SegmentStarTable.java
+++ b/iris-common/src/main/java/cfa/vo/iris/sed/stil/SegmentStarTable.java
@@ -51,7 +51,7 @@ import cfa.vo.utils.Default;
  * no more than 8 columns representing spectral and flux values and error ranges.
  *
  */
-public class SegmentStarTable extends RandomStarTable {
+public class SegmentStarTable extends RandomStarTable implements IrisDataStarTable {
     
     private static final Logger logger = Logger.getLogger(SegmentStarTable.class.getName());
     private static final UnitsManager units = Default.getInstance().getUnitsManager();

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FitController.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FitController.java
@@ -135,17 +135,17 @@ public class FitController {
         
         // Extract fitting data from SedModel, don't include masked points.
         sedModel.getFittingData(data, false);
-        double[] xOriginalUnit = data.getX();
-        double[] yOriginalUnit = data.getY();
-        double[] errOriginalUnit = data.getStaterror();
+        double[] xOriginalValues = data.getX();
+        double[] yOriginalValues = data.getY();
+        double[] errOriginalValues = data.getStaterror();
         
         // Convert data's units to fitting units
         UnitsManager um = Default.getInstance().getUnitsManager();
-        data.setX(um.convertX(xOriginalUnit, sedModel.getXUnits(), SherpaClient.X_UNIT));
-        data.setY(um.convertY(yOriginalUnit, xOriginalUnit,
+        data.setX(um.convertX(xOriginalValues, sedModel.getXUnits(), SherpaClient.X_UNIT));
+        data.setY(um.convertY(yOriginalValues, xOriginalValues,
                 sedModel.getYUnits(), sedModel.getXUnits(),
                 SherpaClient.Y_UNIT));
-        data.setStaterror(um.convertY(errOriginalUnit, xOriginalUnit,
+        data.setStaterror(um.convertErrors(errOriginalValues, yOriginalValues, xOriginalValues,
                 sedModel.getYUnits(), sedModel.getXUnits(),
                 SherpaClient.Y_UNIT));
         return data;

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FitController.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FitController.java
@@ -1,13 +1,16 @@
 package cfa.vo.iris.fitting;
 
+import cfa.vo.interop.SAMPFactory;
 import cfa.vo.iris.fitting.custom.CustomModelsManager;
 import cfa.vo.iris.fitting.custom.DefaultCustomModel;
 import cfa.vo.iris.fitting.custom.ModelsListener;
 import cfa.vo.iris.sed.stil.SegmentStarTable;
+import cfa.vo.iris.units.UnitsException;
 import cfa.vo.iris.units.UnitsManager;
 import cfa.vo.iris.visualizer.preferences.SedModel;
 import cfa.vo.iris.visualizer.stil.tables.IrisStarTable;
 import cfa.vo.sherpa.ConfidenceResults;
+import cfa.vo.sherpa.Data;
 import cfa.vo.sherpa.FitResults;
 import cfa.vo.sherpa.SherpaClient;
 import cfa.vo.sherpa.models.Model;
@@ -114,13 +117,38 @@ public class FitController {
      * @throws Exception An exception may be thrown by the sherpa-samp service if the fitting operation failed.
      */
     public FitResults fit() throws Exception {
-        FitResults retVal = client.fit(sedModel.getSed());
+        Data data = constructSherpaCall(sedModel);
+        
+        // Make call to sherpa to fit data
+        FitResults retVal = client.fit(data, sedModel.getSed().getFit());
         sedModel.getFit().integrateResults(retVal);
         
         // Record the version number on the SED in the FitConfiguration
         sedModel.getFit().setSedVersion(sedModel.getVersion());
         
         return retVal;
+    }
+    
+    Data constructSherpaCall(SedModel model) throws UnitsException {
+        Data data = SAMPFactory.get(Data.class);
+        data.setName(SherpaClient.DATA_NAME);
+        
+        // Extract fitting data from SedModel, don't include masked points.
+        sedModel.getFittingData(data, false);
+        double[] xOriginalUnit = data.getX();
+        double[] yOriginalUnit = data.getY();
+        double[] errOriginalUnit = data.getStaterror();
+        
+        // Convert data's units to fitting units
+        UnitsManager um = Default.getInstance().getUnitsManager();
+        data.setX(um.convertX(xOriginalUnit, sedModel.getXUnits(), SherpaClient.X_UNIT));
+        data.setY(um.convertY(yOriginalUnit, xOriginalUnit,
+                sedModel.getYUnits(), sedModel.getXUnits(),
+                SherpaClient.Y_UNIT));
+        data.setStaterror(um.convertY(errOriginalUnit, xOriginalUnit,
+                sedModel.getYUnits(), sedModel.getXUnits(),
+                SherpaClient.Y_UNIT));
+        return data;
     }
 
     /**
@@ -222,16 +250,17 @@ public class FitController {
 
         UnitsManager uManager = Default.getInstance().getUnitsManager();
 
-        for (IrisStarTable table: sedModel.getDataTables()) {
+        for (IrisStarTable ist: sedModel.getDataTables()) {
+            SegmentStarTable table = ist.getPlotterDataTable();
             double[] x = table.getSpecValues();
             double[] xStandardUnit = uManager.convertX(x, xUnit, SherpaClient.X_UNIT);
             double[] yStandardUnit = client.evaluate(xStandardUnit, sedModel.getFit());
             double[] y = Default.getInstance().getUnitsManager().convertY(yStandardUnit, xStandardUnit,
                     SherpaClient.Y_UNIT, SherpaClient.X_UNIT, yUnit);
 
-            table.getPlotterDataTable().setModelValues(y);
-            table.getPlotterDataTable().setResidualValues(calcResiduals(table.getFluxValues(), y));
-            table.getPlotterDataTable().setRatioValues(calcRatios(table.getFluxValues(), y));
+            table.setModelValues(y);
+            table.setResidualValues(calcResiduals(table.getFluxValues(), y));
+            table.setRatioValues(calcRatios(table.getFluxValues(), y));
         }
     }
 

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FitController.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FitController.java
@@ -223,15 +223,15 @@ public class FitController {
         UnitsManager uManager = Default.getInstance().getUnitsManager();
 
         for (IrisStarTable table: sedModel.getDataTables()) {
-            double[] x = table.getSpectralDataValues();
+            double[] x = table.getSpecValues();
             double[] xStandardUnit = uManager.convertX(x, xUnit, SherpaClient.X_UNIT);
             double[] yStandardUnit = client.evaluate(xStandardUnit, sedModel.getFit());
             double[] y = Default.getInstance().getUnitsManager().convertY(yStandardUnit, xStandardUnit,
                     SherpaClient.Y_UNIT, SherpaClient.X_UNIT, yUnit);
 
             table.getPlotterDataTable().setModelValues(y);
-            table.getPlotterDataTable().setResidualValues(calcResiduals(table.getFluxDataValues(), y));
-            table.getPlotterDataTable().setRatioValues(calcRatios(table.getFluxDataValues(), y));
+            table.getPlotterDataTable().setResidualValues(calcResiduals(table.getFluxValues(), y));
+            table.getPlotterDataTable().setRatioValues(calcRatios(table.getFluxValues(), y));
         }
     }
 

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedModel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedModel.java
@@ -370,6 +370,7 @@ public class SedModel {
         HashCodeBuilder hcb = new HashCodeBuilder(13,31);
         for (IrisStarTable table : getDataTables()) {
             hcb.append(table.getPlotterDataTable().hashCode());
+            hcb.append(table.getMasked());
         }
         return hcb.hashCode();
     }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedModel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedModel.java
@@ -24,10 +24,13 @@ import java.util.List;
 import java.util.Map;
 
 import cfa.vo.iris.fitting.FitConfiguration;
+
+import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 
 import cfa.vo.iris.sed.ExtSed;
+import cfa.vo.iris.sed.stil.IrisDataStarTable;
 import cfa.vo.iris.visualizer.plotter.ColorPalette;
 import cfa.vo.iris.visualizer.plotter.HSVColorPalette;
 import cfa.vo.iris.units.UnitsException;
@@ -37,8 +40,11 @@ import cfa.vo.iris.visualizer.stil.tables.SegmentColumnInfoMatcher;
 import cfa.vo.iris.visualizer.stil.tables.StackedStarTable;
 import cfa.vo.sedlib.Segment;
 import cfa.vo.sedlib.common.SedNoDataException;
+import cfa.vo.sherpa.Data;
+
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import uk.ac.starlink.table.StarTable;
 
 /**
@@ -128,6 +134,28 @@ public class SedModel {
     }
     
     /**
+     * @return A list of IrisDataStarTables for each Segment in this SED. List is in the same
+     * order as they appear in the SED. Rows are masked if specified.
+     * 
+     * NOTE: The values returned are in the current units of the SED model.
+     * 
+     * @param includeMasked if true the returned table will include all points, if false
+     * it will not include points that have been specified as 'masked'.
+     */
+    public List<IrisDataStarTable> getIrisDataTables(boolean includeMasked) {
+        List<IrisStarTable> tables = getDataTables();
+        List<IrisDataStarTable> dataTables = new ArrayList<>(tables.size());;
+        
+        if (includeMasked) {
+            for (IrisStarTable t : tables) dataTables.add(t.getPlotterDataTable());
+        } else {
+            for (IrisStarTable t : tables) dataTables.add(t);
+        }
+        
+        return dataTables;
+    }
+    
+    /**
      * @return A list of all LayerModels for each Segment in this SED. 
      * List of Segment layers is in the same order as they appear in the SED.
      */
@@ -141,6 +169,37 @@ public class SedModel {
         }
         
         return ret;
+    }
+    
+    /**
+     * Updated the passed {@link Data} object with the fitting data from this SED. As of 
+     * now that include flux, spectral, and stat error values.
+     * 
+     * @param includeMasked if true the returned table will include all points, if false
+     * it will not include points that have been specified as 'masked'.
+     * 
+     */
+    // TODO: Make this better! e.g., should have some mechanism to just have a stacked
+    // IrisStarTable that would allow us to more easily and efficiently extract data. Still, 
+    // performance wise much better than sedlib.
+    public void getFittingData(final Data data, boolean includeMasked) {
+        
+        List<IrisDataStarTable> dataTables = this.getIrisDataTables(includeMasked);
+        
+        // Extract and construct column data
+        double[] specData = new double[] {};
+        double[] fluxData = new double[] {};
+        double[] fluxErrData = new double[] {};
+        
+        for (IrisDataStarTable table : dataTables) {
+            specData = ArrayUtils.addAll(specData, table.getSpecValues());
+            fluxData = ArrayUtils.addAll(fluxData, table.getFluxValues());
+            fluxErrData = ArrayUtils.addAll(fluxErrData, table.getFluxErrValues());
+        }
+        
+        data.setX(specData);
+        data.setY(fluxData);
+        data.setStaterror(fluxErrData);
     }
     
     /**

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/IrisStarTable.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/stil/tables/IrisStarTable.java
@@ -20,6 +20,8 @@ package cfa.vo.iris.visualizer.stil.tables;
 import java.io.IOException;
 import java.util.BitSet;
 import java.util.List;
+
+import cfa.vo.iris.sed.stil.IrisDataStarTable;
 import cfa.vo.iris.sed.stil.SegmentStarTable;
 import cfa.vo.iris.units.UnitsException;
 import cfa.vo.iris.visualizer.masks.Mask;
@@ -45,7 +47,7 @@ import uk.ac.starlink.table.WrapperStarTable;
  *  to the fitting tool.
  *
  */
-public class IrisStarTable extends WrapperStarTable {
+public class IrisStarTable extends WrapperStarTable implements IrisDataStarTable {
     
     private StarTable segmentMetadataTable;
     private SegmentStarTable plotterDataTable;
@@ -88,6 +90,66 @@ public class IrisStarTable extends WrapperStarTable {
         super.setName(name);
         plotterDataTable.setName(name);
         segmentMetadataTable.setName(name);
+    }
+
+    @Override
+    public double[] getSpecValues() {
+        return getFilteredValues(plotterDataTable.getSpecValues());
+    }
+
+    @Override
+    public double[] getFluxValues() {
+        return getFilteredValues(plotterDataTable.getFluxValues());
+    }
+
+    @Override
+    public double[] getSpecErrValues() {
+        return getFilteredValues(plotterDataTable.getSpecErrValues());
+    }
+
+    @Override
+    public double[] getSpecErrValuesLo() {
+        return getFilteredValues(plotterDataTable.getSpecErrValuesLo());
+    }
+
+    @Override
+    public double[] getSpecErrValuesHi() {
+        return getFilteredValues(plotterDataTable.getSpecErrValuesHi());
+    }
+
+    @Override
+    public double[] getFluxErrValues() {
+        return getFilteredValues(plotterDataTable.getFluxErrValues());
+    }
+
+    @Override
+    public double[] getFluxErrValuesLo() {
+        return getFilteredValues(plotterDataTable.getFluxErrValuesLo());
+    }
+
+    @Override
+    public double[] getFluxErrValuesHi() {
+        return getFilteredValues(plotterDataTable.getFluxErrValuesHi());
+    }
+    
+    /**
+     * Uses the BitSet mask to return a subset of data from the 
+     * provided double[].
+     */
+    private double[] getFilteredValues(double[] data) {
+        
+        int rows = (int) getRowCount();
+        double[] values = new double[rows];
+        
+        BitSet masked = mask.getMaskedRows(this);
+        int c = 0;
+        for (int i=0; i<(int) plotterDataTable.getRowCount(); i++) {
+            // Add only non-masked values.
+            if (!masked.get(i)) {
+                values[c++] = data[i];
+            }
+        }
+        return values;
     }
     
     /**
@@ -155,6 +217,13 @@ public class IrisStarTable extends WrapperStarTable {
         
         return -1;
     }
+    
+    /**
+     * @return BitSet of masked rows in the table.
+     */
+    public BitSet getMasked() {
+        return mask.getMaskedRows(this);
+    }
 
     /**
      * Mask rows from this StarTable.
@@ -181,47 +250,6 @@ public class IrisStarTable extends WrapperStarTable {
     public void clearMasks() {
         mask = new RowSubsetMask(new int[0], this);
         plotterDataTable.setMasked(mask.getMaskedRows(this));
-    }
-    
-    /**
-     * @return BitSet of masked rows in the table.
-     */
-    public BitSet getMasked() {
-        return mask.getMaskedRows(this);
-    }
-    
-    /**
-     * @return the filtered set of spectral axis data values.
-     */
-    public double[] getSpectralDataValues() {
-        return getFilteredValues(plotterDataTable.getSpecValues());
-    }
-    
-    /**
-     * @return the filtered set of flux axis data values.
-     */
-    public double[] getFluxDataValues() {
-        return getFilteredValues(plotterDataTable.getFluxValues());
-    }
-    
-    /*
-     * Uses the BitSet mask to return a subset of data from the 
-     * provided double[].
-     */
-    private double[] getFilteredValues(double[] data) {
-        
-        int rows = (int) getRowCount();
-        double[] values = new double[rows];
-        
-        BitSet masked = mask.getMaskedRows(this);
-        int c = 0;
-        for (int i=0; i<(int) plotterDataTable.getRowCount(); i++) {
-            // Add only non-masked values.
-            if (!masked.get(i)) {
-                values[c++] = data[i];
-            }
-        }
-        return values;
     }
     
     /**

--- a/iris-visualizer/src/test/java/cfa/vo/iris/fitting/FitControllerIT.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/fitting/FitControllerIT.java
@@ -23,6 +23,7 @@ import cfa.vo.iris.test.unit.SherpaResource;
 import cfa.vo.iris.test.unit.TestUtils;
 import cfa.vo.iris.units.UnitsManager;
 import cfa.vo.iris.visualizer.preferences.SedModel;
+import cfa.vo.iris.visualizer.stil.tables.IrisStarTable;
 import cfa.vo.iris.visualizer.stil.tables.IrisStarTableAdapter;
 import cfa.vo.sedlib.Segment;
 import cfa.vo.sherpa.Data;
@@ -75,6 +76,19 @@ public class FitControllerIT {
         FitResults results = controller.fit();
         double[] expected = {0, 1};
         assertArrayEquals(expected, results.getParvals(), 0.01);
+    }
+
+    @Test
+    public void testFitMasked() throws Exception {
+        
+        FitResults original = controller.fit();
+        
+        // Mask first and last rows
+        sedModel.getDataTables().get(0).applyMasks(new int[] {0});
+        FitResults masked = controller.fit();
+        
+        // One less point
+        assertEquals((int) original.getNumpoints() - 1, (int) masked.getNumpoints());
     }
 
     @Test

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/preferences/SedPreferencesTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/preferences/SedPreferencesTest.java
@@ -196,6 +196,16 @@ public class SedPreferencesTest {
         model.refresh();
         int h5 = model.getVersion();
         assertFalse(h4 == h5);
+        
+        // Masking points changes version
+        model.getDataTables().get(0).applyMasks(new int[] {0});
+        int h6 = model.getVersion();
+        assertFalse(h5 == h6);
+        
+        // Remove mask
+        model.getDataTables().get(0).clearMasks();
+        int h7 = model.getVersion();
+        assertTrue(h5 == h7);
     }
     
     @Test

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/tables/MaskingTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/stil/tables/MaskingTest.java
@@ -76,24 +76,24 @@ public class MaskingTest {
         ArrayUtils.assertEquals(new Object[] {false, test.getName(), 4.0, 9.0, 9.0}, test.getRow(3));
         
         // verify values
-        checkEquals(new double[] {7,8,9}, test.getFluxDataValues());
-        checkEquals(new double[] {2,3,4}, test.getSpectralDataValues());
+        checkEquals(new double[] {7,8,9}, test.getFluxValues());
+        checkEquals(new double[] {2,3,4}, test.getSpecValues());
         
         // Apply a filter to row 2
         test.applyMasks(new int[] {2});
         assertEquals(2, test.getRowCount());
         
         // verify values
-        checkEquals(new double[] {7,9}, test.getFluxDataValues());
-        checkEquals(new double[] {2,4}, test.getSpectralDataValues());
+        checkEquals(new double[] {7,9}, test.getFluxValues());
+        checkEquals(new double[] {2,4}, test.getSpecValues());
         
         // Remove the first filter
         test.clearMasks(new int[] {0, 4});
         assertEquals(4, test.getRowCount());
         
         // verify values
-        checkEquals(new double[] {6,7,9,10}, test.getFluxDataValues());
-        checkEquals(new double[] {1,2,4,5}, test.getSpectralDataValues());
+        checkEquals(new double[] {6,7,9,10}, test.getFluxValues());
+        checkEquals(new double[] {1,2,4,5}, test.getSpecValues());
     }
     
     
@@ -182,8 +182,8 @@ public class MaskingTest {
         assertEquals(2, table1.getRowCount());
         assertEquals(1, table2.getRowCount());
         
-        checkEquals(new double[] {2,3}, table1.getFluxDataValues());
-        checkEquals(new double[] {2}, table2.getFluxDataValues());
+        checkEquals(new double[] {2,3}, table1.getFluxValues());
+        checkEquals(new double[] {2}, table2.getFluxValues());
         
         // Clear filter from second star table. Non-masked values should have no effect.
         table2.clearMasks(new int[] {0,4});
@@ -191,8 +191,8 @@ public class MaskingTest {
         assertEquals(2, table1.getRowCount());
         assertEquals(2, table2.getRowCount());
         
-        checkEquals(new double[] {2,3}, table1.getFluxDataValues());
-        checkEquals(new double[] {1,2}, table2.getFluxDataValues());
+        checkEquals(new double[] {2,3}, table1.getFluxValues());
+        checkEquals(new double[] {1,2}, table2.getFluxValues());
         
         // Remove all filters
         IrisStarTable.clearAllMasks(tables);
@@ -200,8 +200,8 @@ public class MaskingTest {
         assertEquals(3, table1.getRowCount());
         assertEquals(3, table2.getRowCount());
         
-        checkEquals(new double[] {1,2,3}, table1.getFluxDataValues());
-        checkEquals(new double[] {1,2,3}, table2.getFluxDataValues());
+        checkEquals(new double[] {1,2,3}, table1.getFluxValues());
+        checkEquals(new double[] {1,2,3}, table2.getFluxValues());
     }
     
     @Test


### PR DESCRIPTION
Resolves
https://github.com/ChandraCXC/iris-dev/issues/112

Added support for the fitting tool to get masked data instead of all the data when computing a fit. Additional unit/functional tests at several layers verify the changes.

One note, I made an interface for the star table that we use for plotting so that we can interchangeably use IrisStarTables and SegmentStarTables, when required.

Also, note that this is branched off model-validation for ease of viewing.