### PR TITLE
Plot Fitting Ranges

### DIFF
--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/MouseXRangesClickedListener.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/MouseXRangesClickedListener.java
@@ -103,6 +103,9 @@ public class MouseXRangesClickedListener extends StilPlotterMouseListener implem
                 // reset fitting range flags
                 isStartPoint = true;
                 pickingRanges = false;
+                
+                // Reset the plotter
+                dataModel.refresh();
             }
         }
     }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/StilPlotter.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/StilPlotter.java
@@ -493,7 +493,9 @@ public class StilPlotter extends JPanel {
         
         // Otherwise add the layer at 10% of the current aspect
         PlaneAspect aspect = display.getAspect();
-        double y = aspect.getYMin() + ((aspect.getYMax() - aspect.getYMin()) * .1);
+        double min = Math.min(aspect.getYMin(), aspect.getYMax());
+        double max = Math.max(aspect.getYMin(), aspect.getYMax());
+        double y = min + ((max - min) * .1);
         
         // Construct the model for the fitting ranges and add it to the plot
         fittingRanges = new FittingRangeModel(ranges, dataModel.getXunits(), y);

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/StilPlotter.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/StilPlotter.java
@@ -19,8 +19,10 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.SwingConstants;
 
+import cfa.vo.iris.fitting.FittingRange;
 import cfa.vo.iris.sed.ExtSed;
 import cfa.vo.iris.sed.quantities.SPVYQuantity;
+import cfa.vo.iris.visualizer.preferences.FittingRangeModel;
 import cfa.vo.iris.visualizer.preferences.FunctionModel;
 import cfa.vo.iris.visualizer.preferences.LayerModel;
 import cfa.vo.iris.visualizer.preferences.SedModel;
@@ -35,6 +37,8 @@ import uk.ac.starlink.ttools.plot2.task.PlotDisplay;
 import uk.ac.starlink.ttools.task.MapEnvironment;
 
 import java.awt.GridBagConstraints;
+
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.builder.ReflectionToStringBuilder;
 
 import java.awt.Insets;
@@ -77,6 +81,9 @@ public class StilPlotter extends JPanel {
     
     // MapEnvironment for the residuals plotter
     private MapEnvironment resEnv;
+    
+    // Fitting ranges currently plotted
+    FittingRangeModel fittingRanges;
     
     // Needs a default constructor for Netbeans
     public StilPlotter() {
@@ -503,8 +510,11 @@ public class StilPlotter extends JPanel {
 
         // Add model functions
         addFunctionModels(env);
+        
+        // Add Fitting ranges
+        addFittingRanges(env);
     }
-    
+
     private void addFunctionModels(MapEnvironment env) {
         
         // Override color settings so that each model function is a different color,
@@ -563,6 +573,26 @@ public class StilPlotter extends JPanel {
             for (String key : prefs.keySet()) {
                 resEnv.setValue(key, prefs.get(key));
             }
+        }
+    }
+    
+    private void addFittingRanges(MapEnvironment env) {
+        List<FittingRange> ranges = dataModel.getFittingRanges();
+
+        // Do nothing if none are available
+        if (CollectionUtils.isEmpty(ranges)) return;
+        
+        // If there is no aspect then do nothing
+        PlaneAspect aspect = getPlotPreferences().getAspect();
+        if (aspect == null) return;
+        
+        // Otherwise add the layer at 5% from the bottom of the aspect
+        double y = aspect.getYMin() + ((aspect.getYMax() - aspect.getYMin()) * .05);
+        fittingRanges = new FittingRangeModel(ranges, dataModel.getXunits(), y);
+        
+        Map<String, Object> prefs = fittingRanges.getPreferences();
+        for (String key : prefs.keySet()) {
+            env.setValue(key, prefs.get(key));
         }
     }
     

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/FittingRangeModel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/FittingRangeModel.java
@@ -1,0 +1,60 @@
+package cfa.vo.iris.visualizer.preferences;
+
+import java.util.Arrays;
+import java.util.List;
+
+import cfa.vo.iris.fitting.FittingRange;
+import cfa.vo.iris.sed.stil.SegmentColumn;
+import cfa.vo.iris.sed.stil.SegmentColumn.Column;
+import cfa.vo.iris.units.UnitsException;
+import cfa.vo.iris.units.UnitsManager;
+import cfa.vo.utils.Default;
+import uk.ac.starlink.table.ColumnStarTable;
+import uk.ac.starlink.table.StarTable;
+
+public class FittingRangeModel extends LayerModel {
+    
+    private static final UnitsManager um = Default.getInstance().getUnitsManager();
+    private static final String FITTING_LAYER = "Fitting Ranges";
+
+    public FittingRangeModel(List<FittingRange> ranges, String xunit, double yvalue) {
+        super(getFittingRangeTable(ranges, xunit, yvalue));
+        this.setShowMarks(false);
+        this.setErrorColor("Red");
+    }
+
+    private static StarTable getFittingRangeTable(List<FittingRange> ranges, String xunit, double yvalue) 
+    {
+        // Construct Y-column
+        double[] yvalues = new double[ranges.size()];
+        Arrays.fill(yvalues, yvalue);
+        
+        // Get fitting ranges from the range list, converting as we go
+        double[] xvaluesLow = new double[ranges.size()];
+        double[] xvaluesHigh = new double[ranges.size()];
+        for (int i=0; i<ranges.size(); i++) {
+            double[] tmp = convertUnits(ranges.get(i), xunit);
+            xvaluesLow[i] = tmp[0];
+            xvaluesHigh[i] = tmp[1];
+        }
+        
+        ColumnStarTable ret = ColumnStarTable.makeTableWithRows(ranges.size());
+        ret.addColumn(new SegmentColumn.SegmentDataColumn(Column.Spectral_Error_Low, xvaluesLow));
+        ret.addColumn(new SegmentColumn.SegmentDataColumn(Column.Spectral_Error_High, xvaluesHigh));
+        ret.addColumn(new SegmentColumn.SegmentDataColumn(Column.Spectral_Error_High, yvalues));
+        ret.setName(FITTING_LAYER);
+        
+        return ret;
+    }
+    
+    private static double[] convertUnits(FittingRange r, String xunit) {
+        try {
+            return um.convertX(
+                    new double[] {r.getStartPoint(), r.getEndPoint()},
+                    r.getXUnit().getString(),
+                    xunit);
+        } catch (UnitsException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/FittingRangeModel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/FittingRangeModel.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 Chandra X-Ray Observatory.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package cfa.vo.iris.visualizer.preferences;
 
 import java.util.Arrays;
@@ -8,6 +23,7 @@ import cfa.vo.iris.sed.stil.SegmentColumn;
 import cfa.vo.iris.sed.stil.SegmentColumn.Column;
 import cfa.vo.iris.units.UnitsException;
 import cfa.vo.iris.units.UnitsManager;
+import cfa.vo.iris.visualizer.plotter.ErrorBarType;
 import cfa.vo.utils.Default;
 import uk.ac.starlink.table.ColumnStarTable;
 import uk.ac.starlink.table.StarTable;
@@ -20,7 +36,8 @@ public class FittingRangeModel extends LayerModel {
     public FittingRangeModel(List<FittingRange> ranges, String xunit, double yvalue) {
         super(getFittingRangeTable(ranges, xunit, yvalue));
         this.setShowMarks(false);
-        this.setErrorColor("Red");
+        this.setErrorBarType(ErrorBarType.capped_lines);
+        this.setErrorColor("ff004e");
     }
 
     private static StarTable getFittingRangeTable(List<FittingRange> ranges, String xunit, double yvalue) 
@@ -39,9 +56,10 @@ public class FittingRangeModel extends LayerModel {
         }
         
         ColumnStarTable ret = ColumnStarTable.makeTableWithRows(ranges.size());
+        ret.addColumn(new SegmentColumn.SegmentDataColumn(Column.Spectral_Value, xvaluesLow));
         ret.addColumn(new SegmentColumn.SegmentDataColumn(Column.Spectral_Error_Low, xvaluesLow));
         ret.addColumn(new SegmentColumn.SegmentDataColumn(Column.Spectral_Error_High, xvaluesHigh));
-        ret.addColumn(new SegmentColumn.SegmentDataColumn(Column.Spectral_Error_High, yvalues));
+        ret.addColumn(new SegmentColumn.SegmentDataColumn(Column.Flux_Value, yvalues));
         ret.setName(FITTING_LAYER);
         
         return ret;

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/FittingRangeModel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/FittingRangeModel.java
@@ -59,9 +59,18 @@ public class FittingRangeModel extends LayerModel {
         double[] xmiddles = new double[ranges.size()];
         for (int i=0; i<ranges.size(); i++) {
             double[] tmp = convertUnits(ranges.get(i), xunit);
-            xvaluesLow[i] = tmp[0];
-            xvaluesHigh[i] = tmp[1];
-            xmiddles[i] = (tmp[0] + tmp[1])/2;
+            double low = tmp[0];
+            double high = tmp[1];
+            
+            // May have switched depending on plotter units
+            if (low > high) {
+                low = tmp[1];
+                high = tmp[0];
+            }
+            
+            xvaluesLow[i] = low;
+            xvaluesHigh[i] = high;
+            xmiddles[i] = (low + high)/2;
         }
         
         ColumnStarTable ret = ColumnStarTable.makeTableWithRows(ranges.size());

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/FittingRangeModel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/FittingRangeModel.java
@@ -23,7 +23,7 @@ import cfa.vo.iris.sed.stil.SegmentColumn;
 import cfa.vo.iris.sed.stil.SegmentColumn.Column;
 import cfa.vo.iris.units.UnitsException;
 import cfa.vo.iris.units.UnitsManager;
-import cfa.vo.iris.visualizer.plotter.ErrorBarType;
+import cfa.vo.iris.visualizer.plotter.ShapeType;
 import cfa.vo.utils.Default;
 import uk.ac.starlink.table.ColumnStarTable;
 import uk.ac.starlink.table.StarTable;
@@ -31,13 +31,20 @@ import uk.ac.starlink.table.StarTable;
 public class FittingRangeModel extends LayerModel {
     
     private static final UnitsManager um = Default.getInstance().getUnitsManager();
+    
     private static final String FITTING_LAYER = "Fitting Ranges";
+    private static final String COLOR = "3305ff";
 
     public FittingRangeModel(List<FittingRange> ranges, String xunit, double yvalue) {
         super(getFittingRangeTable(ranges, xunit, yvalue));
-        this.setShowMarks(false);
-        this.setErrorBarType(ErrorBarType.capped_lines);
-        this.setErrorColor("ff004e");
+        
+        // Set Color to Blue
+        this.setMarkColor(COLOR);
+        this.setErrorColor(COLOR);
+        
+        // Actually looks okay
+        this.setMarkType(ShapeType.filled_triangle_up);
+        this.setSize(0);
     }
 
     private static StarTable getFittingRangeTable(List<FittingRange> ranges, String xunit, double yvalue) 
@@ -49,14 +56,16 @@ public class FittingRangeModel extends LayerModel {
         // Get fitting ranges from the range list, converting as we go
         double[] xvaluesLow = new double[ranges.size()];
         double[] xvaluesHigh = new double[ranges.size()];
+        double[] xmiddles = new double[ranges.size()];
         for (int i=0; i<ranges.size(); i++) {
             double[] tmp = convertUnits(ranges.get(i), xunit);
             xvaluesLow[i] = tmp[0];
             xvaluesHigh[i] = tmp[1];
+            xmiddles[i] = (tmp[0] + tmp[1])/2;
         }
         
         ColumnStarTable ret = ColumnStarTable.makeTableWithRows(ranges.size());
-        ret.addColumn(new SegmentColumn.SegmentDataColumn(Column.Spectral_Value, xvaluesLow));
+        ret.addColumn(new SegmentColumn.SegmentDataColumn(Column.Spectral_Value, xmiddles));
         ret.addColumn(new SegmentColumn.SegmentDataColumn(Column.Spectral_Error_Low, xvaluesLow));
         ret.addColumn(new SegmentColumn.SegmentDataColumn(Column.Spectral_Error_High, xvaluesHigh));
         ret.addColumn(new SegmentColumn.SegmentDataColumn(Column.Flux_Value, yvalues));

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/FittingRangeModel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/FittingRangeModel.java
@@ -23,6 +23,7 @@ import cfa.vo.iris.sed.stil.SegmentColumn;
 import cfa.vo.iris.sed.stil.SegmentColumn.Column;
 import cfa.vo.iris.units.UnitsException;
 import cfa.vo.iris.units.UnitsManager;
+import cfa.vo.iris.visualizer.plotter.LayerType;
 import cfa.vo.iris.visualizer.plotter.ShapeType;
 import cfa.vo.utils.Default;
 import uk.ac.starlink.table.ColumnStarTable;
@@ -43,6 +44,7 @@ public class FittingRangeModel extends LayerModel {
         this.setErrorColor(COLOR);
         
         // Actually looks okay
+        this.setLayerType(LayerType.xyerror.name());
         this.setMarkType(ShapeType.filled_triangle_up);
         this.setSize(0);
     }
@@ -68,9 +70,9 @@ public class FittingRangeModel extends LayerModel {
                 high = tmp[0];
             }
             
-            xvaluesLow[i] = low;
-            xvaluesHigh[i] = high;
             xmiddles[i] = (low + high)/2;
+            xvaluesLow[i] = xmiddles[i] - low;
+            xvaluesHigh[i] = high - xmiddles[i];
         }
         
         ColumnStarTable ret = ColumnStarTable.makeTableWithRows(ranges.size());

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/LayerModel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/LayerModel.java
@@ -194,6 +194,8 @@ public class LayerModel {
             prefs.put(COLOR + suffix, markColor);
         if (markColorWeight != null)
             prefs.put(markShading.name + suffix, markColorWeight);
+        if (size != null)
+            prefs.put(SIZE + suffix, size);
         
         addCommonFields(suffix, prefs);
     }
@@ -218,9 +220,6 @@ public class LayerModel {
         // for the legend. set the flux and error layer legened names
         // to the same name
         prefs.put(LEGEND_LABEL + suffix, getLabel());
-        
-        if (size != null)
-            prefs.put(SIZE + suffix, size);
     }
 
     public StarTable getInSource() {

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerDataModel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerDataModel.java
@@ -5,6 +5,7 @@ import java.beans.PropertyChangeSupport;
 import java.util.LinkedList;
 import java.util.List;
 
+import cfa.vo.iris.fitting.FittingRange;
 import cfa.vo.iris.sed.ExtSed;
 import cfa.vo.iris.visualizer.plotter.ColorPalette;
 import cfa.vo.iris.visualizer.plotter.HSVColorPalette;
@@ -58,15 +59,18 @@ public class VisualizerDataModel {
     // Metadata browser
     private List<IrisStarTable> selectedStarTables;
     
-    // Xunits for StarTables
-    private String xUnits = "";
+    // Xunits for StarTables (default to Angstrom)
+    private String xUnits = "Angstrom";
     
-    // Yunits for StarTables
-    private String yUnits = "";
+    // Yunits for StarTables (default to erg cm**(-2) s**(-1) angstrom**(-1))
+    private String yUnits = "erg/s/cm2/Angstrom";
     
     // list of FunctionModels associated with selectedSeds. These tables will be overplotted
     // as solid lines
     private List<FunctionModel> functionModels;
+    
+    // List of fitting ranges corresponding to the fit functions
+    private List<FittingRange> fittingRanges;
     
     private boolean coplotted = false;
     
@@ -175,7 +179,8 @@ public class VisualizerDataModel {
         List<LayerModel> newSedModels = new LinkedList<>();
         List<IrisStarTable> newSedTables = new LinkedList<>();
         StringBuilder dataModelTitle = new StringBuilder();
-        List<FunctionModel> newFunctionModels = new LinkedList<FunctionModel>();
+        List<FunctionModel> newFunctionModels = new LinkedList<>();
+        this.fittingRanges = new LinkedList<>();
         
         Iterator<ExtSed> it = selectedSeds.iterator();
         while (it.hasNext()) {
@@ -207,6 +212,11 @@ public class VisualizerDataModel {
             FunctionModel model = sedModel.getFunctionModel();
             if (model.hasModelValues()) {
                 newFunctionModels.add(model);
+            }
+            
+            // Add fitting ranges, if available AND we are not coplotting
+            if (!coplotted && sed.getFit() != null) {
+                fittingRanges.addAll(sed.getFit().getFittingRanges());
             }
         }
         this.selectedSeds = ObservableCollections.observableList(selectedSeds);
@@ -306,6 +316,10 @@ public class VisualizerDataModel {
     
     public List<FunctionModel> getFunctionModels() {
         return functionModels;
+    }
+    
+    public List<FittingRange> getFittingRanges() {
+        return fittingRanges;
     }
     
     /**

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/plotter/StilPlotterTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/plotter/StilPlotterTest.java
@@ -599,15 +599,15 @@ public class StilPlotterTest extends AbstractUISpecTest {
         layers_.setAccessible(true);
         PlotLayer[] layers = (PlotLayer[]) layers_.get(plot.getPlotDisplay());
         
-        // there should be 1 layer for the FunctionModel
-        assertEquals(1, ArrayUtils.getLength(layers));
+        // there should be 2 layers for the FunctionModel, one for marks and one for errors
+        assertEquals(2, ArrayUtils.getLength(layers));
         
         FittingRangeModel model = plot.fittingRanges;
         StarTable fitStarTable = model.getInSource();
         
         // Validate values, y value should be at 1 + (10 - 1)*.5 = 1.45
         assertEquals(1, fitStarTable.getRowCount());
-        assertArrayEquals(new Object[] {1.0, 1.0, 9.0, 1.45}, fitStarTable.getRow(0));
+        assertArrayEquals(new Object[] {5.0, 1.0, 9.0, 1.9}, fitStarTable.getRow(0));
     }
     
     private StilPlotter setUpTests(ExtSed sed) throws Exception {

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/plotter/StilPlotterTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/plotter/StilPlotterTest.java
@@ -607,7 +607,7 @@ public class StilPlotterTest extends AbstractUISpecTest {
         
         // Validate values, y value should be at 1 + (10 - 1)*.5 = 1.45
         assertEquals(1, fitStarTable.getRowCount());
-        assertArrayEquals(new Object[] {5.0, 1.0, 9.0, 1.9}, fitStarTable.getRow(0));
+        assertArrayEquals(new Object[] {5.0, 4.0, 4.0, 1.9}, fitStarTable.getRow(0));
     }
     
     private StilPlotter setUpTests(ExtSed sed) throws Exception {

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/preferences/FittingModelTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/preferences/FittingModelTest.java
@@ -29,20 +29,19 @@ public class FittingModelTest {
     
     @Test
     public void testFittingModel() throws Exception {
-        FittingRange range1 = new FittingRange(1000, 10, XUnit.NM);
-        FittingRange range2 = new FittingRange(5, 3, XUnit.CM);
+        FittingRange range1 = new FittingRange(10, 1000, XUnit.NM);
+        FittingRange range2 = new FittingRange(3, 5, XUnit.CM);
         
         FittingRangeModel model = new FittingRangeModel(Arrays.asList(range1, range2), "Angstrom", 1);
         
         StarTable table = model.getInSource();
         assertEquals(2, table.getRowCount());
-        assertArrayEquals(new Object[] {5050.0, 10000.0, 100.0, 1.0}, table.getRow(0));
-        assertArrayEquals(new Object[] {4E8, 5E8, 3E8, 1.0}, table.getRow(1));
+        assertArrayEquals(new Object[] {5050.0, 100.0, 10000.0, 1.0}, table.getRow(0));
+        assertArrayEquals(new Object[] {4E8, 3E8, 5E8, 1.0}, table.getRow(1));
         
         assertEquals(2, model.getNumberOfLayers());
         assertFalse(model.getShowLines());
         assertTrue(model.isShowMarks());
         assertTrue(model.isShowErrorBars());
     }
-
 }

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/preferences/FittingModelTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/preferences/FittingModelTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 Chandra X-Ray Observatory.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package cfa.vo.iris.visualizer.preferences;
 
 import java.util.Arrays;
@@ -6,7 +21,7 @@ import org.junit.Test;
 
 import cfa.vo.iris.fitting.FittingRange;
 import cfa.vo.iris.sed.quantities.XUnit;
-import uk.ac.starlink.table.ColumnStarTable;
+import uk.ac.starlink.table.StarTable;
 
 import static org.junit.Assert.*;
 
@@ -19,10 +34,11 @@ public class FittingModelTest {
         
         FittingRangeModel model = new FittingRangeModel(Arrays.asList(range1, range2), "Angstrom", 1);
         
-        ColumnStarTable table = (ColumnStarTable) model.getInSource();
-        assertArrayEquals(new Object[] {10000.0, 100.0, 1.0}, table.getRow(0));
-        assertArrayEquals(new Object[] {5E8, 3E8, 1.0}, table.getRow(1));
+        StarTable table = model.getInSource();
         assertEquals(2, table.getRowCount());
+        System.out.println(Arrays.toString( table.getRow(0)));
+        assertArrayEquals(new Object[] {10000.0, 10000.0, 100.0, 1.0}, table.getRow(0));
+        assertArrayEquals(new Object[] {5E8, 5E8, 3E8, 1.0}, table.getRow(1));
         
         assertEquals(1, model.getNumberOfLayers());
         assertFalse(model.isShowMarks());

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/preferences/FittingModelTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/preferences/FittingModelTest.java
@@ -36,8 +36,8 @@ public class FittingModelTest {
         
         StarTable table = model.getInSource();
         assertEquals(2, table.getRowCount());
-        assertArrayEquals(new Object[] {5050.0, 100.0, 10000.0, 1.0}, table.getRow(0));
-        assertArrayEquals(new Object[] {4E8, 3E8, 5E8, 1.0}, table.getRow(1));
+        assertArrayEquals(new Object[] {5050.0, 4950.0, 4950.0, 1.0}, table.getRow(0));
+        assertArrayEquals(new Object[] {4.0E8, 1.0E8, 1.0E8, 1.0}, table.getRow(1));
         
         assertEquals(2, model.getNumberOfLayers());
         assertFalse(model.getShowLines());

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/preferences/FittingModelTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/preferences/FittingModelTest.java
@@ -1,0 +1,33 @@
+package cfa.vo.iris.visualizer.preferences;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import cfa.vo.iris.fitting.FittingRange;
+import cfa.vo.iris.sed.quantities.XUnit;
+import uk.ac.starlink.table.ColumnStarTable;
+
+import static org.junit.Assert.*;
+
+public class FittingModelTest {
+    
+    @Test
+    public void testFittingModel() throws Exception {
+        FittingRange range1 = new FittingRange(1000, 10, XUnit.NM);
+        FittingRange range2 = new FittingRange(5, 3, XUnit.CM);
+        
+        FittingRangeModel model = new FittingRangeModel(Arrays.asList(range1, range2), "Angstrom", 1);
+        
+        ColumnStarTable table = (ColumnStarTable) model.getInSource();
+        assertArrayEquals(new Object[] {10000.0, 100.0, 1.0}, table.getRow(0));
+        assertArrayEquals(new Object[] {5E8, 3E8, 1.0}, table.getRow(1));
+        assertEquals(2, table.getRowCount());
+        
+        assertEquals(1, model.getNumberOfLayers());
+        assertFalse(model.isShowMarks());
+        assertFalse(model.getShowLines());
+        assertTrue(model.isShowErrorBars());
+    }
+
+}

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/preferences/FittingModelTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/preferences/FittingModelTest.java
@@ -36,13 +36,12 @@ public class FittingModelTest {
         
         StarTable table = model.getInSource();
         assertEquals(2, table.getRowCount());
-        System.out.println(Arrays.toString( table.getRow(0)));
-        assertArrayEquals(new Object[] {10000.0, 10000.0, 100.0, 1.0}, table.getRow(0));
-        assertArrayEquals(new Object[] {5E8, 5E8, 3E8, 1.0}, table.getRow(1));
+        assertArrayEquals(new Object[] {5050.0, 10000.0, 100.0, 1.0}, table.getRow(0));
+        assertArrayEquals(new Object[] {4E8, 5E8, 3E8, 1.0}, table.getRow(1));
         
-        assertEquals(1, model.getNumberOfLayers());
-        assertFalse(model.isShowMarks());
+        assertEquals(2, model.getNumberOfLayers());
         assertFalse(model.getShowLines());
+        assertTrue(model.isShowMarks());
         assertTrue(model.isShowErrorBars());
     }
 


### PR DESCRIPTION
Opening against #311 since this includes all of those changes.

Plots fitting ranges as a new layer in the stil plotter. There's a significant TODO in the StilPlotter's construction of the plot display, in that we don't have access to the aspect's bounds prior to constructing a plot, so we just do it twice, if necessary. This keeps the fitting ranges from affecting the default view ranges on the plotter.

Ranges are always plotted at 10% from the y-axis minimum.