### PR TITLE
Fix plotted model units conversion

### DIFF
--- a/iris-common/src/main/java/cfa/vo/iris/sed/stil/SegmentStarTable.java
+++ b/iris-common/src/main/java/cfa/vo/iris/sed/stil/SegmentStarTable.java
@@ -25,6 +25,7 @@ import java.util.TreeSet;
 import java.util.UUID;
 
 import cfa.vo.iris.sed.ExtSed;
+import cfa.vo.sherpa.SherpaClient;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.HashCodeBuilder;
@@ -310,6 +311,10 @@ public class SegmentStarTable extends RandomStarTable implements IrisDataStarTab
         setFluxErrValues(units.convertErrors(getOriginalFluxErrValues(), getOriginalFluxValues(), specValues, originalFluxUnits, specUnits, newUnit));
         setFluxErrValuesLo(units.convertErrors(getOriginalFluxErrValuesLo(), getOriginalFluxValues(), specValues, originalFluxUnits, specUnits, newUnit));
         setFluxErrValuesHi(units.convertErrors(getOriginalFluxErrValuesHi(), getOriginalFluxValues(), specValues, originalFluxUnits, specUnits, newUnit));
+
+        if(modelValues != null) {
+            setModelValues(units.convertY(modelValues, specValues, fluxUnits, specUnits, newUnit));
+        }
         
         fluxUnits = newUnit;
         

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FitController.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FitController.java
@@ -255,7 +255,7 @@ public class FitController {
             double[] x = table.getSpecValues();
             double[] xStandardUnit = uManager.convertX(x, xUnit, SherpaClient.X_UNIT);
             double[] yStandardUnit = client.evaluate(xStandardUnit, sedModel.getFit());
-            double[] y = Default.getInstance().getUnitsManager().convertY(yStandardUnit, xStandardUnit,
+            double[] y = uManager.convertY(yStandardUnit, xStandardUnit,
                     SherpaClient.Y_UNIT, SherpaClient.X_UNIT, yUnit);
 
             table.setModelValues(y);

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/plotter/StilPlotterTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/plotter/StilPlotterTest.java
@@ -18,6 +18,7 @@ package cfa.vo.iris.visualizer.plotter;
 import cfa.vo.iris.visualizer.plotter.StilPlotter;
 import static org.junit.Assert.*;
 import cfa.vo.iris.sed.ExtSed;
+import cfa.vo.iris.sed.quantities.XUnit;
 import cfa.vo.iris.test.Ws;
 import cfa.vo.iris.visualizer.plotter.PlotPreferences.PlotType;
 import cfa.vo.iris.test.unit.AbstractUISpecTest;
@@ -375,6 +376,12 @@ public class StilPlotterTest extends AbstractUISpecTest {
         // there should be 1 layer for residuals
         assertTrue(!ArrayUtils.isEmpty(layers));
         assertEquals(1, ArrayUtils.getLength(layers));
+        
+        // now, change the units on the plotter and verify the model units change
+        plot.getDataModel().setUnits("Angstrom", "mJy");
+        for (int i=0; i<seg.getLength(); i++) {
+            assertNotEquals(seg.getFluxAxisValues()[i], model.getDataTables().get(0).getPlotterDataTable().getModelValues()[i]);
+        }
     }
     
     @Test


### PR DESCRIPTION
# Description

Fixes ChandraCXC/iris-dev#113 - bug in model plotting units conversion

The model units in the VisualizerDataModel weren't being updated with the rest of the data on the plotter. Now, the model values are converted to the plotter units along with the segment data in `SegmentStarTable.setFluxUnits()`.