### PR TITLE
Fix Assorted Bugs

### DIFF
--- a/iris-common/src/main/java/cfa/vo/iris/sed/stil/SegmentStarTable.java
+++ b/iris-common/src/main/java/cfa/vo/iris/sed/stil/SegmentStarTable.java
@@ -25,7 +25,6 @@ import java.util.TreeSet;
 import java.util.UUID;
 
 import cfa.vo.iris.sed.ExtSed;
-import cfa.vo.sherpa.SherpaClient;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.HashCodeBuilder;
@@ -485,6 +484,10 @@ public class SegmentStarTable extends RandomStarTable implements IrisDataStarTab
 
     public void setModelValues(double[] modelValues) {
         this.modelValues = modelValues;
+        
+        setRatioValues(calcRatios(getFluxValues(), modelValues));
+        setResidualValues(calcResiduals(getFluxValues(), modelValues));
+        
         updateColumnValues(modelValues, Column.Model_Values);
     }
 
@@ -492,7 +495,10 @@ public class SegmentStarTable extends RandomStarTable implements IrisDataStarTab
         return residualValues;
     }
 
-    public void setResidualValues(double[] residualValues) {
+    /**
+     * Private as these are tied to model values.
+     */
+    private void setResidualValues(double[] residualValues) {
         this.residualValues = residualValues;
         updateColumnValues(residualValues, Column.Residuals);
     }
@@ -500,10 +506,46 @@ public class SegmentStarTable extends RandomStarTable implements IrisDataStarTab
     public double[] getRatioValues() {
         return ratioValues;
     }
-
-    public void setRatioValues(double[] ratioValues) {
+    
+    /**
+     * Private as these are tied to model values.
+     */
+    private void setRatioValues(double[] ratioValues) {
         this.ratioValues = ratioValues;
         updateColumnValues(ratioValues, Column.Ratios);
+    }
+
+    private double[] calcResiduals(double[] expected, double[] actual) {
+        int len = expected.length;
+
+        if (len != actual.length) {
+            throw new IllegalArgumentException("Expected and Actual array should have the same size");
+        }
+
+        double[] ret = new double[len];
+
+        for (int i=0; i<len; i++) {
+            ret[i] = actual[i] - expected[i];
+        }
+
+        return ret;
+    }
+
+    private double[] calcRatios(double[] expected, double[] actual) {
+        int len = expected.length;
+
+        if (len != actual.length) {
+            throw new IllegalArgumentException("Expected and Actual array should have the same size");
+        }
+
+        double[] ret = new double[len];
+
+        for (int i=0; i<len; i++) {
+            double e = expected[i];
+            ret[i] = Math.abs(e - actual[i])/e;
+        }
+
+        return ret;
     }
     
     /**

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FitController.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FitController.java
@@ -259,41 +259,6 @@ public class FitController {
                     SherpaClient.Y_UNIT, SherpaClient.X_UNIT, yUnit);
 
             table.setModelValues(y);
-            table.setResidualValues(calcResiduals(table.getFluxValues(), y));
-            table.setRatioValues(calcRatios(table.getFluxValues(), y));
         }
-    }
-
-    private double[] calcResiduals(double[] expected, double[] actual) {
-        int len = expected.length;
-
-        if (len != actual.length) {
-            throw new IllegalArgumentException("Expected and Actual array should have the same size");
-        }
-
-        double[] ret = new double[len];
-
-        for (int i=0; i<len; i++) {
-            ret[i] = actual[i] - expected[i];
-        }
-
-        return ret;
-    }
-
-    private double[] calcRatios(double[] expected, double[] actual) {
-        int len = expected.length;
-
-        if (len != actual.length) {
-            throw new IllegalArgumentException("Expected and Actual array should have the same size");
-        }
-
-        double[] ret = new double[len];
-
-        for (int i=0; i<len; i++) {
-            double e = expected[i];
-            ret[i] = Math.abs(e - actual[i])/e;
-        }
-
-        return ret;
     }
 }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/IrisStarJTable.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/IrisStarJTable.java
@@ -36,6 +36,7 @@ import javax.swing.table.TableRowSorter;
 
 import java.awt.Rectangle;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 
@@ -406,17 +407,16 @@ public class IrisStarJTable extends StarJTable {
     {
         List<SortKey> newKeys = new ArrayList<>(1);
         
-        if (keys.size() == 0) {
+        if (CollectionUtils.isEmpty(keys)) {
             return newKeys;
         }
         
-        ColumnIdentifier id = new ColumnIdentifier(getStarTable());
-
         // Primary key
         SortKey key = keys.get(0);
         ColumnInfo info = oldTable.getColumnInfo(key.getColumn() - 1);
         
-        // Is the new key in the current star table?
+        // Is the new key in the current star table?        
+        ColumnIdentifier id = new ColumnIdentifier(newTable);
         int newCol = 1; // Starts at 1 because of the index column
         try {
             newCol += id.getColumnIndex(info.getName());

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.form
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.form
@@ -18,33 +18,6 @@
                 <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="extractToSedMenuItemActionPerformed"/>
               </Events>
             </MenuItem>
-            <MenuItem class="javax.swing.JMenuItem" name="broadcastToSampMenuItem">
-              <Properties>
-                <Property name="text" type="java.lang.String" value="Broadcast to SAMP"/>
-              </Properties>
-            </MenuItem>
-            <MenuItem class="javax.swing.JMenuItem" name="createSubsetMenuItem">
-              <Properties>
-                <Property name="text" type="java.lang.String" value="Create Subset"/>
-              </Properties>
-            </MenuItem>
-          </SubComponents>
-        </Menu>
-        <Menu class="javax.swing.JMenu" name="editMenu">
-          <Properties>
-            <Property name="text" type="java.lang.String" value="Edit"/>
-          </Properties>
-          <SubComponents>
-            <MenuItem class="javax.swing.JMenuItem" name="createNewColumnMenuItem">
-              <Properties>
-                <Property name="text" type="java.lang.String" value="Create New Column"/>
-              </Properties>
-            </MenuItem>
-            <MenuItem class="javax.swing.JMenuItem" name="restoreSetMenuItem">
-              <Properties>
-                <Property name="text" type="java.lang.String" value="Restore Set"/>
-              </Properties>
-            </MenuItem>
           </SubComponents>
         </Menu>
         <Menu class="javax.swing.JMenu" name="selectMenu">

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.java
@@ -124,8 +124,6 @@ public class MetadataBrowserMainView extends javax.swing.JInternalFrame {
      * Forces plotter and point tables to redraw themselves by manually resetting the models.
      */
     private void resetDataTables() {
-        plotterStarJTable.setSelectedStarTables(dataModel.getSelectedStarTables());
-        pointStarJTable.setSelectedStarTables(dataModel.getSelectedStarTables());
         dataModel.refresh();
     }
     

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.java
@@ -174,11 +174,6 @@ public class MetadataBrowserMainView extends javax.swing.JInternalFrame {
         jMenuBar1 = new javax.swing.JMenuBar();
         fileMenu = new javax.swing.JMenu();
         extractToSedMenuItem = new javax.swing.JMenuItem();
-        broadcastToSampMenuItem = new javax.swing.JMenuItem();
-        createSubsetMenuItem = new javax.swing.JMenuItem();
-        editMenu = new javax.swing.JMenu();
-        createNewColumnMenuItem = new javax.swing.JMenuItem();
-        restoreSetMenuItem = new javax.swing.JMenuItem();
         selectMenu = new javax.swing.JMenu();
         selectAllMenuItem = new javax.swing.JMenuItem();
         clearSelectionMenuItem = new javax.swing.JMenuItem();
@@ -461,23 +456,7 @@ public class MetadataBrowserMainView extends javax.swing.JInternalFrame {
         });
         fileMenu.add(extractToSedMenuItem);
 
-        broadcastToSampMenuItem.setText("Broadcast to SAMP");
-        fileMenu.add(broadcastToSampMenuItem);
-
-        createSubsetMenuItem.setText("Create Subset");
-        fileMenu.add(createSubsetMenuItem);
-
         jMenuBar1.add(fileMenu);
-
-        editMenu.setText("Edit");
-
-        createNewColumnMenuItem.setText("Create New Column");
-        editMenu.add(createNewColumnMenuItem);
-
-        restoreSetMenuItem.setText("Restore Set");
-        editMenu.add(restoreSetMenuItem);
-
-        jMenuBar1.add(editMenu);
 
         selectMenu.setText("Select");
         selectMenu.setName(""); // NOI18N
@@ -639,17 +618,13 @@ public class MetadataBrowserMainView extends javax.swing.JInternalFrame {
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JButton applyMaskButton;
     private javax.swing.JMenuItem applyMaskMenuItem;
-    private javax.swing.JMenuItem broadcastToSampMenuItem;
     private javax.swing.JButton clearAllButton;
     private javax.swing.JMenuItem clearAllMenuItem;
     private javax.swing.JButton clearMaskButton;
     private javax.swing.JButton clearSelectionButton;
     private javax.swing.JMenuItem clearSelectionMenuItem;
-    private javax.swing.JMenuItem createNewColumnMenuItem;
-    private javax.swing.JMenuItem createSubsetMenuItem;
     private javax.swing.JSplitPane dataPane;
     private javax.swing.JTabbedPane dataTabsPane;
-    private javax.swing.JMenu editMenu;
     private javax.swing.JButton extractButton;
     private javax.swing.JMenuItem extractToSedMenuItem;
     private javax.swing.JMenu fileMenu;
@@ -665,7 +640,6 @@ public class MetadataBrowserMainView extends javax.swing.JInternalFrame {
     private javax.swing.JScrollPane pointMetadataScrollPane;
     private cfa.vo.iris.visualizer.metadata.IrisStarJTable pointStarJTable;
     private javax.swing.JMenuItem removeMasksMenuItem;
-    private javax.swing.JMenuItem restoreSetMenuItem;
     private javax.swing.JPanel segmentMetadataPanel;
     private javax.swing.JScrollPane segmentMetadataScrollPane;
     private javax.swing.JButton selectAllButton;

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotPreferences.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotPreferences.java
@@ -123,8 +123,8 @@ public class PlotPreferences {
         pp.setLegendBorder(true);
         pp.setAspect(aspect);
         pp.setErrorBarType(ErrorBarType.capped_lines);
-        pp.setMarkType(ShapeType.open_circle);
-        pp.setSize(4);
+        pp.setMarkType(ShapeType.filled_diamond);
+        pp.setSize(2);
         
         return pp;
     }
@@ -434,7 +434,7 @@ public class PlotPreferences {
     protected void setSize(Integer size) {
         Integer old = getSize();
         preferences.put(SIZE, size);
-        pcs.firePropertyChange(PROP_LEGEND_BORDER, old, size);
+        pcs.firePropertyChange(PROP_MARK_SIZE, old, size);
     }
     
     /**

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
@@ -192,8 +192,9 @@ public class PlotterView extends JInternalFrame {
         this.mntmXlog.setSelected(plotPreferences.getPlotType()==PlotType.X_LOG);
         this.mntmYlog.setSelected(plotPreferences.getPlotType()==PlotType.Y_LOG);
         
-        // Grid on/off
+        // Grid and legend on/off
         this.mntmGridOnOff.setSelected(plotPreferences.getShowGrid());
+        this.showLegendCheckBox.setSelected(plotPreferences.getShowLegend());
         
         // turn errorbars on/off
 //        this.mntmErrorBars.setSelected(this.stilPlotter1.getVisualizerPreferences()
@@ -201,7 +202,6 @@ public class PlotterView extends JInternalFrame {
 //                .getShowErrorBars());
         
         // set plot window fixed
-        
         this.mntmAutoFixed.setSelected(plotPreferences.getFixed());
     }
 

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/StilPlotter.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/StilPlotter.java
@@ -203,6 +203,9 @@ public class StilPlotter extends JPanel {
      * @param plotType the plot type to use.
      */
     public void setPlotType(PlotPreferences.PlotType plotType) {
+        // Don't reset if value isn't changed
+        if (getPlotPreferences().getPlotType().equals(plotType)) return;
+        
         getPlotPreferences().setPlotType(plotType);
         resetPlot(false, false);
     }
@@ -212,6 +215,9 @@ public class StilPlotter extends JPanel {
     }
     
     public void setGridOn(boolean on) {
+        // Don't reset if value isn't changed
+        if (on == getGridOn()) return;
+        
         getPlotPreferences().setShowGrid(on);
         resetPlot(false, false);
     }
@@ -221,6 +227,9 @@ public class StilPlotter extends JPanel {
     }
     
     public void setShowLegend(boolean on) {
+        // Don't reset if value isn't changed
+        if (on == getShowLegend()) return;
+        
         // Fix the plot between showing legends
         boolean isFixed = getPlotPreferences().getFixed();
         getPlotPreferences().setFixed(true);

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/StilPlotter.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/StilPlotter.java
@@ -504,11 +504,8 @@ public class StilPlotter extends JPanel {
         // Do nothing if none are available
         if (CollectionUtils.isEmpty(ranges)) return display;
         
-        // Otherwise add the layer at 10% of the current aspect
-        PlaneAspect aspect = display.getAspect();
-        double min = Math.min(aspect.getYMin(), aspect.getYMax());
-        double max = Math.max(aspect.getYMin(), aspect.getYMax());
-        double y = min + ((max - min) * .1);
+        // Compute appropriate y-value for fit ranges
+        double y = computeFittingLocation(display.getAspect(), getPlotPreferences().getYlog());
         
         // Construct the model for the fitting ranges and add it to the plot
         fittingRanges = new FittingRangeModel(ranges, dataModel.getXunits(), y);
@@ -690,5 +687,22 @@ public class StilPlotter extends JPanel {
         
         display.revalidate();
         display.repaint();
+    }
+
+    static double computeFittingLocation(PlaneAspect aspect, boolean isLog) {
+        double min = Math.min(aspect.getYMin(), aspect.getYMax());
+        double max = Math.max(aspect.getYMin(), aspect.getYMax());
+        
+        // Put the layer at about 10% from the bottom of the plot for both linear and
+        // log scaled plots.
+        double y;
+        if (isLog) {
+            double exp = Math.log10(min) + ((Math.log10(max) - Math.log10(min)) * .1);
+            y = Math.pow(10, exp);
+        } else {
+            y = min + ((max - min) * .1);
+        }
+        
+        return y;
     }
 }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/FittingRangeModel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/FittingRangeModel.java
@@ -33,8 +33,8 @@ public class FittingRangeModel extends LayerModel {
     
     private static final UnitsManager um = Default.getInstance().getUnitsManager();
     
-    private static final String FITTING_LAYER = "Fitting Ranges";
-    private static final String COLOR = "3305ff";
+    public static final String FITTING_LAYER = "Fitting Ranges";
+    public static final String COLOR = "3305ff";
 
     public FittingRangeModel(List<FittingRange> ranges, String xunit, double yvalue) {
         super(getFittingRangeTable(ranges, xunit, yvalue));

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/LayerModel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/LayerModel.java
@@ -76,6 +76,7 @@ public class LayerModel {
     private ErrorBarType errorBarType;
     private ShapeType markType;
     private Integer size;
+    private Integer errorSize;
     private ShadingType markShading;
     private ShadingType errorShading;
     private String markColor;
@@ -101,6 +102,8 @@ public class LayerModel {
         this.xColName = SegmentColumn.Column.Spectral_Value.name();
         this.yColName = SegmentColumn.Column.Flux_Value.name();
         
+        // By default error sizes are larger than point sizes
+        this.errorSize = 5;
         this.showErrorBars = true;
         this.showMarks = true;
         this.showLine = false;
@@ -180,6 +183,9 @@ public class LayerModel {
             prefs.put(COLOR + suffix, errorColor);
         if (errorColorWeight != null)
             prefs.put(errorShading.name + suffix, errorColorWeight);
+        if (errorSize != null) {
+            prefs.put(SIZE + suffix, errorSize);
+        }
         
         addCommonFields(suffix, prefs);
     }
@@ -316,6 +322,15 @@ public class LayerModel {
 
     public LayerModel setSize(int size) {
         this.size = size;
+        return this;
+    }
+
+    public Integer getErrorSize() {
+        return errorSize;
+    }
+
+    public LayerModel setErrorSize(Integer errorSize) {
+        this.errorSize = errorSize;
         return this;
     }
 

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedModel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedModel.java
@@ -239,26 +239,14 @@ public class SedModel {
             return false;
         }
         
+        // Construct LayerModel
         IrisStarTable newTable = convertSegment(seg, null);
-
-        // Ensure that the layer has a unique identifier in the list of segments
         LayerModel layer = new LayerModel(newTable);
-        int count = 0;
-        String id = layer.getSuffix();
-        while (!isUniqueLayerSuffix(id)) {
-            count++;
-            id = layer.getSuffix() + " " + count;
-        }
-        layer.setSuffix(id);
-        newTable.setName(id);
         
         // add colors to segment layer
         String hexColor = ColorPalette.colorToHex(colors.getNextColor());
         layer.setErrorColor(hexColor);
         layer.setMarkColor(hexColor);
-        
-        // update legend settings
-        layer.setLabel(id);
         
         // set the units
         setUnits(seg, newTable);

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedModel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedModel.java
@@ -112,7 +112,7 @@ public class SedModel {
      */
     public FunctionModel getFunctionModel() {
         // TODO: Only return a model if this SedModel has been fitted.
-        StarTable table = new StackedStarTable(getDataTables(), new SegmentColumnInfoMatcher());
+        StarTable table = new StackedStarTable(getIrisDataTables(true), new SegmentColumnInfoMatcher());
         table.setName(sed.getId());
         
         return new FunctionModel(table);

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerDataModel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerDataModel.java
@@ -4,6 +4,7 @@ import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 
 import cfa.vo.iris.fitting.FittingRange;
 import cfa.vo.iris.sed.ExtSed;
@@ -15,11 +16,11 @@ import cfa.vo.iris.visualizer.stil.tables.IrisStarTable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
-import org.jdesktop.observablecollections.ObservableCollections;
 
 /**
  * Dynamic model for the plotter and metadata browser. Maintains the current state
@@ -225,7 +226,7 @@ public class VisualizerDataModel {
             // Add data from the sedModel
             newSedTables.addAll(sedModel.getDataTables());
         }
-        this.selectedSeds = ObservableCollections.observableList(selectedSeds);
+        this.selectedSeds = selectedSeds;
         
         // Update units and colors
         updateUnits();
@@ -295,8 +296,29 @@ public class VisualizerDataModel {
     // Locked down since these are tied to the selected seds
     synchronized void setLayerModels(List<LayerModel> newModels) {
         List<LayerModel> oldModels = this.layerModels;
-        this.layerModels = ObservableCollections.observableList(newModels);
+        
+        // Verify unique suffixes for the models
+        Set<String> labels = new HashSet<>();
+        for (LayerModel model : newModels) {
+            verifyUniqueLayerSuffix(model, labels);
+        }
+        
+        this.layerModels = newModels;
         pcs.firePropertyChange(PROP_LAYER_MODELS, oldModels, layerModels);
+    }
+    
+    private void verifyUniqueLayerSuffix(LayerModel model, Set<String> labels) {
+        String id = model.getSuffix();
+        
+        int count = 0;
+        while (labels.contains(id)) {
+            count++;
+            id = model.getSuffix() + " " + count;
+        }
+        
+        model.getInSource().setName(id);
+        model.setSuffix(id);
+        labels.add(id);
     }
     
     public List<IrisStarTable> getSedStarTables() {
@@ -306,7 +328,7 @@ public class VisualizerDataModel {
     // Locked down since these are tied to the selected seds
     synchronized void setSedStarTables(List<IrisStarTable> newTables) {
         List<IrisStarTable> oldTables = sedStarTables;
-        this.sedStarTables = ObservableCollections.observableList(newTables);
+        this.sedStarTables = newTables;
         pcs.firePropertyChange(PROP_SED_STARTABLES, oldTables, sedStarTables);
     }
     
@@ -316,7 +338,7 @@ public class VisualizerDataModel {
 
     public synchronized void setSelectedStarTables(List<IrisStarTable> newStarTables) {
         List<IrisStarTable> oldStarTables = selectedStarTables;
-        this.selectedStarTables = ObservableCollections.observableList(newStarTables);
+        this.selectedStarTables = newStarTables;
         pcs.firePropertyChange(PROP_SELECTED_STARTABLES, oldStarTables, selectedStarTables);
     }
     
@@ -333,7 +355,7 @@ public class VisualizerDataModel {
      */
     private synchronized void setFunctionModels(List<FunctionModel> newFunctionModels) {
         List<FunctionModel> oldFunctionModels = functionModels;
-        this.functionModels = ObservableCollections.observableList(newFunctionModels);
+        this.functionModels = newFunctionModels;
         pcs.firePropertyChange(PROP_FUNCTION_MODELS, oldFunctionModels, functionModels);
     }
 
@@ -341,13 +363,7 @@ public class VisualizerDataModel {
         // This is a total cop-out. Just clear all existing preferences and reset
         // with the new selected SED.
         List<ExtSed> oldSeds = this.selectedSeds;
-        
         this.setSelectedSeds(new LinkedList<ExtSed>());
-        this.setLayerModels(new LinkedList<LayerModel>());
-        this.setSedStarTables(new LinkedList<IrisStarTable>());
-        this.setSelectedStarTables(new LinkedList<IrisStarTable>());
-        this.setFunctionModels(new LinkedList<FunctionModel>());
-        
         setSelectedSeds(oldSeds);
     }
     

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerDataModel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerDataModel.java
@@ -194,12 +194,15 @@ public class VisualizerDataModel {
             
             // Add models to the SED
             SedModel sedModel = store.getSedModel(sed);
-            newSedTables.addAll(sedModel.getDataTables());
             dataModelTitle.append(sed.getId() + " ");
-
-            // For coplotting we plot the entire SED as a single layer
+            
+            // For coplotting we plot the entire SED as a single layer, do not add layers
+            // for SEDs with no segments
             if (coplotted) {
-                newSedModels.add(sedModel.getSedLayerModel());
+                // Only add LayerModels if they have data available
+                if (sed.getNumberOfSegments() > 0) {
+                    newSedModels.add(sedModel.getSedLayerModel());
+                }
             }
             // Otherwise we add a single layer for each corresponding segment
             else {
@@ -218,6 +221,9 @@ public class VisualizerDataModel {
             if (!coplotted && sed.getFit() != null) {
                 fittingRanges.addAll(sed.getFit().getFittingRanges());
             }
+            
+            // Add data from the sedModel
+            newSedTables.addAll(sedModel.getDataTables());
         }
         this.selectedSeds = ObservableCollections.observableList(selectedSeds);
         

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/metadata/IrisStarJTableTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/metadata/IrisStarJTableTest.java
@@ -279,4 +279,36 @@ public class IrisStarJTableTest {
         table.setSelectedStarTables(Arrays.asList(segTable1, segTable2));
         assertEquals(300.0, table.getValueAt(0, 3));
     }
+    
+    @Test
+    public void testRowSortErrorLastCol() throws Exception {
+        IrisStarJTable table = new IrisStarJTable();
+        table.setSortBySpecValues(true);
+        table.setUsePlotterDataTables(true);
+        
+        // Create Segment
+        IrisStarTable segTable = adapter.convertSegment(TestUtils.createSampleSegment(
+                new double[] {1,2,3}, new double[] {4,5,6}));
+        table.setSelectedStarTables(Arrays.asList(segTable));
+        
+        // Sort by Original Flux Value (last column)
+        table.getRowSorter().setSortKeys(Arrays.asList(new RowSorter.SortKey(4, SortOrder.DESCENDING)));
+        
+        // Verify table values
+        assertEquals(3.0, table.getValueAt(0, 2));
+        assertEquals(2.0, table.getValueAt(1, 2));
+        assertEquals(1.0, table.getValueAt(2, 2));
+        
+        // Apply a mask
+        segTable.applyMasks(new int[] {0});
+        
+        // Resetting should preserve sort order
+        table.setSelectedStarTables(Arrays.asList(segTable));
+        
+        // Verify table values
+        assertEquals(false, table.getValueAt(0, 1));
+        assertEquals(false, table.getValueAt(1, 1));
+        assertEquals(true, table.getValueAt(2, 1));
+        table.setSelectedStarTables(Arrays.asList(segTable));
+    }
 }

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainViewTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainViewTest.java
@@ -317,7 +317,7 @@ public class MetadataBrowserMainViewTest extends AbstractUISpecTest {
         dataStore.update(sed);
         dataModel.setSelectedSed(sed);
         
-        invokeWithRetry(20, 100, new Runnable() {
+        invokeWithRetry(50, 100, new Runnable() {
             @Override
             public void run() {
                 assertEquals(mbView.getTitle(), mbWindow.getTitle());
@@ -338,7 +338,7 @@ public class MetadataBrowserMainViewTest extends AbstractUISpecTest {
         mbView.addRowToSelection(0, 2);
         mbWindow.getButton("Mask Points").click();
         
-        invokeWithRetry(20, 100, new Runnable() {
+        invokeWithRetry(50, 100, new Runnable() {
             @Override
             public void run() {
                 IrisStarTable table = mbView.getDataModel().getSelectedStarTables().get(0);
@@ -351,7 +351,7 @@ public class MetadataBrowserMainViewTest extends AbstractUISpecTest {
         masked.set(0, plotterTable.getRowCount());
         mbWindow.getButton("Mask Points").click();
         
-        invokeWithRetry(20, 100, new Runnable() {
+        invokeWithRetry(50, 100, new Runnable() {
             @Override
             public void run() {
                 IrisStarTable table = mbView.getDataModel().getSelectedStarTables().get(0);

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/plotter/StilPlotterTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/plotter/StilPlotterTest.java
@@ -24,7 +24,6 @@ import cfa.vo.iris.sed.ExtSed;
 import cfa.vo.iris.sed.quantities.XUnit;
 import cfa.vo.iris.test.Ws;
 import cfa.vo.iris.visualizer.plotter.PlotPreferences.PlotType;
-import cfa.vo.iris.test.unit.AbstractUISpecTest;
 import cfa.vo.iris.test.unit.TestUtils;
 import cfa.vo.iris.visualizer.plotter.PlotterView;
 import cfa.vo.iris.visualizer.preferences.FittingRangeModel;
@@ -45,6 +44,7 @@ import org.apache.commons.lang.StringUtils;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.uispec4j.Trigger;
+import org.uispec4j.UISpec4J;
 import org.uispec4j.Window;
 import org.uispec4j.interception.WindowHandler;
 import org.uispec4j.interception.WindowInterceptor;
@@ -60,7 +60,11 @@ import uk.ac.starlink.table.StarTable;
 import uk.ac.starlink.task.BooleanParameter;
 import uk.ac.starlink.ttools.plot2.geom.PlaneSurfaceFactory;
 
-public class StilPlotterTest extends AbstractUISpecTest {
+public class StilPlotterTest {
+    
+    static {
+        UISpec4J.init();
+    }
     
     private Ws ws = new Ws();
     private VisualizerComponentPreferences preferences;
@@ -603,7 +607,7 @@ public class StilPlotterTest extends AbstractUISpecTest {
             @Override
             public void run() {
                 assertTrue(plot.fittingRanges != null);
-                assertTrue(plot.fittingRanges.getSize() == 1);
+                assertEquals(FittingRangeModel.FITTING_LAYER, plot.fittingRanges.getInSource().getName());
             }
         });
 

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/plotter/StilPlotterTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/plotter/StilPlotterTest.java
@@ -329,8 +329,6 @@ public class StilPlotterTest {
         
         SedModel model = plot.getDataModel().getSedModel(sed);
         model.getDataTables().get(0).getPlotterDataTable().setModelValues(seg.getFluxAxisValues());
-        model.getDataTables().get(0).getPlotterDataTable().setRatioValues(seg.getSpectralAxisValues());
-        model.getDataTables().get(0).getPlotterDataTable().setResidualValues(seg.getSpectralAxisValues());
         plot.getDataModel().refresh();
         
         FunctionModel functionModel = model.getFunctionModel();
@@ -414,13 +412,9 @@ public class StilPlotterTest {
         // Add model functions
         SedModel model1 = plot.getDataModel().getSedModel(sed1);
         model1.getDataTables().get(0).getPlotterDataTable().setModelValues(seg1.getFluxAxisValues());
-        model1.getDataTables().get(0).getPlotterDataTable().setRatioValues(seg1.getSpectralAxisValues());
-        model1.getDataTables().get(0).getPlotterDataTable().setResidualValues(seg1.getSpectralAxisValues());
         
         SedModel model2 = plot.getDataModel().getSedModel(sed2);
         model2.getDataTables().get(0).getPlotterDataTable().setModelValues(seg2.getFluxAxisValues());
-        model2.getDataTables().get(0).getPlotterDataTable().setRatioValues(seg2.getSpectralAxisValues());
-        model2.getDataTables().get(0).getPlotterDataTable().setResidualValues(seg2.getSpectralAxisValues());
         
         // Refresh the plotter
         plot.getDataModel().refresh();
@@ -485,8 +479,6 @@ public class StilPlotterTest {
         // Add model function to SED
         SedModel model = plot.getDataModel().getSedModel(sed1);
         model.getDataTables().get(0).getPlotterDataTable().setModelValues(seg1.getFluxAxisValues());
-        model.getDataTables().get(0).getPlotterDataTable().setRatioValues(seg1.getSpectralAxisValues());
-        model.getDataTables().get(0).getPlotterDataTable().setResidualValues(seg1.getSpectralAxisValues());
         
         // SedModel now has a version
         model.setModelVersion(model.getVersion());

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/plotter/StilPlotterTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/plotter/StilPlotterTest.java
@@ -599,13 +599,14 @@ public class StilPlotterTest extends AbstractUISpecTest {
         plot.setSeds(Arrays.asList(sed));
         plot.resetPlot(false, false);
         
-        TestUtils.invokeWithRetry(50, 100, new Runnable() {
+        TestUtils.invokeWithRetry(100, 100, new Runnable() {
             @Override
             public void run() {
                 assertTrue(plot.fittingRanges != null);
+                assertTrue(plot.fittingRanges.getSize() == 1);
             }
         });
-        
+
         PlotDisplay<PlaneSurfaceFactory.Profile, PlaneAspect> display = plot.getPlotDisplay();
         
         // Just make sure plot aspect hasn't changed
@@ -623,9 +624,33 @@ public class StilPlotterTest extends AbstractUISpecTest {
         FittingRangeModel model = plot.fittingRanges;
         StarTable fitStarTable = model.getInSource();
         
-        // Validate values, y value should be at 1 + (10 - 1)*.5 = 1.45
+        // Validate values
         assertEquals(1, fitStarTable.getRowCount());
-        assertArrayEquals(new Object[] {5.0, 4.0, 4.0, 1.9}, fitStarTable.getRow(0));
+        Object[] row = fitStarTable.getRow(0);
+        assertEquals(4, row.length);
+        
+        assertEquals(5.0, (double) row[0], 0.00001);
+        assertEquals(4.0, (double) row[1], 0.00001);
+        assertEquals(4.0, (double) row[2], 0.00001);
+        assertEquals(1.258925, (double) row[3], 0.00001);
+    }
+    
+    @Test
+    public void testFittingRangeCalculation() {
+        
+        // Linear tests
+        PlaneAspect aspect = new PlaneAspect(new double[] {0,10}, new double[] {.1,10});
+        assertEquals(1.09, StilPlotter.computeFittingLocation(aspect, false), 0.0001);
+
+        aspect = new PlaneAspect(new double[] {0,10}, new double[] {-10,1});
+        assertEquals(-8.9, StilPlotter.computeFittingLocation(aspect, false), 0.0001);
+        
+        // Log tests
+        aspect = new PlaneAspect(new double[] {0,10}, new double[] {.1,.5});
+        assertEquals(.11745, StilPlotter.computeFittingLocation(aspect, true), 0.0001);
+        
+        aspect = new PlaneAspect(new double[] {0,10}, new double[] {.1,5});
+        assertEquals(.14787, StilPlotter.computeFittingLocation(aspect, true), 0.0001);
     }
     
     private StilPlotter setUpTests(ExtSed sed) throws Exception {

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/plotter/StilPlotterTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/plotter/StilPlotterTest.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.*;
 import cfa.vo.iris.fitting.FitConfiguration;
 import cfa.vo.iris.fitting.FittingRange;
 import cfa.vo.iris.sed.ExtSed;
-import cfa.vo.iris.sed.quantities.XUnit;
 import cfa.vo.iris.test.Ws;
 import cfa.vo.iris.visualizer.plotter.PlotPreferences.PlotType;
 import cfa.vo.iris.test.unit.TestUtils;
@@ -83,7 +82,7 @@ public class StilPlotterTest {
         // check shape
         StringParameter par = new StringParameter("shape");
         env.acquireValue(par);
-        assertEquals(par.objectValue(env), "open_circle");
+        assertEquals(par.objectValue(env), ShapeType.filled_diamond.name());
         
         // check xlog and ylog
         BooleanParameter log = new BooleanParameter("xlog");

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/preferences/SedPreferencesTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/preferences/SedPreferencesTest.java
@@ -31,7 +31,6 @@ import cfa.vo.iris.sed.ExtSed;
 import cfa.vo.iris.visualizer.stil.tables.IrisStarTable;
 import cfa.vo.iris.visualizer.stil.tables.IrisStarTableAdapter;
 import cfa.vo.sedlib.Segment;
-import cfa.vo.sedlib.Target;
 import cfa.vo.sedlib.TextParam;
 import cfa.vo.sherpa.Data;
 
@@ -98,39 +97,6 @@ public class SedPreferencesTest {
     }
     
     @Test
-    public void testSuffixesWithSameTargetNames() throws Exception {
-        ExtSed sed = new ExtSed("test");
-        IrisStarTableAdapter adapter = new IrisStarTableAdapter(null);
-        
-        SedModel model = new SedModel(sed, adapter);
-        
-        // create two segments with the same Target name
-        Target targ = new Target();
-        targ.setName(new TextParam("my segment"));
-        
-        Segment seg1 = createSampleSegment();
-        seg1.setTarget(targ);
-        Segment seg2 = createSampleSegment();
-        seg2.setTarget(targ);
-        
-        sed.addSegment(seg1);
-        sed.addSegment(seg2);
-        
-        model.refresh();
-        assertEquals("my segment", model.getSegmentModel(seg1).getSuffix());
-        assertEquals("my segment 1", model.getSegmentModel(seg2).getSuffix());
-        
-        // add another segment of the same target name
-        // suffix number should go up 1
-        Segment seg3 = createSampleSegment();
-        seg3.setTarget(targ);
-        sed.addSegment(seg3);
-        
-        model.refresh();
-        assertEquals("my segment 2", model.getSegmentModel(seg3).getSuffix());
-    }
-    
-    @Test
     public void testAddMultipleSegments() throws Exception {
         
         final ExtSed sed = new ExtSed("sed");
@@ -147,7 +113,7 @@ public class SedPreferencesTest {
         SedModel model = new SedModel(sed, adapter);
         
         assertEquals("target1", model.getSegmentModel(sed.getSegment(0)).getSuffix());
-        assertEquals("target1 1", model.getSegmentModel(sed.getSegment(1)).getSuffix());
+        assertEquals("target1", model.getSegmentModel(sed.getSegment(1)).getSuffix());
     }
     
     @Test


### PR DESCRIPTION
Opening this now to prevent any one PR from containing too many commits in one go. This PR address the following issues:

+ Co-plotting an empty SED throws exception - the dataModel will skip adding empty SEDs
+ Show legend not correctly bound on plot window - updated the plotterview method to include the show legend option.
+ Masking points throws an arrayindexoutofbounds exception when re-plotting with model functions - since the model functions are based on all points, but were trying to use masked tables - fixed that in the SedModel
+ Fitting ranges don't show up at the right spot on log-scales - address that in the StilPlotter
+ Removed Unused menu items from the Metadata Browser.

EDIT:
+ Fixed issue with grid lines and a fixed plot.
+ Fixed error related to sorting/masking in the metadata browser.