### PR TITLE
Fitting tool RFEs

### DIFF
--- a/iris-common/src/main/java/cfa/vo/iris/fitting/ConfResultsConverter.java
+++ b/iris-common/src/main/java/cfa/vo/iris/fitting/ConfResultsConverter.java
@@ -31,9 +31,11 @@ public class ConfResultsConverter extends Converter<ConfidenceResults, List<Conf
         double[] vals = res.getParvals();
         double[] mins = res.getParmins();
         double[] maxes = res.getParmaxes();
-        int l = maxes.length;
-        for (int i=0; i<l; i++) {
-            retVal.add(new ParameterLimits(names.get(i), vals[i], mins[i], maxes[i]));
+        if (maxes != null) {
+            int l = maxes.length;
+            for (int i = 0; i < l; i++) {
+                retVal.add(new ParameterLimits(names.get(i), vals[i], mins[i], maxes[i]));
+            }
         }
 
         return retVal;

--- a/iris-common/src/main/java/cfa/vo/iris/fitting/FitConfiguration.java
+++ b/iris-common/src/main/java/cfa/vo/iris/fitting/FitConfiguration.java
@@ -62,13 +62,8 @@ public class FitConfiguration {
     private transient final PropertyChangeSupport propertyChangeSupport = new java.beans.PropertyChangeSupport(this);
 
     public FitConfiguration() {
-        model = SAMPFactory.get(CompositeModel.class);
-        confidence = SAMPFactory.get(Confidence.class);
-        confidence.getConfig().setSigma(1.6);
-        confidence.setName("conf");
-        stat = Statistic.Chi2;
-        method = OptimizationMethod.LevenbergMarquardt;
         fittingRanges = new ArrayList<>();
+        init();
     }
 
     @Nonnull
@@ -357,6 +352,10 @@ public class FitConfiguration {
         setConfidenceResults(null);
     }
 
+    public void reset() {
+        init();
+    }
+
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder();
@@ -410,6 +409,24 @@ public class FitConfiguration {
     public void removePropertyChangeListener(java.beans.PropertyChangeListener listener )
     {
         propertyChangeSupport.removePropertyChangeListener( listener );
+    }
+
+    private void init() {
+        setModel(SAMPFactory.get(CompositeModel.class));
+        setConfidence(SAMPFactory.get(Confidence.class));
+        confidence.getConfig().setSigma(1.6);
+        confidence.setName("conf");
+        setConfidenceResults(SAMPFactory.get(ConfidenceResults.class));
+        setStat(Statistic.Chi2);
+        setMethod(OptimizationMethod.LevenbergMarquardt);
+        clearFittingRanges();
+        setStatVal(null);
+        setDof(null);
+        setnFev(null);
+        setNumPoints(null);
+        setqVal(null);
+        setrStat(null);
+        setUserModelList(new ArrayList<UserModel>());
     }
 
     private void removeUserModel(Model m) {

--- a/iris-common/src/main/java/cfa/vo/sherpa/SherpaClient.java
+++ b/iris-common/src/main/java/cfa/vo/sherpa/SherpaClient.java
@@ -21,8 +21,13 @@ import cfa.vo.iris.fitting.FitConfiguration;
 import cfa.vo.iris.sed.ExtSed;
 import cfa.vo.iris.utils.UTYPE;
 import cfa.vo.sherpa.models.*;
+import org.astrogrid.samp.Message;
 import org.astrogrid.samp.Response;
+import org.astrogrid.samp.client.SampException;
+
+import java.util.HashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class SherpaClient {
@@ -36,6 +41,7 @@ public class SherpaClient {
     private static final String FIT_MTYPE = "spectrum.fit.fit";
     private static final String CONFIDENCE_MTYPE = "spectrum.fit.confidence";
     private static final String EVALUATE_MTYPE = "spectrum.fit.calc.model.values";
+    private static final String STOP_FIT_MTYPE = "spectrum.fit.fit.stop";
     private Logger logger = Logger.getLogger(SherpaClient.class.getName());
 
     public SherpaClient(SampService sampService) {
@@ -143,6 +149,16 @@ public class SherpaClient {
 
     public String createId(String prefix) {
         return prefix + stringCounter.incrementAndGet();
+    }
+
+    public void stopFit() throws SampException {
+        try {
+            Message msg = new Message(STOP_FIT_MTYPE, new HashMap());
+            sampService.sendMessage(new SimpleSAMPMessage(msg));
+        } catch (Exception ex) {
+            logger.log(Level.SEVERE, null, ex);
+            throw ex;
+        }
     }
 
     private SherpaFitConfiguration make(Data data, FitConfiguration fit) {

--- a/iris-common/src/main/java/cfa/vo/sherpa/SherpaClient.java
+++ b/iris-common/src/main/java/cfa/vo/sherpa/SherpaClient.java
@@ -42,6 +42,7 @@ public class SherpaClient {
     private static final String CONFIDENCE_MTYPE = "spectrum.fit.confidence";
     private static final String EVALUATE_MTYPE = "spectrum.fit.calc.model.values";
     private static final String STOP_FIT_MTYPE = "spectrum.fit.fit.stop";
+    private static final String STOP_CONFIDENCE_MTYPE = "spectrum.fit.confidence.stop";
     private Logger logger = Logger.getLogger(SherpaClient.class.getName());
 
     public SherpaClient(SampService sampService) {
@@ -154,6 +155,16 @@ public class SherpaClient {
     public void stopFit() throws SampException {
         try {
             Message msg = new Message(STOP_FIT_MTYPE, new HashMap());
+            sampService.sendMessage(new SimpleSAMPMessage(msg));
+        } catch (Exception ex) {
+            logger.log(Level.SEVERE, null, ex);
+            throw ex;
+        }
+    }
+
+    public void stopConfidence() throws SampException {
+        try {
+            Message msg = new Message(STOP_CONFIDENCE_MTYPE, new HashMap());
             sampService.sendMessage(new SimpleSAMPMessage(msg));
         } catch (Exception ex) {
             logger.log(Level.SEVERE, null, ex);

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/ConfidencePanel.form
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/ConfidencePanel.form
@@ -111,12 +111,21 @@
       <SubComponents>
         <Component class="org.jdesktop.swingx.JXBusyLabel" name="busyConfidence">
         </Component>
-        <Component class="javax.swing.JButton" name="jButton1">
+        <Component class="javax.swing.JButton" name="computeButton">
           <Properties>
             <Property name="text" type="java.lang.String" value="Compute"/>
           </Properties>
           <Events>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="doConfidence"/>
+          </Events>
+        </Component>
+        <Component class="javax.swing.JButton" name="stopButton">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="Stop"/>
+            <Property name="enabled" type="boolean" value="false"/>
+          </Properties>
+          <Events>
+            <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="stopButtonActionPerformed"/>
           </Events>
         </Component>
       </SubComponents>

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/ConfidencePanel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/ConfidencePanel.java
@@ -222,11 +222,13 @@ public class ConfidencePanel extends javax.swing.JPanel {
                     logger.log(Level.SEVERE, "Error computing confidence", ex);
                 } finally {
                     busyConfidence.setBusy(false);
+                    jButton1.setEnabled(true);
                 }
             }
         };
             
         busyConfidence.setBusy(true);
+        jButton1.setEnabled(false);
         worker.execute();
         
     }//GEN-LAST:event_doConfidence

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/ConfidencePanel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/ConfidencePanel.java
@@ -18,13 +18,16 @@ package cfa.vo.iris.fitting;
 import cfa.vo.iris.gui.NarrowOptionPane;
 import cfa.vo.sherpa.ConfidenceResults;
 import java.util.concurrent.ExecutionException;
+
+import org.astrogrid.samp.client.SampException;
 import org.jdesktop.beansbinding.BeanProperty;
 import org.jdesktop.beansbinding.Property;
 import org.jdesktop.swingbinding.JTableBinding;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.swing.SwingWorker;
+import javax.swing.*;
+
 import org.jdesktop.beansbinding.Converter;
 
 
@@ -108,7 +111,8 @@ public class ConfidencePanel extends javax.swing.JPanel {
         jTable1 = new javax.swing.JTable();
         jPanel1 = new javax.swing.JPanel();
         busyConfidence = new org.jdesktop.swingx.JXBusyLabel();
-        jButton1 = new javax.swing.JButton();
+        computeButton = new javax.swing.JButton();
+        stopButton = new javax.swing.JButton();
 
         setMinimumSize(null);
         setPreferredSize(null);
@@ -178,13 +182,22 @@ public class ConfidencePanel extends javax.swing.JPanel {
 
         jPanel1.add(busyConfidence);
 
-        jButton1.setText("Compute");
-        jButton1.addActionListener(new java.awt.event.ActionListener() {
+        computeButton.setText("Compute");
+        computeButton.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 doConfidence(evt);
             }
         });
-        jPanel1.add(jButton1);
+        jPanel1.add(computeButton);
+
+        stopButton.setText("Stop");
+        stopButton.setEnabled(false);
+        stopButton.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                stopButtonActionPerformed(evt);
+            }
+        });
+        jPanel1.add(stopButton);
 
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 2;
@@ -222,27 +235,41 @@ public class ConfidencePanel extends javax.swing.JPanel {
                     logger.log(Level.SEVERE, "Error computing confidence", ex);
                 } finally {
                     busyConfidence.setBusy(false);
-                    jButton1.setEnabled(true);
+                    computeButton.setEnabled(true);
+                    stopButton.setEnabled(false);
                 }
             }
         };
             
         busyConfidence.setBusy(true);
-        jButton1.setEnabled(false);
+        computeButton.setEnabled(false);
+        stopButton.setEnabled(true);
         worker.execute();
         
     }//GEN-LAST:event_doConfidence
 
+    private void stopButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_stopButtonActionPerformed
+        stopButton.setEnabled(false);
+        try {
+            controller.stopConfidence();
+        } catch (SampException e) {
+            NarrowOptionPane.showMessageDialog(this, e.getMessage(), "Unexpected Error", JOptionPane.ERROR_MESSAGE);
+        } finally {
+            stopButton.setEnabled(true);
+        }
+    }//GEN-LAST:event_stopButtonActionPerformed
+
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private org.jdesktop.swingx.JXBusyLabel busyConfidence;
-    private javax.swing.JButton jButton1;
+    private javax.swing.JButton computeButton;
     private javax.swing.JLabel jLabel1;
     private javax.swing.JPanel jPanel1;
     private javax.swing.JScrollPane jScrollPane1;
     private javax.swing.JTable jTable1;
     private javax.swing.JTextField jTextField1;
     private javax.swing.JLabel sigmaText;
+    private javax.swing.JButton stopButton;
     private org.jdesktop.beansbinding.BindingGroup bindingGroup;
     // End of variables declaration//GEN-END:variables
 

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/ConfidencePanel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/ConfidencePanel.java
@@ -67,6 +67,13 @@ public class ConfidencePanel extends javax.swing.JPanel {
     }
 
     /**
+     * Reset GUI
+     */
+    public void reset() {
+        setConfidenceResults(controller.getFit().getConfidenceResults());
+    }
+
+    /**
      * Set the value of confidenceResults
      *
      * @param confidenceResults new value of confidenceResults

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FitController.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FitController.java
@@ -284,6 +284,13 @@ public class FitController {
         client.stopConfidence();
     }
 
+    /**
+     * Clear fit info
+     */
+    public void clearAll() {
+        sedModel.reset();
+    }
+
     private double[] calcResiduals(double[] expected, double[] actual) {
         int len = expected.length;
 

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FitController.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FitController.java
@@ -277,6 +277,13 @@ public class FitController {
         client.stopFit();
     }
 
+    /**
+     * Stop confidence calculation
+     */
+    public void stopConfidence() throws SampException {
+        client.stopConfidence();
+    }
+
     private double[] calcResiduals(double[] expected, double[] actual) {
         int len = expected.length;
 

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FitController.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FitController.java
@@ -121,7 +121,11 @@ public class FitController {
      */
     public FitResults fit() throws Exception {
         Data data = constructSherpaCall(sedModel);
-        
+
+        if (!getFit().isModelValid()) {
+            throw new Exception("Model is invalid. Please correct model expression and retry.");
+        }
+
         // Make call to sherpa to fit data
         FitResults retVal = client.fit(data, getFit());
         sedModel.getFit().integrateResults(retVal);

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FitController.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FitController.java
@@ -9,6 +9,7 @@ import cfa.vo.iris.units.UnitsException;
 import cfa.vo.iris.units.UnitsManager;
 import cfa.vo.iris.visualizer.preferences.SedModel;
 import cfa.vo.iris.visualizer.stil.tables.IrisStarTable;
+import cfa.vo.sedlib.common.SedNoDataException;
 import cfa.vo.sherpa.ConfidenceResults;
 import cfa.vo.sherpa.Data;
 import cfa.vo.sherpa.FitResults;
@@ -18,6 +19,8 @@ import cfa.vo.sherpa.models.DefaultModel;
 import cfa.vo.utils.Default;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.mrbean.MrBeanModule;
+import org.apache.commons.lang.ArrayUtils;
+import org.astrogrid.samp.client.SampException;
 
 import javax.swing.tree.TreeModel;
 import java.io.IOException;
@@ -129,17 +132,20 @@ public class FitController {
         return retVal;
     }
     
-    Data constructSherpaCall(SedModel model) throws UnitsException {
+    Data constructSherpaCall(SedModel model) throws UnitsException, SedNoDataException {
         Data data = SAMPFactory.get(Data.class);
         data.setName(SherpaClient.DATA_NAME);
         
         // Extract fitting data from SedModel, don't include masked points.
-        sedModel.getFittingData(data, false);
+        model.getFittingData(data, false);
         double[] xoldvalues = data.getX();
+        if (ArrayUtils.isEmpty(xoldvalues)) {
+            throw new SedNoDataException("No Data in SED. Please add some data and try again.");
+        }
         double[] yoldvalues = data.getY();
         double[] erroldvalues = data.getStaterror();
-        String xoldunits = sedModel.getXUnits();
-        String yoldUnits = sedModel.getYUnits();
+        String xoldunits = model.getXUnits();
+        String yoldUnits = model.getYUnits();
         
         // Convert data's units to fitting units
         UnitsManager um = Default.getInstance().getUnitsManager();
@@ -262,6 +268,13 @@ public class FitController {
             table.setResidualValues(calcResiduals(table.getFluxValues(), y));
             table.setRatioValues(calcRatios(table.getFluxValues(), y));
         }
+    }
+
+    /**
+     * Stop fit
+     */
+    public void stopFit() throws SampException {
+        client.stopFit();
     }
 
     private double[] calcResiduals(double[] expected, double[] actual) {

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.form
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.form
@@ -221,14 +221,6 @@
                                   </Constraints>
                                 </Component>
                                 <Container class="javax.swing.JPanel" name="jPanel6">
-                                  <Properties>
-                                    <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-                                      <Dimension value="null"/>
-                                    </Property>
-                                    <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-                                      <Dimension value="null"/>
-                                    </Property>
-                                  </Properties>
                                   <Constraints>
                                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
                                       <GridBagConstraints gridX="0" gridY="4" gridWidth="2" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="0.0" weightY="0.0"/>
@@ -252,6 +244,9 @@
                                         <Property name="text" type="java.lang.String" value="Stop"/>
                                         <Property name="enabled" type="boolean" value="false"/>
                                       </Properties>
+                                      <Events>
+                                        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="stopFitButtonActionPerformed"/>
+                                      </Events>
                                     </Component>
                                   </SubComponents>
                                 </Container>
@@ -391,9 +386,6 @@
                       <Border info="org.netbeans.modules.form.compat2.border.TitledBorderInfo">
                         <TitledBorder title="Available Components"/>
                       </Border>
-                    </Property>
-                    <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-                      <Dimension value="null"/>
                     </Property>
                   </Properties>
 

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.form
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.form
@@ -220,26 +220,41 @@
                                     </Constraint>
                                   </Constraints>
                                 </Component>
-                                <Component class="javax.swing.JButton" name="fitButton">
+                                <Container class="javax.swing.JPanel" name="jPanel6">
                                   <Properties>
-                                    <Property name="text" type="java.lang.String" value="Fit"/>
+                                    <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+                                      <Dimension value="null"/>
+                                    </Property>
+                                    <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+                                      <Dimension value="null"/>
+                                    </Property>
                                   </Properties>
-                                  <Events>
-                                    <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="doFit"/>
-                                  </Events>
                                   <Constraints>
                                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-                                      <GridBagConstraints gridX="1" gridY="4" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="18" insetsLeft="0" insetsBottom="18" insetsRight="0" anchor="17" weightX="1.0" weightY="0.0"/>
+                                      <GridBagConstraints gridX="0" gridY="4" gridWidth="2" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="0.0" weightY="0.0"/>
                                     </Constraint>
                                   </Constraints>
-                                </Component>
-                                <Component class="org.jdesktop.swingx.JXBusyLabel" name="busyFit">
-                                  <Constraints>
-                                    <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-                                      <GridBagConstraints gridX="0" gridY="4" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="13" weightX="0.0" weightY="0.0"/>
-                                    </Constraint>
-                                  </Constraints>
-                                </Component>
+
+                                  <Layout class="org.netbeans.modules.form.compat2.layouts.DesignFlowLayout"/>
+                                  <SubComponents>
+                                    <Component class="org.jdesktop.swingx.JXBusyLabel" name="busyFit">
+                                    </Component>
+                                    <Component class="javax.swing.JButton" name="fitButton">
+                                      <Properties>
+                                        <Property name="text" type="java.lang.String" value="Fit"/>
+                                      </Properties>
+                                      <Events>
+                                        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="doFit"/>
+                                      </Events>
+                                    </Component>
+                                    <Component class="javax.swing.JButton" name="stopFitButton">
+                                      <Properties>
+                                        <Property name="text" type="java.lang.String" value="Stop"/>
+                                        <Property name="enabled" type="boolean" value="false"/>
+                                      </Properties>
+                                    </Component>
+                                  </SubComponents>
+                                </Container>
                               </SubComponents>
                             </Container>
                             <Component class="cfa.vo.iris.gui.widgets.ModelViewerPanel" name="modelViewerPanel">

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.form
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.form
@@ -248,6 +248,14 @@
                                         <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="stopFitButtonActionPerformed"/>
                                       </Events>
                                     </Component>
+                                    <Component class="javax.swing.JButton" name="clearButton">
+                                      <Properties>
+                                        <Property name="text" type="java.lang.String" value="Clear All"/>
+                                      </Properties>
+                                      <Events>
+                                        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="clearButtonActionPerformed"/>
+                                      </Events>
+                                    </Component>
                                   </SubComponents>
                                 </Container>
                               </SubComponents>

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.java
@@ -31,6 +31,7 @@ import cfa.vo.sherpa.FitResults;
 import cfa.vo.sherpa.models.Model;
 import cfa.vo.sherpa.optimization.OptimizationMethod;
 import cfa.vo.sherpa.stats.Statistic;
+import org.astrogrid.samp.client.SampException;
 
 import javax.swing.*;
 import javax.swing.tree.*;
@@ -266,8 +267,6 @@ public class FittingMainView extends JInternalFrame implements SedListener {
         gridBagConstraints.insets = new java.awt.Insets(6, 0, 6, 0);
         jPanel5.add(openFittingRangesButton, gridBagConstraints);
 
-        jPanel6.setMinimumSize(null);
-        jPanel6.setPreferredSize(null);
         jPanel6.add(busyFit);
 
         fitButton.setText("Fit");
@@ -280,6 +279,11 @@ public class FittingMainView extends JInternalFrame implements SedListener {
 
         stopFitButton.setText("Stop");
         stopFitButton.setEnabled(false);
+        stopFitButton.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                stopFitButtonActionPerformed(evt);
+            }
+        });
         jPanel6.add(stopFitButton);
 
         gridBagConstraints = new java.awt.GridBagConstraints();
@@ -358,7 +362,6 @@ public class FittingMainView extends JInternalFrame implements SedListener {
         jSplitPane1.setRightComponent(jPanel2);
 
         availableComponents.setBorder(javax.swing.BorderFactory.createTitledBorder("Available Components"));
-        availableComponents.setPreferredSize(null);
         availableComponents.setLayout(new java.awt.GridBagLayout());
 
         javax.swing.tree.DefaultMutableTreeNode treeNode1 = new javax.swing.tree.DefaultMutableTreeNode("Model Components");
@@ -545,12 +548,14 @@ public class FittingMainView extends JInternalFrame implements SedListener {
                 } finally {
                     busyFit.setBusy(false);
                     fitButton.setEnabled(true);
+                    stopFitButton.setEnabled(false);
                 }
             }
         };
             
         busyFit.setBusy(true);
         fitButton.setEnabled(false);
+        stopFitButton.setEnabled(true);
         worker.execute();
             
         
@@ -562,6 +567,17 @@ public class FittingMainView extends JInternalFrame implements SedListener {
         this.getDesktopPane().setLayer(fittingRangesFrame, 1);
         GUIUtils.moveToFront(fittingRangesFrame);
     }//GEN-LAST:event_openFittingRangesButtonActionPerformed
+
+    private void stopFitButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_stopFitButtonActionPerformed
+        stopFitButton.setEnabled(false);
+        try {
+            controller.stopFit();
+        } catch (SampException e) {
+            NarrowOptionPane.showMessageDialog(this, e.getMessage(), "Unexpected Error", JOptionPane.ERROR_MESSAGE);
+        } finally {
+            stopFitButton.setEnabled(true);
+        }
+    }//GEN-LAST:event_stopFitButtonActionPerformed
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JPanel availableComponents;

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.java
@@ -151,6 +151,7 @@ public class FittingMainView extends JInternalFrame implements SedListener {
         busyFit = new org.jdesktop.swingx.JXBusyLabel();
         fitButton = new javax.swing.JButton();
         stopFitButton = new javax.swing.JButton();
+        clearButton = new javax.swing.JButton();
         modelViewerPanel = new cfa.vo.iris.gui.widgets.ModelViewerPanel();
         jSplitPane2 = new javax.swing.JSplitPane();
         resultsContainer = new javax.swing.JPanel();
@@ -285,6 +286,14 @@ public class FittingMainView extends JInternalFrame implements SedListener {
             }
         });
         jPanel6.add(stopFitButton);
+
+        clearButton.setText("Clear All");
+        clearButton.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                clearButtonActionPerformed(evt);
+            }
+        });
+        jPanel6.add(clearButton);
 
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
@@ -549,6 +558,7 @@ public class FittingMainView extends JInternalFrame implements SedListener {
                     busyFit.setBusy(false);
                     fitButton.setEnabled(true);
                     stopFitButton.setEnabled(false);
+                    clearButton.setEnabled(true);
                 }
             }
         };
@@ -556,6 +566,7 @@ public class FittingMainView extends JInternalFrame implements SedListener {
         busyFit.setBusy(true);
         fitButton.setEnabled(false);
         stopFitButton.setEnabled(true);
+        clearButton.setEnabled(false);
         worker.execute();
             
         
@@ -579,10 +590,16 @@ public class FittingMainView extends JInternalFrame implements SedListener {
         }
     }//GEN-LAST:event_stopFitButtonActionPerformed
 
+    private void clearButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_clearButtonActionPerformed
+        controller.clearAll();
+        confidencePanel.reset();
+    }//GEN-LAST:event_clearButtonActionPerformed
+
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JPanel availableComponents;
     private javax.swing.JTree availableTree;
     private org.jdesktop.swingx.JXBusyLabel busyFit;
+    private javax.swing.JButton clearButton;
     private javax.swing.JPanel confidenceContainer;
     private cfa.vo.iris.fitting.ConfidencePanel confidencePanel;
     private javax.swing.JTextField currentSedField;

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.java
@@ -146,8 +146,10 @@ public class FittingMainView extends JInternalFrame implements SedListener {
         jLabel2 = new javax.swing.JLabel();
         statisticCombo = new javax.swing.JComboBox();
         openFittingRangesButton = new javax.swing.JButton();
-        fitButton = new javax.swing.JButton();
+        jPanel6 = new javax.swing.JPanel();
         busyFit = new org.jdesktop.swingx.JXBusyLabel();
+        fitButton = new javax.swing.JButton();
+        stopFitButton = new javax.swing.JButton();
         modelViewerPanel = new cfa.vo.iris.gui.widgets.ModelViewerPanel();
         jSplitPane2 = new javax.swing.JSplitPane();
         resultsContainer = new javax.swing.JPanel();
@@ -264,25 +266,28 @@ public class FittingMainView extends JInternalFrame implements SedListener {
         gridBagConstraints.insets = new java.awt.Insets(6, 0, 6, 0);
         jPanel5.add(openFittingRangesButton, gridBagConstraints);
 
+        jPanel6.setMinimumSize(null);
+        jPanel6.setPreferredSize(null);
+        jPanel6.add(busyFit);
+
         fitButton.setText("Fit");
         fitButton.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 doFit(evt);
             }
         });
-        gridBagConstraints = new java.awt.GridBagConstraints();
-        gridBagConstraints.gridx = 1;
-        gridBagConstraints.gridy = 4;
-        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
-        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
-        gridBagConstraints.weightx = 1.0;
-        gridBagConstraints.insets = new java.awt.Insets(18, 0, 18, 0);
-        jPanel5.add(fitButton, gridBagConstraints);
+        jPanel6.add(fitButton);
+
+        stopFitButton.setText("Stop");
+        stopFitButton.setEnabled(false);
+        jPanel6.add(stopFitButton);
+
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 4;
-        gridBagConstraints.anchor = java.awt.GridBagConstraints.EAST;
-        jPanel5.add(busyFit, gridBagConstraints);
+        gridBagConstraints.gridwidth = 2;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
+        jPanel5.add(jPanel6, gridBagConstraints);
 
         jSplitPane3.setRightComponent(jPanel5);
 
@@ -539,11 +544,13 @@ public class FittingMainView extends JInternalFrame implements SedListener {
                         modelViewerPanel.fitResult(false);
                 } finally {
                     busyFit.setBusy(false);
+                    fitButton.setEnabled(true);
                 }
             }
         };
             
         busyFit.setBusy(true);
+        fitButton.setEnabled(false);
         worker.execute();
             
         
@@ -574,6 +581,7 @@ public class FittingMainView extends JInternalFrame implements SedListener {
     private javax.swing.JPanel jPanel3;
     private javax.swing.JPanel jPanel4;
     private javax.swing.JPanel jPanel5;
+    private javax.swing.JPanel jPanel6;
     private javax.swing.JScrollPane jScrollPane2;
     private javax.swing.JScrollPane jScrollPane3;
     private javax.swing.JSplitPane jSplitPane1;
@@ -593,6 +601,7 @@ public class FittingMainView extends JInternalFrame implements SedListener {
     private javax.swing.JButton searchButton;
     private javax.swing.JTextField searchField;
     private javax.swing.JComboBox statisticCombo;
+    private javax.swing.JButton stopFitButton;
     private org.jdesktop.beansbinding.BindingGroup bindingGroup;
     // End of variables declaration//GEN-END:variables
 

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedModel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedModel.java
@@ -394,4 +394,13 @@ public class SedModel {
     public ExtSed getSed() {
         return sed;
     }
+
+    /**
+     * Reset the model
+     */
+    public void reset() {
+        removeAll();
+        refresh();
+        sed.getFit().reset();
+    }
 }

--- a/samp-factory/src/main/resources/cfa/vo/sherpa/models/sherpa_models.xml
+++ b/samp-factory/src/main/resources/cfa/vo/sherpa/models/sherpa_models.xml
@@ -402,25 +402,25 @@
         </parameter>
     </model>
     <model name="polynomial" description="1-D polynomial function of order &lt;= 5">
-        <parameter name="c0" val="1.0" min="1.1754943508222875e-38" max="3.4028234663852886e+38" frozen="0" hidden="0"
+        <parameter name="c0" val="1.0" min="-3.4028234663852886E38" max="3.4028234663852886e+38" frozen="0" hidden="0"
                    alwaysfrozen="0" units="" link="INDEF">
         </parameter>
-        <parameter name="c1" val="0.0" min="1.1754943508222875e-38" max="3.4028234663852886e+38" frozen="1" hidden="0"
+        <parameter name="c1" val="0.0" min="-3.4028234663852886E38" max="3.4028234663852886e+38" frozen="1" hidden="0"
                    alwaysfrozen="0" units="" link="INDEF">
         </parameter>
-        <parameter name="c2" val="0.0" min="1.1754943508222875e-38" max="3.4028234663852886e+38" frozen="1" hidden="0"
+        <parameter name="c2" val="0.0" min="-3.4028234663852886E38" max="3.4028234663852886e+38" frozen="1" hidden="0"
                    alwaysfrozen="0" units="" link="INDEF">
         </parameter>
-        <parameter name="c3" val="0.0" min="1.1754943508222875e-38" max="3.4028234663852886e+38" frozen="1" hidden="0"
+        <parameter name="c3" val="0.0" min="-3.4028234663852886E38" max="3.4028234663852886e+38" frozen="1" hidden="0"
                    alwaysfrozen="0" units="" link="INDEF">
         </parameter>
-        <parameter name="c4" val="0.0" min="1.1754943508222875e-38" max="3.4028234663852886e+38" frozen="1" hidden="0"
+        <parameter name="c4" val="0.0" min="-3.4028234663852886E38" max="3.4028234663852886e+38" frozen="1" hidden="0"
                    alwaysfrozen="0" units="" link="INDEF">
         </parameter>
-        <parameter name="c5" val="0.0" min="1.1754943508222875e-38" max="3.4028234663852886e+38" frozen="1" hidden="0"
+        <parameter name="c5" val="0.0" min="-3.4028234663852886E38" max="3.4028234663852886e+38" frozen="1" hidden="0"
                    alwaysfrozen="0" units="" link="INDEF">
         </parameter>
-        <parameter name="offset" val="0.0" min="1.1754943508222875e-38" max="3.4028234663852886e+38" frozen="1"
+        <parameter name="offset" val="0.0" min="-3.4028234663852886E38" max="3.4028234663852886e+38" frozen="1"
                    hidden="0" alwaysfrozen="0" units="" link="INDEF">
         </parameter>
     </model>


### PR DESCRIPTION
Add the following features to Fitting Tool:
  * `Fit` button is now disabled during a fit.
  * `Compute` confidence button is now disabled during a calculation.
  * `Stop` buttons for fitting and confidence limit calculations.
  * Add a `Clear All` button for resetting fit and confidence.

Tests performed interactively. It turns out Iris has had a nasty bug that would make `sherpa-samp` quit when receiving a `stop` message from SAMP since the very first release. This is described in #11.
This PR fixes #11.

This PR also add error handling for fits performed when model expression is invalid, rather than relying on `sherpa-samp's` error handling.