### PR TITLE
Fitting warnings and error handling

### DIFF
--- a/iris-common/src/main/java/cfa/vo/iris/fitting/FitConfiguration.java
+++ b/iris-common/src/main/java/cfa/vo/iris/fitting/FitConfiguration.java
@@ -15,6 +15,8 @@ import cfa.vo.sherpa.stats.Stat;
 import cfa.vo.sherpa.stats.Statistic;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.jdesktop.observablecollections.ObservableCollections;
 import org.jdesktop.observablecollections.ObservableList;
@@ -217,7 +219,7 @@ public class FitConfiguration {
     }
 
     public void setUserModelList(List<UserModel> userModelList) {
-        ObservableList oldList = this.userModelList;
+        ObservableList<UserModel> oldList = this.userModelList;
         this.userModelList = ObservableCollections.observableList(userModelList);
         propertyChangeSupport.firePropertyChange(PROP_USERMODELLIST, oldList, userModelList);
     }
@@ -386,11 +388,10 @@ public class FitConfiguration {
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder(17, 37)
+        HashCodeBuilder hcb = new HashCodeBuilder(17, 37)
                 // Non primitive return types must manually specify which sub-objects to 
                 // include in order to maintain equality.
                 .append(model.getName())
-                .append(model.getParts())
                 .append(confidence.getConfig().getSigma())
                 .append(confidence.getName())
                 .append(stat)
@@ -402,8 +403,18 @@ public class FitConfiguration {
                 .append(numPoints)
                 .append(statVal)
                 .append(dof)
-                .append(userModelList)
-                .toHashCode();
+                .append(userModelList);
+        
+        // Must manually include param and values in hashCode computation
+        if (CollectionUtils.isNotEmpty(model.getParts())) {
+            for (Model part : model.getParts()) {
+                for (Parameter param : part.getPars()) {
+                    hcb.append(HashCodeBuilder.reflectionHashCode(param));
+                }
+            }
+        }
+        
+        return hcb.toHashCode();
     }
 
     public void addPropertyChangeListener(java.beans.PropertyChangeListener listener )

--- a/iris-common/src/main/java/cfa/vo/iris/fitting/FitConfiguration.java
+++ b/iris-common/src/main/java/cfa/vo/iris/fitting/FitConfiguration.java
@@ -387,10 +387,14 @@ public class FitConfiguration {
     @Override
     public int hashCode() {
         return new HashCodeBuilder(17, 37)
-                .append(model)
+                // Non primitive return types must manually specify which sub-objects to 
+                // include in order to maintain equality.
+                .append(model.getName())
+                .append(model.getParts())
+                .append(confidence.getConfig().getSigma())
+                .append(confidence.getName())
                 .append(stat)
                 .append(method)
-                .append(confidence)
                 .append(confResults)
                 .append(rStat)
                 .append(nFev)

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FitController.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FitController.java
@@ -124,7 +124,7 @@ public class FitController {
         sedModel.getFit().integrateResults(retVal);
         
         // Record the version number on the SED in the FitConfiguration
-        sedModel.getFit().setSedVersion(sedModel.getVersion());
+        sedModel.getFit().setSedVersion(sedModel.computeVersion());
         
         return retVal;
     }
@@ -242,7 +242,7 @@ public class FitController {
     public void evaluateModel(SedModel sedModel) throws Exception {
         
         // Update the model version with the current version of the Sed
-        sedModel.setModelVersion(sedModel.getVersion());
+        sedModel.setModelVersion(sedModel.computeVersion());
         sedModel.setHasModelFunction(true);
         
         String xUnit = sedModel.getXUnits();

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FitController.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FitController.java
@@ -126,6 +126,9 @@ public class FitController {
         // Record the version number on the SED in the FitConfiguration
         sedModel.getFit().setSedVersion(sedModel.computeVersion());
         
+        // Record the FitConfiguration version in the SedModel
+        sedModel.setFitConfigurationVersion(sedModel.getFit().hashCode());
+        
         return retVal;
     }
     

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.java
@@ -648,6 +648,7 @@ public class FittingMainView extends JInternalFrame implements SedListener {
 
         @Override
         public void actionPerformed(ActionEvent actionEvent) {
+            checkFittingConfigurationVersion();
             int result = chooser.showSaveDialog(FittingMainView.this);
             if (result == JFileChooser.APPROVE_OPTION) {
                 try {
@@ -666,6 +667,7 @@ public class FittingMainView extends JInternalFrame implements SedListener {
 
         @Override
         public void actionPerformed(ActionEvent actionEvent) {
+            checkFittingConfigurationVersion();
             int result = chooser.showSaveDialog(FittingMainView.this);
             if (result == JFileChooser.APPROVE_OPTION) {
                 try {
@@ -692,6 +694,22 @@ public class FittingMainView extends JInternalFrame implements SedListener {
                     NarrowOptionPane.showMessageDialog(FittingMainView.this, ex.getMessage(), "Error", NarrowOptionPane.ERROR_MESSAGE);
                 }
             }
+        }
+    }
+
+    private void checkFittingConfigurationVersion() {
+        SedModel model = controller.getSedModel();
+        
+        // If no version avaiable ignore it
+        if (model.getFitConfigurationVersion() == 0) {
+            return;
+        }
+        
+        // Check the version against the current version
+        if (model.getFitConfigurationVersion() != model.getFit().hashCode()) {
+            NarrowOptionPane.showMessageDialog(FittingMainView.this,
+                    "The fitting configuration has changed since the last fit was performed, you may want to refit your data before saving.",
+                    "Warning", NarrowOptionPane.WARNING_MESSAGE);
         }
     }
 }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
@@ -19,6 +19,7 @@ import cfa.vo.iris.IWorkspace;
 import cfa.vo.iris.fitting.FitController;
 import cfa.vo.iris.IrisApplication;
 import cfa.vo.iris.gui.GUIUtils;
+import cfa.vo.iris.gui.NarrowOptionPane;
 import cfa.vo.iris.visualizer.IrisVisualizer;
 import cfa.vo.iris.visualizer.metadata.MetadataBrowserMainView;
 import cfa.vo.iris.visualizer.plotter.PlotPreferences.PlotType;
@@ -694,7 +695,14 @@ public class PlotterView extends JInternalFrame {
         
         // Re-evaluate all models currently plotted
         for (SedModel model : preferences.getDataModel().getSedModels()) {
-            preferences.evaluateModel(model, controller);
+            try {
+                preferences.evaluateModel(model, controller);
+            } catch (Exception e) {
+                NarrowOptionPane.showMessageDialog(this,
+                        "Exception caught while re-evaluating model: " + e.getMessage(),
+                        "Error",
+                        NarrowOptionPane.ERROR_MESSAGE);
+            }
         }
     }//GEN-LAST:event_evaluateButtonActionPerformed
 

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/StilPlotter.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/StilPlotter.java
@@ -288,7 +288,7 @@ public class StilPlotter extends JPanel {
             
             // If there is no model or the model is valid, then we're good
             if (!sedModel.getHasModelFunction() ||
-               (sedModel.getVersion() == sedModel.getModelVersion())) 
+               (sedModel.computeVersion() == sedModel.getModelVersion())) 
             {
                 continue;
             }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedModel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedModel.java
@@ -366,7 +366,7 @@ public class SedModel {
         sed.setFit(fit);
     }
     
-    public int getVersion() {
+    public int computeVersion() {
         HashCodeBuilder hcb = new HashCodeBuilder(13,31);
         for (IrisStarTable table : getDataTables()) {
             hcb.append(table.getPlotterDataTable().hashCode());

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedModel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedModel.java
@@ -67,6 +67,7 @@ public class SedModel {
     // Evaluated model version number
     private int modelVersion = 13;
     private boolean hasModelFunction = false;
+    private int fitConfigurationVersion = 0;
 
     public SedModel(ExtSed sed, IrisStarTableAdapter adapter) {
         this.sed = sed;
@@ -389,6 +390,14 @@ public class SedModel {
 
     public void setHasModelFunction(boolean hasModelFunction) {
         this.hasModelFunction = hasModelFunction;
+    }
+
+    public int getFitConfigurationVersion() {
+        return fitConfigurationVersion;
+    }
+
+    public void setFitConfigurationVersion(int fitConfigurationVersion) {
+        this.fitConfigurationVersion = fitConfigurationVersion;
     }
     
     public ExtSed getSed() {

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerComponentPreferences.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerComponentPreferences.java
@@ -154,20 +154,17 @@ public class VisualizerComponentPreferences {
             return;
         }
         
-        // Otherwise asynchronously evaluate the model
         final VisualizerDataModel dataModel = this.getDataModel();
-        visualizerExecutor.submit(new Callable<SedModel>() {
-            @Override
-            public SedModel call() throws Exception {
-                controller.evaluateModel(model);
-                
-                // Refresh the model once completed
-                if (dataModel.getSelectedSeds().contains(model.getSed())) {
-                    dataModel.refresh();
-                }
-                return model;
-            }
-        });
+        try {
+            controller.evaluateModel(model);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        
+        // Refresh the model once completed
+        if (dataModel.getSelectedSeds().contains(model.getSed())) {
+            dataModel.refresh();
+        }
     }
     
     /**

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerDataModel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerDataModel.java
@@ -368,7 +368,7 @@ public class VisualizerDataModel {
      */
     public void updateFittingVersionNumbers() {
         for (SedModel model : getSedModels()) {
-            int version = model.getVersion();
+            int version = model.computeVersion();
             if (model.getHasModelFunction()) {
                 model.setModelVersion(version);
             }

--- a/iris-visualizer/src/test/java/cfa/vo/iris/fitting/FitControllerTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/fitting/FitControllerTest.java
@@ -271,8 +271,28 @@ public class FitControllerTest {
         int h1 = ft.hashCode();
         assertEquals(h1, ft.hashCode());
         
+        // Changing confidence changes hc
         ft.getConfidence().setName("hi there");
-        assertNotEquals(h1, ft.hashCode());
+        int h2 = ft.hashCode();
+        assertNotEquals(h1, h2);
+        
+        // Adding model changes hc
+        ModelFactory factory = new ModelFactory();
+        Model m = factory.getModel("polynomial", "m1");
+        ft.addModel(m);
+        int h3 = ft.hashCode();
+        assertNotEquals(h2, h3);
+        
+        // Changing params changes hc
+        Parameter c0 = m.getPars().get(0);
+        c0.setFrozen(0);
+        c0.setVal(0.1);
+        int h4 = ft.hashCode();
+        assertNotEquals(h3, h4);
+        
+        // Blind check
+        int h5 = ft.hashCode();
+        assertEquals(h4, h5);
     }
 
     private FitConfiguration createFit() throws Exception {

--- a/iris-visualizer/src/test/java/cfa/vo/iris/fitting/FitControllerTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/fitting/FitControllerTest.java
@@ -23,7 +23,6 @@ import cfa.vo.iris.sed.quantities.SPVYUnit;
 import cfa.vo.iris.sed.quantities.XUnit;
 import cfa.vo.iris.sed.stil.SegmentStarTable;
 import cfa.vo.iris.test.unit.TestUtils;
-import cfa.vo.iris.units.spv.XUnits;
 import cfa.vo.iris.visualizer.preferences.SedModel;
 import cfa.vo.iris.visualizer.stil.tables.IrisStarTable;
 import cfa.vo.iris.visualizer.stil.tables.IrisStarTableAdapter;
@@ -263,6 +262,17 @@ public class FitControllerTest {
 //        SegmentStarTable data = model.getDataTables().get(0).getPlotterDataTable();
 //        assertArrayEquals(new double[]{1.1, 1.2}, data.getSpecValues(), 0.001);
 //        assertArrayEquals(new double[]{2.1, 2.2}, data.getModelValues(), 0.001);
+    }
+    
+    @Test
+    public void testVersioning() throws Exception {
+        FitConfiguration ft = new FitConfiguration();
+        
+        int h1 = ft.hashCode();
+        assertEquals(h1, ft.hashCode());
+        
+        ft.getConfidence().setName("hi there");
+        assertNotEquals(h1, ft.hashCode());
     }
 
     private FitConfiguration createFit() throws Exception {

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/plotter/StilPlotterTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/plotter/StilPlotterTest.java
@@ -486,7 +486,7 @@ public class StilPlotterTest extends AbstractUISpecTest {
         model.getDataTables().get(0).getPlotterDataTable().setResidualValues(seg1.getSpectralAxisValues());
         
         // SedModel now has a version
-        model.setModelVersion(model.getVersion());
+        model.setModelVersion(model.computeVersion());
         model.setHasModelFunction(true);
         
         // Reset the plotter, no message should be sent

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/preferences/SedPreferencesTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/preferences/SedPreferencesTest.java
@@ -168,43 +168,43 @@ public class SedPreferencesTest {
         
         // Empty SED -> 0 version
         SedModel model = new SedModel(sed, adapter);
-        int h1 = model.getVersion();
+        int h1 = model.computeVersion();
         assertEquals(13, h1);
         
         // Add basic segment
         Segment segment1 = createSampleSegment();//createSampleSegment(new double[] {1,1}, new double[] {1,1});
         sed.addSegment(segment1);
         model.refresh();
-        int h2 = model.getVersion();
+        int h2 = model.computeVersion();
         assertFalse(h1 == h2);
 
         // Additional segment changes hashcode
         Segment segment2 = createSampleSegment(new double[] {1,2}, new double[] {2,2});
         sed.addSegment(segment2);
         model.refresh();
-        int h3 = model.getVersion();
+        int h3 = model.computeVersion();
         assertFalse(h2 == h3);
         
         // Remove 2nd segment
         sed.remove(segment2);
         model.refresh();
-        int h4 = model.getVersion();
+        int h4 = model.computeVersion();
         assertTrue(h2 == h4);
         
         // Changing values changes version
         segment1.setSpectralAxisValues(new double[] {1, 2, 100});
         model.refresh();
-        int h5 = model.getVersion();
+        int h5 = model.computeVersion();
         assertFalse(h4 == h5);
         
         // Masking points changes version
         model.getDataTables().get(0).applyMasks(new int[] {0});
-        int h6 = model.getVersion();
+        int h6 = model.computeVersion();
         assertFalse(h5 == h6);
         
         // Remove mask
         model.getDataTables().get(0).clearMasks();
-        int h7 = model.getVersion();
+        int h7 = model.computeVersion();
         assertTrue(h5 == h7);
     }
     

--- a/iris/src/test/java/cfa/vo/iris/fitting/IrisFunctionalIT.java
+++ b/iris/src/test/java/cfa/vo/iris/fitting/IrisFunctionalIT.java
@@ -19,6 +19,8 @@ import cfa.vo.iris.gui.widgets.ModelViewerPanel;
 import cfa.vo.iris.test.IrisAppResource;
 import cfa.vo.iris.test.unit.AbstractUISpecTest;
 import cfa.vo.iris.test.unit.TestUtils;
+
+import org.apache.commons.lang.StringUtils;
 import org.junit.*;
 import org.junit.rules.TemporaryFolder;
 import org.uispec4j.*;
@@ -204,11 +206,18 @@ public class IrisFunctionalIT extends AbstractUISpecTest {
     private void saveText() throws Exception {
         File outputFile = tempFolder.newFile("output.fit");
 
-        WindowInterceptor
-                .init(fittingView.getMenuBar().getMenu("File").getSubMenu("Save Text...").triggerClick())
-                .process(FileChooserHandler.init().select(outputFile.getAbsolutePath()))
-                .run()
-        ;
+        WindowInterceptor interceptor = WindowInterceptor
+                .init(fittingView.getMenuBar().getMenu("File").getSubMenu("Save Text...").triggerClick());
+        
+        interceptor.process(new WindowHandler() {
+            @Override
+            public Trigger process(Window w) throws Exception {
+                // Warning for changed data
+                junit.framework.Assert.assertTrue(StringUtils.contains(w.getTitle(), "Warning"));
+                w.getButton("Ok").click();
+                return Trigger.DO_NOTHING;
+            }
+        }).process(FileChooserHandler.init().select(outputFile.getAbsolutePath())).run();
 
         String expected = TestUtils.readFile(getClass(), "fit.output");
         String actual = com.google.common.io.Files.toString(outputFile, Charset.defaultCharset());


### PR DESCRIPTION
Includes changes for:

+ Making model evaluation synchronous, and show the exception if the re-evaluation fails.
+ Adjusting the hashCode method in the FitConfiguration class. Save the hashCode when performing a fit.
+ Showing a warning window before saving if the FitConfiguration has changed since the last fit.

Right now there's no warning window for when users are just changing param values, that's WIP, but I'm switching gears to get the async serialization stuff in today.