### PR TITLE
Fixes issue 332 (plotting negative values on a fixed log plot)

### DIFF
--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/StilPlotter.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/StilPlotter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 Smithsonian Astrophysical Observatory
+ * Copyright (C) 2015,2016 Smithsonian Astrophysical Observatory
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -277,7 +277,14 @@ public class StilPlotter extends JPanel {
         // forcing a redraw
         if (fixed && !forceReset) {
             PlaneAspect existingAspect = getPlotPreferences().getAspect();
-            display.setAspect(existingAspect);
+            
+            // If switching any axis from linear to log scale, only keep the 
+            // original aspect if that axis has positive values. Otherwise, an 
+            // error will occur when trying to calc the log of a negative number.
+            if ((getPlotPreferences().getXlog() && existingAspect.getXMin() > 0) 
+                    && (getPlotPreferences().getYlog() && existingAspect.getYMin() > 0)) {
+                display.setAspect(existingAspect);
+            }
         }
         
         // Add the display to the plot view

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/StilPlotter.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/StilPlotter.java
@@ -281,8 +281,10 @@ public class StilPlotter extends JPanel {
             // If switching any axis from linear to log scale, only keep the 
             // original aspect if that axis has positive values. Otherwise, an 
             // error will occur when trying to calc the log of a negative number.
-            if ((getPlotPreferences().getXlog() && existingAspect.getXMin() > 0) 
-                    && (getPlotPreferences().getYlog() && existingAspect.getYMin() > 0)) {
+            if ((getPlotPreferences().getXlog() && existingAspect.getXMin() <= 0) 
+                    || (getPlotPreferences().getYlog() && existingAspect.getYMin() <= 0)) {
+                // reset the axis
+            } else {
                 display.setAspect(existingAspect);
             }
         }

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/plotter/StilPlotterTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/plotter/StilPlotterTest.java
@@ -649,6 +649,37 @@ public class StilPlotterTest {
         assertEquals(.14787, StilPlotter.computeFittingLocation(aspect, true), 0.0001);
     }
     
+    @Test
+    public void testFixedPlotChangePlotType() throws Exception {
+        // for GH issue #332
+        ExtSed sed = new ExtSed("test", false);
+        StilPlotter plot = setUpTests(sed);
+        
+        PlaneAspect control = plot.getPlotDisplay().getAspect();
+        
+        // linear first
+        plot.setPlotType(PlotType.LINEAR);
+        
+        // set fixed
+        plot.getPlotPreferences().setFixed(true);
+        
+        // zoom out
+        double[] xlimits = new double[] {-3.3, 13.3};
+        double[] ylimits = new double[] {0, 13.3};
+        plot.getPlotDisplay().setAspect(new PlaneAspect(xlimits, ylimits));
+        
+        // now set to LOG scale. No exceptions should be thrown.
+        plot.setPlotType(PlotType.LOG);
+        
+        PlaneAspect aspect = plot.getPlotDisplay().getAspect();
+        
+        // Verify plot aspect goes back to default log scale values 
+        assertEquals(control.getXMax(), aspect.getXMax(), 0.01);
+        assertEquals(control.getYMax(), aspect.getYMax(), 0.01);
+        assertEquals(control.getXMin(), aspect.getXMin(), 0.01);
+        assertEquals(control.getYMin(), aspect.getYMin(), 0.01);
+    }
+    
     private StilPlotter setUpTests(ExtSed sed) throws Exception {
         preferences = new VisualizerComponentPreferences(ws, new SingleThreadExecutor());
         preferences.getDataStore().update(sed);

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/plotter/StilPlotterTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/plotter/StilPlotterTest.java
@@ -652,7 +652,7 @@ public class StilPlotterTest {
     @Test
     public void testFixedPlotChangePlotType() throws Exception {
         // for GH issue #332
-        ExtSed sed = new ExtSed("test", false);
+        ExtSed sed = new ExtSed("test", true);
         StilPlotter plot = setUpTests(sed);
         
         PlaneAspect control = plot.getPlotDisplay().getAspect();
@@ -678,6 +678,41 @@ public class StilPlotterTest {
         assertEquals(control.getYMax(), aspect.getYMax(), 0.01);
         assertEquals(control.getXMin(), aspect.getXMin(), 0.01);
         assertEquals(control.getYMin(), aspect.getYMin(), 0.01);
+        
+        // go back to linear, cause a SED change, and verify the plot aspect 
+        // doesn't change.
+        plot.setPlotType(PlotType.LINEAR);
+        
+        // zoom out
+        xlimits = new double[] {-3.3, 13.3};
+        ylimits = new double[] {0, 13.3};
+        plot.getPlotDisplay().setAspect(new PlaneAspect(xlimits, ylimits));
+        control = plot.getPlotDisplay().getAspect();
+        
+        // throw sed change
+        sed.addSegment(TestUtils.createSampleSegment());
+        preferences.getDataStore().update(sed);
+        preferences.updateSelectedSed(sed);
+        plot.setPreferences(preferences);
+        
+        // assert plot ranges haven't changed
+        aspect = plot.getPlotDisplay().getAspect();
+        assertEquals(control.getXMax(), aspect.getXMax(), 0.01);
+        assertEquals(control.getYMax(), aspect.getYMax(), 0.01);
+        assertEquals(control.getXMin(), aspect.getXMin(), 0.01);
+        assertEquals(control.getYMin(), aspect.getYMin(), 0.01);
+        
+        // now unset fixed plot range; ranges should update on sed change
+        plot.getPlotPreferences().setFixed(false);
+        preferences.getDataStore().update(sed);
+        preferences.updateSelectedSed(sed);
+        plot.setPreferences(preferences);
+        
+        aspect = plot.getPlotDisplay().getAspect();
+        assertNotEquals(control.getXMax(), aspect.getXMax(), 0.01);
+        assertNotEquals(control.getYMax(), aspect.getYMax(), 0.01);
+        assertNotEquals(control.getXMin(), aspect.getXMin(), 0.01);
+        assertNotEquals(control.getYMin(), aspect.getYMin(), 0.01);
     }
     
     private StilPlotter setUpTests(ExtSed sed) throws Exception {


### PR DESCRIPTION
This PR addresses bug #332. 

When switching from a linear scale to a logarithmic scale on a fixed plot, the X and Y axis ranges are checked for negative values. If no negative axes ranges are found, the aspect is kept and used for the updated display. Otherwise, the display is reset to the full, default view of the SED. In other words, if _either axis_ has a minimum value of 0 or less, the whole plot is reset, even if the offending axis is to remain linear.

The check is done in StilPlotter.resetPlot().

A test which follows the steps reported in the #332 bug report is added to StilPlotterTest. Tests were also done by hand to check the code works as expected with various plot scale changes.
