### PR TITLE
Bug 334 error in legend label

### DIFF
--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/LayerModel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/LayerModel.java
@@ -98,6 +98,7 @@ public class LayerModel {
         
         this.setInSource(table);
         this.suffix = table.getName();
+        this.leglabel = table.getName();
         
         this.xColName = SegmentColumn.Column.Spectral_Value.name();
         this.yColName = SegmentColumn.Column.Flux_Value.name();

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerDataModel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerDataModel.java
@@ -344,6 +344,7 @@ public class VisualizerDataModel {
         
         model.getInSource().setName(id);
         model.setSuffix(id);
+        model.setLabel(id);
         labels.add(id);
     }
     

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/plotter/StilPlotterTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/plotter/StilPlotterTest.java
@@ -110,6 +110,15 @@ public class StilPlotterTest {
         assertEquals(layers[0].getDataSpec().getSourceTable().getRowCount(), 
                 layers[1].getDataSpec().getSourceTable().getRowCount());
         
+        // the legend label should match the segment startable names
+        plot.getDataModel().getLayerModels();
+        par = new StringParameter("leglabel3C 273");
+        env.acquireValue(par);
+        assertEquals(par.objectValue(env), "3C 273");
+        par = new StringParameter("leglabel3C 273_ERROR");
+        env.acquireValue(par);
+        assertEquals(par.objectValue(env), "3C 273");
+        
         // assert that the plot has the same amount of data as the original SED
         assertEquals(sed.getSegment(0).getLength(),
                 layers[0].getDataSpec().getSourceTable().getRowCount());


### PR DESCRIPTION
Addresses #334 - "_ERROR" is appended to each Segment label in the Plotter legend

This change fixes #334 by setting the LayerModel's `leglabel` in VisualizerDataModel to the LayerModel's `suffix` (which by default is the segment StarTable's name). Like the metadata browser, the legend labels are incremented by 1, 2, 3, etc. for segments which share the same base table name. 

For example, if there are two segments with the target name "MESSIER 87", the first segment plotted has the label "MESSIER 87," while the second one is labeled "MESSIER 87 1". A third segment of the same name would be "MESSIER 87 2".

Before this fix, the LayerModel's `leglabel` property was always set to 'null'. By default, STILTS uses the `suffix` property as the Layer's label if the `leglabel` property isn't set. STILTS must have been picking up the error LayerModel's `suffix` for the some of the segment's labels. Setting the Layer's `leglabel` manually then forces STILTS to use the right label.

A test was added to StilPlotterTest to check that the `leglabel` property is not null and is set to the proper value.