### PR TITLE
Move "Add ranges" button and prevent unnecessary 'SED changed' warning

### DIFF
--- a/iris-common/src/main/java/cfa/vo/iris/fitting/FitConfiguration.java
+++ b/iris-common/src/main/java/cfa/vo/iris/fitting/FitConfiguration.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2016 Smithsonian Astrophysical Observatory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package cfa.vo.iris.fitting;
 
 import cfa.vo.iris.fitting.custom.DefaultCustomModel;

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FitController.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FitController.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2016 Smithsonian Astrophysical Observatory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package cfa.vo.iris.fitting;
 
 import cfa.vo.interop.SAMPFactory;
@@ -305,7 +320,7 @@ public class FitController {
         
         // Update the model version with the current version of the Sed
         sedModel.setModelVersion(sedModel.computeVersion());
-        sedModel.setHasModelFunction(true);
+        sedModel.setHasModelFunction(true);  // TODO: should this happen? what if no model exists?
         
         String xUnit = sedModel.getXUnits();
         String yUnit = sedModel.getYUnits();

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.form
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.form
@@ -216,14 +216,14 @@
                                   </Events>
                                   <Constraints>
                                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-                                      <GridBagConstraints gridX="0" gridY="5" gridWidth="2" gridHeight="1" fill="2" ipadX="82" ipadY="0" insetsTop="6" insetsLeft="0" insetsBottom="6" insetsRight="0" anchor="17" weightX="1.0" weightY="0.0"/>
+                                      <GridBagConstraints gridX="0" gridY="4" gridWidth="2" gridHeight="1" fill="2" ipadX="82" ipadY="0" insetsTop="6" insetsLeft="0" insetsBottom="6" insetsRight="0" anchor="17" weightX="1.0" weightY="0.0"/>
                                     </Constraint>
                                   </Constraints>
                                 </Component>
                                 <Container class="javax.swing.JPanel" name="jPanel6">
                                   <Constraints>
                                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-                                      <GridBagConstraints gridX="0" gridY="4" gridWidth="2" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="0.0" weightY="0.0"/>
+                                      <GridBagConstraints gridX="0" gridY="5" gridWidth="2" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="0.0" weightY="0.0"/>
                                     </Constraint>
                                   </Constraints>
 
@@ -305,7 +305,7 @@
                           <Layout>
                             <DimensionLayout dim="0">
                               <Group type="103" groupAlignment="0" attributes="0">
-                                  <Component id="resultsPanel" alignment="0" pref="318" max="32767" attributes="0"/>
+                                  <Component id="resultsPanel" alignment="0" max="32767" attributes="0"/>
                               </Group>
                             </DimensionLayout>
                             <DimensionLayout dim="1">

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.java
@@ -259,7 +259,7 @@ public class FittingMainView extends JInternalFrame implements SedListener {
         });
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy = 5;
+        gridBagConstraints.gridy = 4;
         gridBagConstraints.gridwidth = 2;
         gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
         gridBagConstraints.ipadx = 82;
@@ -298,7 +298,7 @@ public class FittingMainView extends JInternalFrame implements SedListener {
 
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy = 4;
+        gridBagConstraints.gridy = 5;
         gridBagConstraints.gridwidth = 2;
         gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
         jPanel5.add(jPanel6, gridBagConstraints);
@@ -317,7 +317,7 @@ public class FittingMainView extends JInternalFrame implements SedListener {
         );
         modelPanelLayout.setVerticalGroup(
             modelPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addComponent(jSplitPane3, javax.swing.GroupLayout.DEFAULT_SIZE, 229, Short.MAX_VALUE)
+            .addComponent(jSplitPane3, javax.swing.GroupLayout.PREFERRED_SIZE, 229, Short.MAX_VALUE)
         );
 
         jSplitPane4.setLeftComponent(modelPanel);
@@ -331,7 +331,7 @@ public class FittingMainView extends JInternalFrame implements SedListener {
         resultsContainer.setLayout(resultsContainerLayout);
         resultsContainerLayout.setHorizontalGroup(
             resultsContainerLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addComponent(resultsPanel, javax.swing.GroupLayout.DEFAULT_SIZE, 318, Short.MAX_VALUE)
+            .addComponent(resultsPanel, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
         );
         resultsContainerLayout.setVerticalGroup(
             resultsContainerLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/StilPlotter.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/StilPlotter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 Smithsonian Astrophysical Observatory
+ * Copyright (C) 2015, 2016 Smithsonian Astrophysical Observatory
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedModel.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/SedModel.java
@@ -435,13 +435,14 @@ public class SedModel {
     }
 
     /**
-     * Clears fitting data from the underlying star tables, and resets the FitConfiguration
-     * to default, empty values.
+     * Clears fitting data from the underlying star tables, and resets the 
+     * FitConfiguration to default, empty values.
      */
     public void clearFittingData() {
         for (IrisStarTable table : this.getDataTables()) {
             table.getPlotterDataTable().clearModelValues();
         }
         sed.getFit().reset();
+        this.setHasModelFunction(false);
     }
 }

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/plotter/StilPlotterTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/plotter/StilPlotterTest.java
@@ -519,11 +519,20 @@ public class StilPlotterTest {
         Segment seg3 = TestUtils.createSampleSegment();
         sed1.addSegment(seg3);
         preferences.getDataStore().update(sed1, seg3);
+        plot.setSeds(Arrays.asList(sed1));
+        
+        // no warning pops up
         
         // add new model, then add a segment. The warning should pop up again.
         model.getDataTables().get(0).getPlotterDataTable().setModelValues(seg1.getFluxAxisValues());
-        preferences.getDataStore().update(sed1, seg2);
+        model.setModelVersion(model.computeVersion());
+        model.setHasModelFunction(true);
         
+        Segment seg4 = TestUtils.createSampleSegment();
+        sed1.addSegment(seg4);
+        preferences.getDataStore().update(sed1, seg4);
+        
+        // intercept warning message on plotting the updated sed
         WindowInterceptor.init(new Trigger() {
             @Override
             public void run() throws Exception {

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/plotter/StilPlotterTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/plotter/StilPlotterTest.java
@@ -511,6 +511,18 @@ public class StilPlotterTest {
         
         // Now that it has been run, the dialog should not show up again
         plot.setSeds(Arrays.asList(sed1));
+        
+        // for iris-#336 bug. Now clear the model and add a 
+        // segment; no warning message should pop up as there is no model.
+        model.clearFittingData();
+        
+        Segment seg3 = TestUtils.createSampleSegment();
+        sed1.addSegment(seg3);
+        preferences.getDataStore().update(sed1, seg3);
+        
+        // add new model, then add a segment. The warning should pop up again.
+        model.getDataTables().get(0).getPlotterDataTable().setModelValues(seg1.getFluxAxisValues());
+        plot.setSeds(Arrays.asList(sed1));
     }
     
     @Test

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/plotter/StilPlotterTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/plotter/StilPlotterTest.java
@@ -522,7 +522,22 @@ public class StilPlotterTest {
         
         // add new model, then add a segment. The warning should pop up again.
         model.getDataTables().get(0).getPlotterDataTable().setModelValues(seg1.getFluxAxisValues());
-        plot.setSeds(Arrays.asList(sed1));
+        preferences.getDataStore().update(sed1, seg2);
+        
+        WindowInterceptor.init(new Trigger() {
+            @Override
+            public void run() throws Exception {
+                plot.setSeds(Arrays.asList(sed1));
+            }
+        }).process(new WindowHandler() {
+            @Override
+            public Trigger process(Window warning) throws Exception {
+                assertTrue(StringUtils.contains(warning.getTitle(), "Warning"));
+                assertTrue(StringUtils.contains(
+                        warning.getTextBox("Warning").getText(), sed1.getId()));
+                return Trigger.DO_NOTHING;
+            }
+        }).run();
     }
     
     @Test

--- a/iris/src/main/java/cfa/vo/iris/vizier/VizierFrame.java
+++ b/iris/src/main/java/cfa/vo/iris/vizier/VizierFrame.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012, 2015 Smithsonian Astrophysical Observatory
+ * Copyright (C) 2012, 2015, 2016 Smithsonian Astrophysical Observatory
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Addresses:
#336 
ChandraCXC/iris-dev/issues/118

# Description

These changes are minor updates to the Fitting Tool:

- (ChandraCXC/iris-dev/issues/118) The "Add Ranges" button is moved to be above the "Fit" button and associated widgets.
- (#336) When a SED is fit, its model is cleared, and then changed (new segment, new masked points), a "SED changed" warning no longer appears. 

   The warning is called from `StilPlotter.validateModelFunctions()` if `SedModel.hasModelFunction` is True or if the SedModel's model version has changed. This PR sets `hasModelFunction` to False in `SedModel.clearFittingData()`.

# Testing

A test has been added to StilPlotter.testModelFunctionValidity() to check the fix to #336. Testing was done by hand to check that masking or otherwise editing the SED after the model was cleared did not cause the warning message to popup, and to check that the "Add Ranges" button still functions as expected.