### PR TITLE
Iris dev #89 no warning save model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target
 .idea
 *.iml
 nbactions.xml
+.DS_Store

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.java
@@ -717,7 +717,28 @@ public class FittingMainView extends JInternalFrame implements SedListener {
             int result = chooser.showSaveDialog(FittingMainView.this);
             if (result == JFileChooser.APPROVE_OPTION) {
                 try {
-                    controller.saveJson(new FileOutputStream(chooser.getSelectedFile()));
+                    
+                    boolean overwrite = true;
+                    int resp = NarrowOptionPane.YES_OPTION;
+                    
+                    String filePath = chooser.getSelectedFile().getAbsolutePath();
+                    
+                    if (chooser.getSelectedFile().exists()) {
+                        resp = NarrowOptionPane.showConfirmDialog(FittingMainView.this,
+                            filePath + " exists, do you want to overwrite it?", 
+                            "File exists", NarrowOptionPane.YES_NO_OPTION);
+                    }
+                    
+                    // overwrite and response are always true UNLESS the user 
+                    // specifies otherwise in the OptionPane above.
+                    overwrite = (resp == NarrowOptionPane.YES_OPTION);
+                    if (overwrite) {
+                        controller.saveJson(new FileOutputStream(chooser.getSelectedFile()));
+                        NarrowOptionPane.showMessageDialog(FittingMainView.this, 
+                                "Saved file " + filePath, "Saved File", 
+                                NarrowOptionPane.INFORMATION_MESSAGE);
+                    }
+
                 } catch(IOException ex) {
                     NarrowOptionPane.showMessageDialog(FittingMainView.this, ex.getMessage(), "Error", NarrowOptionPane.ERROR_MESSAGE);
                 }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.java
@@ -698,7 +698,26 @@ public class FittingMainView extends JInternalFrame implements SedListener {
             int result = chooser.showSaveDialog(FittingMainView.this);
             if (result == JFileChooser.APPROVE_OPTION) {
                 try {
-                    controller.save(new FileOutputStream(chooser.getSelectedFile()));
+                    boolean overwrite = true;
+                    int resp = NarrowOptionPane.YES_OPTION;
+                    
+                    String filePath = chooser.getSelectedFile().getAbsolutePath();
+                    
+                    if (chooser.getSelectedFile().exists()) {
+                        resp = NarrowOptionPane.showConfirmDialog(FittingMainView.this,
+                            filePath + " exists, do you want to overwrite it?", 
+                            "File exists", NarrowOptionPane.YES_NO_OPTION);
+                    }
+                    
+                    // overwrite and response are always true UNLESS the user 
+                    // specifies otherwise in the OptionPane above.
+                    overwrite = (resp == NarrowOptionPane.YES_OPTION);
+                    if (overwrite) {
+                        controller.save(new FileOutputStream(chooser.getSelectedFile()));
+                        NarrowOptionPane.showMessageDialog(FittingMainView.this, 
+                                "Saved file " + filePath, "Saved File", 
+                                NarrowOptionPane.INFORMATION_MESSAGE);
+                    }
                 } catch(FileNotFoundException ex) {
                     NarrowOptionPane.showMessageDialog(FittingMainView.this, ex.getMessage(), "Error", NarrowOptionPane.ERROR_MESSAGE);
                 }
@@ -717,18 +736,17 @@ public class FittingMainView extends JInternalFrame implements SedListener {
             int result = chooser.showSaveDialog(FittingMainView.this);
             if (result == JFileChooser.APPROVE_OPTION) {
                 try {
-                    
                     boolean overwrite = true;
                     int resp = NarrowOptionPane.YES_OPTION;
-                    
+
                     String filePath = chooser.getSelectedFile().getAbsolutePath();
-                    
+
                     if (chooser.getSelectedFile().exists()) {
                         resp = NarrowOptionPane.showConfirmDialog(FittingMainView.this,
                             filePath + " exists, do you want to overwrite it?", 
                             "File exists", NarrowOptionPane.YES_NO_OPTION);
                     }
-                    
+
                     // overwrite and response are always true UNLESS the user 
                     // specifies otherwise in the OptionPane above.
                     overwrite = (resp == NarrowOptionPane.YES_OPTION);
@@ -738,7 +756,6 @@ public class FittingMainView extends JInternalFrame implements SedListener {
                                 "Saved file " + filePath, "Saved File", 
                                 NarrowOptionPane.INFORMATION_MESSAGE);
                     }
-
                 } catch(IOException ex) {
                     NarrowOptionPane.showMessageDialog(FittingMainView.this, ex.getMessage(), "Error", NarrowOptionPane.ERROR_MESSAGE);
                 }

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.form
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.form
@@ -276,21 +276,6 @@
             </Constraint>
           </Constraints>
         </Component>
-        <Component class="javax.swing.JSpinner" name="fluxOrDensity">
-          <Properties>
-            <Property name="model" type="javax.swing.SpinnerModel" editor="org.netbeans.modules.form.editors2.SpinnerModelEditor">
-              <SpinnerModel type="list">
-                <ListItem value="Flux"/>
-                <ListItem value="Flux Density"/>
-              </SpinnerModel>
-            </Property>
-          </Properties>
-          <Constraints>
-            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-              <GridBagConstraints gridX="9" gridY="0" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="5" insetsLeft="0" insetsBottom="0" insetsRight="9" anchor="12" weightX="0.0" weightY="0.0"/>
-            </Constraint>
-          </Constraints>
-        </Component>
         <Component class="javax.swing.JButton" name="zoomOut">
           <Properties>
             <Property name="text" type="java.lang.String" value="Out"/>

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/plotter/PlotterView.java
@@ -227,7 +227,6 @@ public class PlotterView extends JInternalFrame {
         btnReset = new javax.swing.JButton();
         zoomIn = new javax.swing.JButton();
         btnUnits = new javax.swing.JButton();
-        fluxOrDensity = new javax.swing.JSpinner();
         zoomOut = new javax.swing.JButton();
         metadataButton = new javax.swing.JButton();
         buttonPanel = new javax.swing.JPanel();
@@ -350,14 +349,6 @@ public class PlotterView extends JInternalFrame {
         gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHEAST;
         gridBagConstraints.insets = new java.awt.Insets(5, 0, 0, 0);
         topButtonsPanel.add(btnUnits, gridBagConstraints);
-
-        fluxOrDensity.setModel(new javax.swing.SpinnerListModel(new String[] {"Flux", "Flux Density"}));
-        gridBagConstraints = new java.awt.GridBagConstraints();
-        gridBagConstraints.gridx = 9;
-        gridBagConstraints.gridy = 0;
-        gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHEAST;
-        gridBagConstraints.insets = new java.awt.Insets(5, 0, 0, 9);
-        topButtonsPanel.add(fluxOrDensity, gridBagConstraints);
 
         zoomOut.setText("Out");
         zoomOut.addActionListener(new java.awt.event.ActionListener() {
@@ -719,7 +710,6 @@ public class PlotterView extends JInternalFrame {
     private javax.swing.JPanel buttonPanel;
     private cfa.vo.iris.visualizer.plotter.JButtonArrow down;
     private javax.swing.JButton evaluateButton;
-    private javax.swing.JSpinner fluxOrDensity;
     private cfa.vo.iris.visualizer.plotter.JButtonArrow left;
     private javax.swing.JMenuBar menuBar;
     private javax.swing.JButton metadataButton;

--- a/iris/src/test/java/cfa/vo/iris/fitting/IrisFunctionalIT.java
+++ b/iris/src/test/java/cfa/vo/iris/fitting/IrisFunctionalIT.java
@@ -205,7 +205,7 @@ public class IrisFunctionalIT extends AbstractUISpecTest {
     }
 
     private void saveText() throws Exception {
-        File outputFile = tempFolder.newFile("output.fit");
+        String outputFile = tempFolder.getRoot().getAbsolutePath()+"output.fit";
 
         WindowInterceptor interceptor = WindowInterceptor
                 .init(fittingView.getMenuBar().getMenu("File").getSubMenu("Save Text...").triggerClick());
@@ -218,10 +218,10 @@ public class IrisFunctionalIT extends AbstractUISpecTest {
                 w.getButton("Ok").click();
                 return Trigger.DO_NOTHING;
             }
-        }).process(FileChooserHandler.init().select(outputFile.getAbsolutePath())).run();
+        }).process(FileChooserHandler.init().select(outputFile)).run();
 
         String expected = TestUtils.readFile(getClass(), "fit.output");
-        String actual = com.google.common.io.Files.toString(outputFile, Charset.defaultCharset());
+        String actual = com.google.common.io.Files.toString(new File(outputFile), Charset.defaultCharset());
         actual = actual.replaceAll("(/home/.*?/|/Users/.*?/)", "\\$HOME/");
 
         assertEquals(expected, actual);


### PR DESCRIPTION
# Description

This PR fixed ChandraCXC/iris-dev#89, where no warning message appeared if the user tries to overwrite an existing file. Now a warning message pops up asking the user if they wish to overwrite the file or not.

Also added to this PR is the removal of the 'Flux/Flux Density' spinner from the Plot window, as it is unused.

The `.gitignore` file is updated to exlcude *.DS_store files.

# Testing

Tests for overwriting and canceling the overwrite have been added to the functions `testSaveText()` and `testSaveJson()` in FittingToolComponentTest.java. Tests were also performed by hand to ensure the right confirmation message appeared when selecting an existing filename in the JFileChooser, and that all the buttons -- Yes, No, and the dispose 'X' button -- worked as expected.