### PR TITLE
Make sure clearAll button clears selected parameter, if any

### DIFF
--- a/iris-common/src/main/java/cfa/vo/iris/gui/widgets/ModelParameterPanel.java
+++ b/iris-common/src/main/java/cfa/vo/iris/gui/widgets/ModelParameterPanel.java
@@ -49,8 +49,11 @@ public class ModelParameterPanel extends AbstractGridPanel {
         createBinding("min", min, "text");
         createBinding("max", max, "text");
         createBinding("frozen", frozen, "selected");
-        Binding name = group.getBinding("name");
-        name.setSourceUnreadableValue("No Parameter Selected");
+        group.getBinding("name").setSourceUnreadableValue("No Parameter Selected");
+        group.getBinding("val").setSourceUnreadableValue("");
+        group.getBinding("min").setSourceUnreadableValue("");
+        group.getBinding("max").setSourceUnreadableValue("");
+        group.getBinding("frozen").setSourceUnreadableValue(false);
     }
 
     @Override

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.java
@@ -597,6 +597,7 @@ public class FittingMainView extends JInternalFrame implements SedListener {
         controller.clearAll();
         preferences.getDataModel().refresh();
         confidencePanel.reset();
+        modelViewerPanel.setSelectedParameter(null);
     }//GEN-LAST:event_clearButtonActionPerformed
 
     // Variables declaration - do not modify//GEN-BEGIN:variables

--- a/iris/src/test/java/cfa/vo/iris/fitting/IrisFunctionalIT.java
+++ b/iris/src/test/java/cfa/vo/iris/fitting/IrisFunctionalIT.java
@@ -90,6 +90,20 @@ public class IrisFunctionalIT extends AbstractUISpecTest {
         fitCustomModel();
         saveText();
         simplefit();
+        clearAll();
+    }
+
+    private void clearAll() {
+        Button clearAll = fittingView.getButton("Clear All");
+        clearAll.click();
+        TextBox current = fittingView.getInputTextBox("Name");
+        current.textEquals("No Parameter Selected").check();
+        current = fittingView.getInputTextBox("Min");
+        current.textIsEmpty().check();
+        current = fittingView.getInputTextBox("Max");
+        current.textIsEmpty().check();
+        CheckBox frozen = fittingView.getCheckBox("Frozen");
+        UISpecAssert.not(frozen.isSelected()).check();
     }
 
     private void simplefit() throws Exception {


### PR DESCRIPTION
This PR ensures that when clicking "Clear All" in the fitting tool, if a parameter is selected in the model view panel, then the parameter is cleared as well.