### PR TITLE
make sed extraction asynchronous and safer

### DIFF
--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainView.java
@@ -589,8 +589,13 @@ public class MetadataBrowserMainView extends javax.swing.JInternalFrame {
             @Override
             protected void done() {
                 try {
-                    ExtSed sed = get();
-                    preferences.addSed(sed);
+                    final ExtSed sed = get();
+                    SwingUtilities.invokeLater(new Runnable() {
+                        @Override
+                        public void run() {
+                            preferences.addSed(sed);
+                        }
+                    });
                     JOptionPane.showMessageDialog(MetadataBrowserMainView.this, "Adding new SED (" + sed.getId() + ") to workspace.");
                 } catch (InterruptedException ex) {
                     // noop

--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerComponentPreferences.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/preferences/VisualizerComponentPreferences.java
@@ -136,7 +136,7 @@ public class VisualizerComponentPreferences {
      */
     public ExtSed createNewWorkspaceSed(RowSelection selection) throws SedInconsistentException, SedNoDataException {
         
-        final ExtSed sed = (ExtSed) ws.getSedManager().newSed("FilterSed");
+        final ExtSed sed = new ExtSed("FilterSed", false);
         
         // Extract selected rows to new Segments
         final SegmentExtractor extractor =
@@ -249,5 +249,9 @@ public class VisualizerComponentPreferences {
             preferencesStore.put(key, prefs);
             return prefs;
         }
+    }
+
+    public void addSed(ExtSed sed) {
+        ws.getSedManager().add(sed);
     }
 }

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainViewTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/metadata/MetadataBrowserMainViewTest.java
@@ -376,7 +376,7 @@ public class MetadataBrowserMainViewTest extends AbstractUISpecTest {
                 // Check warning message
                 assertEquals("No SEDs in browser. Please load an SED.", 
                         warning.getTextBox("OptionPane.label").getText());
-                return Trigger.DO_NOTHING;
+                return warning.getButton("OK").triggerClick();
             }
         }).run();
         
@@ -414,7 +414,7 @@ public class MetadataBrowserMainViewTest extends AbstractUISpecTest {
                 // Check warning message
                 assertEquals(warning.getTextBox("OptionPane.label").getText(), 
                              "No rows selected to extract. Please select rows.");
-                return Trigger.DO_NOTHING;
+                return warning.getButton("OK").triggerClick();
             }
         }).run();
         
@@ -427,8 +427,8 @@ public class MetadataBrowserMainViewTest extends AbstractUISpecTest {
             public Trigger process(Window warning) throws Exception {
                 // Check warning message
                 assertTrue(StringUtils.contains(warning.getTextBox("OptionPane.label").getText(), 
-                             "Added new SED"));
-                return Trigger.DO_NOTHING;
+                             "Adding new SED"));
+                return warning.getButton("OK").triggerClick();
             }
         }).run();
         
@@ -470,8 +470,8 @@ public class MetadataBrowserMainViewTest extends AbstractUISpecTest {
             public Trigger process(Window warning) throws Exception {
                 // Check warning message
                 assertTrue(StringUtils.contains(warning.getTextBox("OptionPane.label").getText(), 
-                             "Added new SED"));
-                return Trigger.DO_NOTHING;
+                             "Adding new SED"));
+                return warning.getButton("OK").triggerClick();
             }
         }).run();
         


### PR DESCRIPTION
I can't reproduce ChandraCXC/iris-dev#128. However, investigating the issue I found out the implementation of the extraction could be made safer and asynchronous. At the very least, if the issue can be reproduced on some systems, this PR should minimize it by a) not stopping the GUI thread and b) by creating and populating the SED first and adding it to the SedManager only when ready.

A couple of questions for @jbudynk on the UI. I didn't include a spinning wheel, do you think we need one? Also, I did not add a Stop button as the Stop functionality should be implemented, and I didn't look into what that would require. If you feel strongly we should add a Stop button I'll look into it, maybe after we have addressed the current outstanding issues.