### PR TITLE
Handle index column sorting (and fix ChandraCXC/iris-dev#116)

### DIFF
--- a/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/IrisStarJTable.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/visualizer/metadata/IrisStarJTable.java
@@ -406,26 +406,34 @@ public class IrisStarJTable extends StarJTable {
             StarTable newTable)
     {
         List<SortKey> newKeys = new ArrayList<>(1);
-        
+
         if (CollectionUtils.isEmpty(keys)) {
             return newKeys;
         }
-        
+
         // Primary key
         SortKey key = keys.get(0);
-        ColumnInfo info = oldTable.getColumnInfo(key.getColumn() - 1);
-        
-        // Is the new key in the current star table?        
+        int idx = key.getColumn() - 1;
+        ColumnInfo info = null;
+        if (idx != -1) { // index column
+            info = oldTable.getColumnInfo(idx);
+        }
+
+        // Is the new key in the current star table?
         ColumnIdentifier id = new ColumnIdentifier(newTable);
         int newCol = 1; // Starts at 1 because of the index column
         try {
-            newCol += id.getColumnIndex(info.getName());
+            if (info != null) {
+                newCol += id.getColumnIndex(info.getName());
+            } else { // index column
+                newCol = 0;
+            }
         } catch (IOException ex) {
             return newKeys;
         }
-        
+
         newKeys.add(new SortKey(newCol, key.getSortOrder()));
-        
+
         return newKeys;
     }
 }

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/metadata/IrisStarJTableTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/metadata/IrisStarJTableTest.java
@@ -312,4 +312,36 @@ public class IrisStarJTableTest {
         assertEquals(true, table.getValueAt(2, 1));
         table.setSelectedStarTables(Arrays.asList(segTable));
     }
+
+    @Test
+    public void testRowSortErrorIndexCol() throws Exception {
+        IrisStarJTable table = new IrisStarJTable();
+        table.setSortBySpecValues(true);
+        table.setUsePlotterDataTables(true);
+
+        // Create Segment
+        IrisStarTable segTable = adapter.convertSegment(TestUtils.createSampleSegment(
+                new double[] {10,20,30}, new double[] {40,50,60}));
+        table.setSelectedStarTables(Arrays.asList(segTable));
+
+        // Sort by Original Flux Value (last column)
+        table.getRowSorter().setSortKeys(Arrays.asList(new RowSorter.SortKey(0, SortOrder.DESCENDING)));
+
+        // Verify table values
+        assertEquals(30.0, table.getValueAt(0, 2));
+        assertEquals(20.0, table.getValueAt(1, 2));
+        assertEquals(10.0, table.getValueAt(2, 2));
+
+        // Apply a mask
+        segTable.applyMasks(new int[] {0});
+
+        // Resetting should preserve sort order
+        table.setSelectedStarTables(Arrays.asList(segTable));
+
+        // Verify table values
+        assertEquals(false, table.getValueAt(0, 1));
+        assertEquals(false, table.getValueAt(1, 1));
+        assertEquals(true, table.getValueAt(2, 1));
+        table.setSelectedStarTables(Arrays.asList(segTable));
+    }
 }


### PR DESCRIPTION
This PR fixes ChandraCXC/iris-dev#116 by properly handling the index column.

There is an issue, though it pre-exists this PR: [this test](https://github.com/ChandraCXC/iris/blob/081f1a86078362748af0bacc2af985c3bffe73ff/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/metadata/IrisStarJTableTest.java#L255) seems to suggest sorting order should be preserved when a segment is added to an SED. However, that does not seem the case when running Iris. This PR does not fix that issue, but the fix will hopefully be compatible with an actual fix. 