### PR TITLE
Fix irisdev 131 update fit stats

### DIFF
--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.form
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.form
@@ -305,7 +305,7 @@
                           <Layout>
                             <DimensionLayout dim="0">
                               <Group type="103" groupAlignment="0" attributes="0">
-                                  <Component id="resultsPanel" alignment="0" max="32767" attributes="0"/>
+                                  <Component id="resultsPanel" alignment="0" pref="318" max="32767" attributes="0"/>
                               </Group>
                             </DimensionLayout>
                             <DimensionLayout dim="1">

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.java
@@ -98,6 +98,7 @@ public class FittingMainView extends JInternalFrame implements SedListener {
         if (SedCommand.SELECTED.equals(payload) || 
                 (SedCommand.CHANGED.equals(payload) && source.equals(sedModel.getSed()))) {
             setSedModel(dataStore.getSedModel(source));
+            resultsPanel.setFit(dataStore.getSedModel(source).getFit());
         }
     }
 

--- a/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.java
+++ b/iris-visualizer/src/main/java/cfa/vo/iris/fitting/FittingMainView.java
@@ -317,7 +317,7 @@ public class FittingMainView extends JInternalFrame implements SedListener {
         );
         modelPanelLayout.setVerticalGroup(
             modelPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addComponent(jSplitPane3, javax.swing.GroupLayout.PREFERRED_SIZE, 229, Short.MAX_VALUE)
+            .addComponent(jSplitPane3, javax.swing.GroupLayout.DEFAULT_SIZE, 229, Short.MAX_VALUE)
         );
 
         jSplitPane4.setLeftComponent(modelPanel);
@@ -331,7 +331,7 @@ public class FittingMainView extends JInternalFrame implements SedListener {
         resultsContainer.setLayout(resultsContainerLayout);
         resultsContainerLayout.setHorizontalGroup(
             resultsContainerLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addComponent(resultsPanel, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+            .addComponent(resultsPanel, javax.swing.GroupLayout.DEFAULT_SIZE, 318, Short.MAX_VALUE)
         );
         resultsContainerLayout.setVerticalGroup(
             resultsContainerLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)

--- a/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/FittingToolComponentTest.java
+++ b/iris-visualizer/src/test/java/cfa/vo/iris/visualizer/FittingToolComponentTest.java
@@ -73,6 +73,50 @@ public class FittingToolComponentTest extends AbstractComponentGUITest {
     }
 
     @Test
+    public void testSwitchSedAfterFitting() throws Exception {
+        ExtSed sed = sedManager.newSed("TestSed");
+        final Window mainFit = setupFitWindow(sed);
+
+        FitConfiguration fit = createFit();
+        fit.setStatVal(200.0);
+        fit.setrStat(300.0);
+        fit.setqVal(400.0);
+        fit.setnFev(10);
+        fit.setNumPoints(1000);
+        fit.setDof(5);
+        sed.setFit(fit);
+
+        ExtSed sed2 = sedManager.newSed("TestSed2");
+
+        fit = createFit();
+        fit.setStatVal(2000.0);
+        fit.setrStat(3000.0);
+        fit.setqVal(4000.0);
+        fit.setnFev(100);
+        fit.setNumPoints(10000);
+        fit.setDof(50);
+        sed2.setFit(fit);
+
+        sedManager.select(sed);
+
+        UISpecAssert.waitUntil(mainFit.getInputTextBox("final fit").textEquals("200.0"), 5000);
+        mainFit.getInputTextBox("reduced").textEquals("300.0");
+        mainFit.getInputTextBox("q-value").textEquals("400.0");
+        mainFit.getInputTextBox("evaluations").textEquals("10.0");
+        mainFit.getInputTextBox("points").textEquals("1000.0");
+        mainFit.getInputTextBox("degrees").textEquals("5");
+
+        sedManager.select(sed2);
+
+        UISpecAssert.waitUntil(mainFit.getInputTextBox("final fit").textEquals("2000.0"), 5000);
+        mainFit.getInputTextBox("reduced").textEquals("3000.0");
+        mainFit.getInputTextBox("q-value").textEquals("4000.0");
+        mainFit.getInputTextBox("evaluations").textEquals("100.0");
+        mainFit.getInputTextBox("points").textEquals("10000.0");
+        mainFit.getInputTextBox("degrees").textEquals("50");
+    }
+
+    @Test
     public void testFittingNoSed() throws Exception {
         WindowInterceptor wi = WindowInterceptor.init(
             window.getMenuBar()

--- a/iris/src/test/java/cfa/vo/iris/fitting/IrisFunctionalIT.java
+++ b/iris/src/test/java/cfa/vo/iris/fitting/IrisFunctionalIT.java
@@ -127,6 +127,7 @@ public class IrisFunctionalIT extends AbstractUISpecTest {
         UISpecAssert.waitUntil(np.textEquals("23"), TIMEOUT);
 
         TextBox statS = fittingView.getInputTextBox("Final Fit Statistic");
+        UISpecAssert.waitUntil(UISpecAssert.not(statS.textIsEmpty()), 5000);
         Double stat = Double.valueOf(statS.getText());
         assertEquals(14102.333, stat, 0.01);
 


### PR DESCRIPTION
This PR makes sure that the fit summary panel is updated when a SED is selected, not only after a fit.

A test was failing on Travis, so I added another timeout.

This PR also reverts back most of the changes in PR #340 that introduced issues in the Fitting Tool GUI